### PR TITLE
feat(actions): action buttons with skill invocation on issue cards

### DIFF
--- a/src-tauri/src/commands/action_commands.rs
+++ b/src-tauri/src/commands/action_commands.rs
@@ -1,0 +1,407 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use rusqlite::{Connection, Row};
+use tauri::{AppHandle, Manager, State};
+use uuid::Uuid;
+
+use crate::database::connection::DatabaseState;
+use crate::models::action::{Action, CreateActionRequest, UpdateActionRequest};
+use crate::session::manager::SessionManager;
+use crate::session::provider::SpawnConfig;
+
+use super::shared::resolve_nullable_field;
+
+const ACTION_SELECT_COLUMNS: &str =
+    "id, dashboard_id, name, icon, command_template, sort_order, visible";
+
+fn row_to_action(row: &Row) -> Result<Action, rusqlite::Error> {
+    Ok(Action {
+        id: row.get(0)?,
+        dashboard_id: row.get(1)?,
+        name: row.get(2)?,
+        icon: row.get(3)?,
+        command_template: row.get(4)?,
+        sort_order: row.get(5)?,
+        visible: row.get(6)?,
+    })
+}
+
+/// Replace `{{variable}}` placeholders in a command template with actual values.
+/// Unknown variables are left as-is (graceful degradation).
+pub fn resolve_command_template(template: &str, variables: &HashMap<&str, String>) -> String {
+    let mut result = template.to_string();
+    for (key, value) in variables {
+        let placeholder = format!("{{{{{key}}}}}");
+        result = result.replace(&placeholder, value);
+    }
+    result
+}
+
+fn seed_default_actions(connection: &Connection, dashboard_id: &str) -> Result<(), String> {
+    let defaults = [
+        ("Execute", "play", "claude \"/mp-execute #{{issue_number}}\""),
+        ("Review", "eye", "claude \"/mp-review #{{issue_number}}\""),
+        (
+            "Check & Fix",
+            "wrench",
+            "claude \"/mp-check-fix #{{issue_number}}\"",
+        ),
+    ];
+
+    for (sort_order, (name, icon, command_template)) in defaults.iter().enumerate() {
+        let id = Uuid::new_v4().to_string();
+        connection
+            .execute(
+                "INSERT INTO actions (id, dashboard_id, name, icon, command_template, sort_order, visible) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, 1)",
+                rusqlite::params![id, dashboard_id, name, icon, command_template, sort_order as i64],
+            )
+            .map_err(|error| format!("Failed to seed default action: {error}"))?;
+    }
+
+    Ok(())
+}
+
+#[tauri::command]
+pub fn create_action(
+    state: State<DatabaseState>,
+    request: CreateActionRequest,
+) -> Result<Action, String> {
+    let connection = state.0.lock().map_err(|error| error.to_string())?;
+    let id = Uuid::new_v4().to_string();
+
+    connection
+        .execute(
+            "INSERT INTO actions (id, dashboard_id, name, icon, command_template, sort_order, visible) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            rusqlite::params![
+                id,
+                request.dashboard_id,
+                request.name,
+                request.icon,
+                request.command_template,
+                request.sort_order.unwrap_or(0),
+                request.visible.unwrap_or(true),
+            ],
+        )
+        .map_err(|error| format!("Failed to create action: {error}"))?;
+
+    let query = format!("SELECT {ACTION_SELECT_COLUMNS} FROM actions WHERE id = ?1");
+    connection
+        .query_row(&query, [&id], |row| row_to_action(row))
+        .map_err(|error| format!("Failed to read created action: {error}"))
+}
+
+#[tauri::command]
+pub fn get_actions_for_dashboard(
+    state: State<DatabaseState>,
+    dashboard_id: String,
+) -> Result<Vec<Action>, String> {
+    let connection = state.0.lock().map_err(|error| error.to_string())?;
+
+    // Seed defaults if no actions exist for this dashboard (including global ones)
+    let count: i64 = connection
+        .query_row(
+            "SELECT COUNT(*) FROM actions WHERE dashboard_id = ?1 OR dashboard_id IS NULL",
+            [&dashboard_id],
+            |row| row.get(0),
+        )
+        .map_err(|error| format!("Failed to count actions: {error}"))?;
+
+    if count == 0 {
+        seed_default_actions(&connection, &dashboard_id)?;
+    }
+
+    // Return global (null dashboard_id) + dashboard-specific, ordered by sort_order
+    let query = format!(
+        "SELECT {ACTION_SELECT_COLUMNS} FROM actions \
+         WHERE dashboard_id IS NULL OR dashboard_id = ?1 \
+         ORDER BY sort_order"
+    );
+
+    let mut statement = connection
+        .prepare(&query)
+        .map_err(|error| format!("Failed to prepare query: {error}"))?;
+
+    let actions = statement
+        .query_map([&dashboard_id], |row| row_to_action(row))
+        .map_err(|error| format!("Failed to query actions: {error}"))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| format!("Failed to read action row: {error}"))?;
+
+    Ok(actions)
+}
+
+#[tauri::command]
+pub fn get_action(state: State<DatabaseState>, id: String) -> Result<Action, String> {
+    let connection = state.0.lock().map_err(|error| error.to_string())?;
+
+    let query = format!("SELECT {ACTION_SELECT_COLUMNS} FROM actions WHERE id = ?1");
+    connection
+        .query_row(&query, [&id], |row| row_to_action(row))
+        .map_err(|error| format!("Action not found: {error}"))
+}
+
+#[tauri::command]
+pub fn update_action(
+    state: State<DatabaseState>,
+    request: UpdateActionRequest,
+) -> Result<Action, String> {
+    let connection = state.0.lock().map_err(|error| error.to_string())?;
+
+    let select_query = format!("SELECT {ACTION_SELECT_COLUMNS} FROM actions WHERE id = ?1");
+    let existing = connection
+        .query_row(&select_query, [&request.id], |row| row_to_action(row))
+        .map_err(|error| format!("Action not found: {error}"))?;
+
+    let name = request.name.unwrap_or(existing.name);
+    let icon = resolve_nullable_field(request.icon, existing.icon);
+    let command_template = request.command_template.unwrap_or(existing.command_template);
+    let sort_order = request.sort_order.unwrap_or(existing.sort_order);
+    let visible = request.visible.unwrap_or(existing.visible);
+
+    connection
+        .execute(
+            "UPDATE actions SET name = ?1, icon = ?2, command_template = ?3, sort_order = ?4, visible = ?5 \
+             WHERE id = ?6",
+            rusqlite::params![name, icon, command_template, sort_order, visible, existing.id],
+        )
+        .map_err(|error| format!("Failed to update action: {error}"))?;
+
+    connection
+        .query_row(&select_query, [&existing.id], |row| row_to_action(row))
+        .map_err(|error| format!("Failed to read updated action: {error}"))
+}
+
+#[tauri::command]
+pub fn delete_action(state: State<DatabaseState>, id: String) -> Result<(), String> {
+    let connection = state.0.lock().map_err(|error| error.to_string())?;
+
+    let rows_affected = connection
+        .execute("DELETE FROM actions WHERE id = ?1", [&id])
+        .map_err(|error| format!("Failed to delete action: {error}"))?;
+
+    if rows_affected == 0 {
+        return Err("Action not found".to_string());
+    }
+
+    Ok(())
+}
+
+#[tauri::command]
+pub fn reorder_actions(
+    state: State<DatabaseState>,
+    action_ids: Vec<String>,
+) -> Result<(), String> {
+    let mut connection = state.0.lock().map_err(|error| error.to_string())?;
+
+    let transaction = connection
+        .transaction()
+        .map_err(|error| format!("Failed to begin transaction: {error}"))?;
+
+    for (index, action_id) in action_ids.iter().enumerate() {
+        transaction
+            .execute(
+                "UPDATE actions SET sort_order = ?1 WHERE id = ?2",
+                rusqlite::params![index as i64, action_id],
+            )
+            .map_err(|error| format!("Failed to reorder action: {error}"))?;
+    }
+
+    transaction
+        .commit()
+        .map_err(|error| format!("Failed to commit reorder: {error}"))
+}
+
+struct IssueContext {
+    issue_id: String,
+    issue_name: String,
+    github_issue_number: Option<i64>,
+    branch_name: Option<String>,
+    base_branch: Option<String>,
+    worktree_folder: Option<String>,
+    dashboard_github_repo: Option<String>,
+    dashboard_default_base_branch: Option<String>,
+    dashboard_local_folder: Option<String>,
+}
+
+#[tauri::command]
+pub async fn execute_action(
+    state: State<'_, DatabaseState>,
+    manager: State<'_, SessionManager>,
+    app_handle: AppHandle,
+    action_id: String,
+    issue_id: String,
+) -> Result<String, String> {
+    let (resolved_command, working_directory) = {
+        let connection = state.0.lock().map_err(|error| error.to_string())?;
+
+        // Load action
+        let action_query = format!("SELECT {ACTION_SELECT_COLUMNS} FROM actions WHERE id = ?1");
+        let action = connection
+            .query_row(&action_query, [&action_id], |row| row_to_action(row))
+            .map_err(|error| format!("Action not found: {error}"))?;
+
+        // Load issue + dashboard fields for variable substitution
+        let context: IssueContext = connection
+            .query_row(
+                "SELECT i.id, i.name, i.github_issue_number, i.branch_name, \
+                 i.base_branch, i.worktree_folder, d.github_repo, d.default_base_branch, d.local_folder \
+                 FROM issues i JOIN dashboards d ON i.dashboard_id = d.id \
+                 WHERE i.id = ?1",
+                [&issue_id],
+                |row| {
+                    Ok(IssueContext {
+                        issue_id: row.get(0)?,
+                        issue_name: row.get(1)?,
+                        github_issue_number: row.get(2)?,
+                        branch_name: row.get(3)?,
+                        base_branch: row.get(4)?,
+                        worktree_folder: row.get(5)?,
+                        dashboard_github_repo: row.get(6)?,
+                        dashboard_default_base_branch: row.get(7)?,
+                        dashboard_local_folder: row.get(8)?,
+                    })
+                },
+            )
+            .map_err(|error| format!("Issue not found: {error}"))?;
+
+        let mut variables: HashMap<&str, String> = HashMap::new();
+        variables.insert("issue_id", context.issue_id.clone());
+        variables.insert("issue_name", context.issue_name);
+
+        if let Some(number) = context.github_issue_number {
+            variables.insert("issue_number", number.to_string());
+        }
+        if let Some(ref branch) = context.branch_name {
+            variables.insert("branch_name", branch.clone());
+        }
+
+        // base_branch: prefer issue-level, fall back to dashboard default
+        let base_branch = context.base_branch.or(context.dashboard_default_base_branch);
+        if let Some(branch) = base_branch {
+            variables.insert("base_branch", branch);
+        }
+
+        if let Some(ref folder) = context.worktree_folder {
+            variables.insert("worktree_folder", folder.clone());
+        }
+        if let Some(repo) = context.dashboard_github_repo {
+            variables.insert("github_repo", repo);
+        }
+
+        let resolved = resolve_command_template(&action.command_template, &variables);
+
+        // Working directory: prefer worktree_folder, fall back to dashboard local_folder
+        let working_dir = context
+            .worktree_folder
+            .or(context.dashboard_local_folder)
+            .ok_or_else(|| "No working directory: issue has no worktree_folder and dashboard has no local_folder".to_string())?;
+
+        (resolved, working_dir)
+    };
+
+    let session_id = Uuid::new_v4().to_string();
+
+    // Create session row before spawning (needs resolved_command for original_intent)
+    {
+        let conn = state.0.lock().map_err(|error| error.to_string())?;
+        conn.execute(
+            "INSERT INTO sessions (id, issue_id, provider, state, original_intent, source, working_directory) \
+             VALUES (?1, ?2, 'claude-code', 'running', ?3, 'spawned', ?4)",
+            rusqlite::params![session_id, issue_id, &resolved_command, &working_directory],
+        )
+        .map_err(|error| format!("Failed to create session row: {error}"))?;
+    }
+
+    let app_data_directory = app_handle
+        .path()
+        .app_data_dir()
+        .map_err(|error| error.to_string())?;
+    let database_connection = crate::database::connection::open_actor_connection(app_data_directory)?;
+
+    let config = SpawnConfig {
+        prompt: resolved_command,
+        working_directory: PathBuf::from(&working_directory),
+        resume_session_id: None,
+        permission_mode: None,
+        model: None,
+        max_turns: None,
+        env_vars: HashMap::new(),
+    };
+
+    manager
+        .spawn_session(session_id.clone(), config, app_handle, database_connection)
+        .await?;
+
+    Ok(session_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_template_replaces_all_variables() {
+        let mut variables = HashMap::new();
+        variables.insert("issue_number", "42".to_string());
+        variables.insert("branch_name", "feature/login".to_string());
+        variables.insert("github_repo", "user/repo".to_string());
+
+        let result = resolve_command_template(
+            "claude \"/mp-execute #{{issue_number}}\" --branch {{branch_name}} --repo {{github_repo}}",
+            &variables,
+        );
+
+        assert_eq!(
+            result,
+            "claude \"/mp-execute #42\" --branch feature/login --repo user/repo"
+        );
+    }
+
+    #[test]
+    fn resolve_template_leaves_unknown_variables() {
+        let variables = HashMap::new();
+
+        let result = resolve_command_template(
+            "claude \"/mp-execute #{{issue_number}}\"",
+            &variables,
+        );
+
+        assert_eq!(result, "claude \"/mp-execute #{{issue_number}}\"");
+    }
+
+    #[test]
+    fn resolve_template_handles_multiple_occurrences() {
+        let mut variables = HashMap::new();
+        variables.insert("issue_number", "7".to_string());
+
+        let result = resolve_command_template(
+            "echo {{issue_number}} && echo {{issue_number}}",
+            &variables,
+        );
+
+        assert_eq!(result, "echo 7 && echo 7");
+    }
+
+    #[test]
+    fn resolve_template_passthrough_no_variables() {
+        let variables = HashMap::new();
+        let result = resolve_command_template("echo hello", &variables);
+        assert_eq!(result, "echo hello");
+    }
+
+    #[test]
+    fn resolve_template_partial_substitution() {
+        let mut variables = HashMap::new();
+        variables.insert("issue_number", "5".to_string());
+
+        let result = resolve_command_template(
+            "{{issue_number}} {{branch_name}}",
+            &variables,
+        );
+
+        assert_eq!(result, "5 {{branch_name}}");
+    }
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod action_commands;
 pub mod dashboard_commands;
 pub mod git_status_commands;
 pub mod github_commands;

--- a/src-tauri/src/commands/session_commands.rs
+++ b/src-tauri/src/commands/session_commands.rs
@@ -262,11 +262,5 @@ fn open_actor_database_connection(
         .path()
         .app_data_dir()
         .map_err(|e| e.to_string())?;
-    let db_path = app_data_directory.join("bamgit.db");
-    let connection =
-        Connection::open(&db_path).map_err(|e| format!("Failed to open DB for actor: {e}"))?;
-    connection
-        .execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")
-        .map_err(|e| format!("Failed to set pragmas: {e}"))?;
-    Ok(Arc::new(StdMutex::new(connection)))
+    crate::database::connection::open_actor_connection(app_data_directory)
 }

--- a/src-tauri/src/database/connection.rs
+++ b/src-tauri/src/database/connection.rs
@@ -1,5 +1,5 @@
 use std::path::PathBuf;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use rusqlite::Connection;
 
@@ -24,4 +24,16 @@ pub fn initialize_database(app_data_directory: PathBuf) -> Result<DatabaseState,
         .map_err(|error| format!("Failed to run migrations: {error}"))?;
 
     Ok(DatabaseState(Mutex::new(connection)))
+}
+
+/// Open a separate database connection for background actors (session actors, etc.).
+/// Uses WAL mode so it can coexist with the main DatabaseState connection.
+pub fn open_actor_connection(app_data_directory: PathBuf) -> Result<Arc<Mutex<Connection>>, String> {
+    let db_path = app_data_directory.join("bamgit.db");
+    let connection =
+        Connection::open(&db_path).map_err(|error| format!("Failed to open DB for actor: {error}"))?;
+    connection
+        .execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")
+        .map_err(|error| format!("Failed to set pragmas: {error}"))?;
+    Ok(Arc::new(Mutex::new(connection)))
 }

--- a/src-tauri/src/database/migrations.rs
+++ b/src-tauri/src/database/migrations.rs
@@ -2,11 +2,11 @@ use rusqlite::Connection;
 
 use super::schema;
 
-const CURRENT_VERSION: i32 = 3;
+const CURRENT_VERSION: i32 = 4;
 
 type MigrationFunction = fn(&Connection) -> Result<(), rusqlite::Error>;
 
-static MIGRATIONS: &[MigrationFunction] = &[migrate_v1, migrate_v2, migrate_v3];
+static MIGRATIONS: &[MigrationFunction] = &[migrate_v1, migrate_v2, migrate_v3, migrate_v4];
 
 fn migrate_v1(connection: &Connection) -> Result<(), rusqlite::Error> {
     schema::create_tables(connection)
@@ -61,6 +61,24 @@ fn migrate_v3(connection: &Connection) -> Result<(), rusqlite::Error> {
     }
 
     Ok(())
+}
+
+fn migrate_v4(connection: &Connection) -> Result<(), rusqlite::Error> {
+    // Create actions table for existing users upgrading from v3.
+    // Also adds ON DELETE CASCADE on dashboard_id (fresh installs via schema.rs already have it).
+    connection.execute_batch(
+        "
+        CREATE TABLE IF NOT EXISTS actions (
+            id TEXT PRIMARY KEY,
+            dashboard_id TEXT REFERENCES dashboards(id) ON DELETE CASCADE,
+            name TEXT NOT NULL,
+            icon TEXT,
+            command_template TEXT NOT NULL,
+            sort_order INTEGER NOT NULL DEFAULT 0,
+            visible INTEGER NOT NULL DEFAULT 1
+        );
+        ",
+    )
 }
 
 pub fn get_schema_version(connection: &Connection) -> Result<i32, rusqlite::Error> {

--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -75,7 +75,7 @@ pub fn create_tables(connection: &Connection) -> Result<(), rusqlite::Error> {
 
         CREATE TABLE IF NOT EXISTS actions (
             id TEXT PRIMARY KEY,
-            dashboard_id TEXT REFERENCES dashboards(id),
+            dashboard_id TEXT REFERENCES dashboards(id) ON DELETE CASCADE,
             name TEXT NOT NULL,
             icon TEXT,
             command_template TEXT NOT NULL,

--- a/src-tauri/src/database/tests.rs
+++ b/src-tauri/src/database/tests.rs
@@ -22,7 +22,7 @@ mod tests {
         migrations::run_migrations(&connection).unwrap();
 
         let version = migrations::get_schema_version(&connection).unwrap();
-        assert_eq!(version, 3);
+        assert_eq!(version, 4);
     }
 
     #[test]
@@ -32,7 +32,7 @@ mod tests {
         migrations::run_migrations(&connection).unwrap();
 
         let version = migrations::get_schema_version(&connection).unwrap();
-        assert_eq!(version, 3);
+        assert_eq!(version, 4);
     }
 
     // --- Schema tests ---
@@ -696,7 +696,7 @@ mod tests {
         migrations::run_migrations(&connection).unwrap();
 
         let version = migrations::get_schema_version(&connection).unwrap();
-        assert_eq!(version, 3);
+        assert_eq!(version, 4);
 
         // portfolio_dashboard_pointers table exists
         let exists: bool = connection
@@ -970,5 +970,224 @@ mod tests {
         );
 
         assert!(result.is_err(), "Invalid source should be rejected");
+    }
+
+    // --- Action CRUD tests ---
+
+    fn insert_test_action(
+        connection: &Connection,
+        id: &str,
+        dashboard_id: Option<&str>,
+        name: &str,
+        command_template: &str,
+    ) {
+        connection
+            .execute(
+                "INSERT INTO actions (id, dashboard_id, name, command_template) VALUES (?1, ?2, ?3, ?4)",
+                rusqlite::params![id, dashboard_id, name, command_template],
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn action_crud_round_trip() {
+        let connection = setup_test_database();
+        insert_test_dashboard(&connection, "d1", "repo");
+
+        // Create
+        connection
+            .execute(
+                "INSERT INTO actions (id, dashboard_id, name, icon, command_template, sort_order, visible) \
+                 VALUES ('a1', 'd1', 'Execute', 'play', 'claude \"/mp-execute #42\"', 0, 1)",
+                [],
+            )
+            .unwrap();
+
+        // Read
+        let (name, icon, command_template, sort_order, visible): (
+            String,
+            Option<String>,
+            String,
+            i64,
+            bool,
+        ) = connection
+            .query_row(
+                "SELECT name, icon, command_template, sort_order, visible FROM actions WHERE id = 'a1'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?)),
+            )
+            .unwrap();
+
+        assert_eq!(name, "Execute");
+        assert_eq!(icon.as_deref(), Some("play"));
+        assert_eq!(command_template, "claude \"/mp-execute #42\"");
+        assert_eq!(sort_order, 0);
+        assert!(visible);
+
+        // Update
+        connection
+            .execute(
+                "UPDATE actions SET name = 'Run', icon = 'rocket' WHERE id = 'a1'",
+                [],
+            )
+            .unwrap();
+
+        let updated_name: String = connection
+            .query_row("SELECT name FROM actions WHERE id = 'a1'", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(updated_name, "Run");
+
+        // Delete
+        let rows_affected = connection
+            .execute("DELETE FROM actions WHERE id = 'a1'", [])
+            .unwrap();
+        assert_eq!(rows_affected, 1);
+    }
+
+    #[test]
+    fn action_sort_order_defaults_to_zero() {
+        let connection = setup_test_database();
+        insert_test_dashboard(&connection, "d1", "repo");
+        insert_test_action(&connection, "a1", Some("d1"), "Test", "echo hello");
+
+        let sort_order: i64 = connection
+            .query_row("SELECT sort_order FROM actions WHERE id = 'a1'", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+
+        assert_eq!(sort_order, 0);
+    }
+
+    #[test]
+    fn action_visible_defaults_to_true() {
+        let connection = setup_test_database();
+        insert_test_dashboard(&connection, "d1", "repo");
+        insert_test_action(&connection, "a1", Some("d1"), "Test", "echo hello");
+
+        let visible: bool = connection
+            .query_row("SELECT visible FROM actions WHERE id = 'a1'", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+
+        assert!(visible);
+    }
+
+    #[test]
+    fn action_with_null_dashboard_id_is_global() {
+        let connection = setup_test_database();
+
+        // Global action (null dashboard_id)
+        insert_test_action(&connection, "a1", None, "Global Action", "echo global");
+
+        let dashboard_id: Option<String> = connection
+            .query_row(
+                "SELECT dashboard_id FROM actions WHERE id = 'a1'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+
+        assert_eq!(dashboard_id, None);
+    }
+
+    #[test]
+    fn action_foreign_key_rejects_invalid_dashboard_id() {
+        let connection = setup_test_database();
+
+        let result = connection.execute(
+            "INSERT INTO actions (id, dashboard_id, name, command_template) VALUES ('a1', 'nonexistent', 'Test', 'echo')",
+            [],
+        );
+
+        assert!(
+            result.is_err(),
+            "Action with invalid dashboard_id should be rejected"
+        );
+    }
+
+    #[test]
+    fn action_sort_order_persists_and_orders_correctly() {
+        let connection = setup_test_database();
+        insert_test_dashboard(&connection, "d1", "repo");
+
+        connection
+            .execute(
+                "INSERT INTO actions (id, dashboard_id, name, command_template, sort_order) VALUES ('a1', 'd1', 'Third', 'echo 3', 2)",
+                [],
+            )
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO actions (id, dashboard_id, name, command_template, sort_order) VALUES ('a2', 'd1', 'First', 'echo 1', 0)",
+                [],
+            )
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO actions (id, dashboard_id, name, command_template, sort_order) VALUES ('a3', 'd1', 'Second', 'echo 2', 1)",
+                [],
+            )
+            .unwrap();
+
+        let mut statement = connection
+            .prepare("SELECT name FROM actions WHERE dashboard_id = 'd1' ORDER BY sort_order")
+            .unwrap();
+        let names: Vec<String> = statement
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+
+        assert_eq!(names, vec!["First", "Second", "Third"]);
+    }
+
+    #[test]
+    fn delete_dashboard_cascades_to_actions() {
+        let connection = setup_test_database();
+        insert_test_dashboard(&connection, "d1", "repo");
+        insert_test_action(&connection, "a1", Some("d1"), "Action 1", "echo 1");
+        insert_test_action(&connection, "a2", Some("d1"), "Action 2", "echo 2");
+
+        connection
+            .execute("DELETE FROM dashboards WHERE id = 'd1'", [])
+            .unwrap();
+
+        let count: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM actions WHERE dashboard_id = 'd1'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+
+        assert_eq!(count, 0, "Deleting dashboard should cascade to actions");
+    }
+
+    #[test]
+    fn global_actions_returned_alongside_dashboard_actions() {
+        let connection = setup_test_database();
+        insert_test_dashboard(&connection, "d1", "repo");
+
+        // Global action
+        insert_test_action(&connection, "a_global", None, "Global", "echo global");
+        // Dashboard-specific action
+        insert_test_action(&connection, "a_dash", Some("d1"), "Dashboard", "echo dash");
+
+        let mut statement = connection
+            .prepare(
+                "SELECT name FROM actions WHERE dashboard_id IS NULL OR dashboard_id = 'd1' ORDER BY sort_order",
+            )
+            .unwrap();
+        let names: Vec<String> = statement
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+
+        assert_eq!(names, vec!["Global", "Dashboard"]);
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,8 +5,8 @@ mod models;
 mod session;
 
 use commands::{
-    dashboard_commands, git_status_commands, github_commands, issue_commands, portfolio_commands,
-    session_commands,
+    action_commands, dashboard_commands, git_status_commands, github_commands, issue_commands,
+    portfolio_commands, session_commands,
 };
 use git::fetch_coordinator::FetchCoordinator;
 use session::discovery_polling::DiscoveryPoller;
@@ -73,6 +73,13 @@ pub fn run() {
             github_commands::fetch_pr_for_branch,
             github_commands::fetch_assigned_issues,
             github_commands::sync_all_github_state,
+            action_commands::create_action,
+            action_commands::get_actions_for_dashboard,
+            action_commands::get_action,
+            action_commands::update_action,
+            action_commands::delete_action,
+            action_commands::reorder_actions,
+            action_commands::execute_action,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/src-tauri/src/models/action.rs
+++ b/src-tauri/src/models/action.rs
@@ -1,0 +1,32 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Action {
+    pub id: String,
+    pub dashboard_id: Option<String>,
+    pub name: String,
+    pub icon: Option<String>,
+    pub command_template: String,
+    pub sort_order: i64,
+    pub visible: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateActionRequest {
+    pub dashboard_id: Option<String>,
+    pub name: String,
+    pub icon: Option<String>,
+    pub command_template: String,
+    pub sort_order: Option<i64>,
+    pub visible: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpdateActionRequest {
+    pub id: String,
+    pub name: Option<String>,
+    pub icon: Option<Option<String>>,
+    pub command_template: Option<String>,
+    pub sort_order: Option<i64>,
+    pub visible: Option<bool>,
+}

--- a/src-tauri/src/models/mod.rs
+++ b/src-tauri/src/models/mod.rs
@@ -1,3 +1,4 @@
+pub mod action;
 pub mod dashboard;
 pub mod git_status;
 pub mod github;

--- a/src/lib/components/ActionButtonGroup.svelte
+++ b/src/lib/components/ActionButtonGroup.svelte
@@ -15,7 +15,7 @@
 	};
 
 	function get_icon_display(icon: string | null): string {
-		if (!icon) {
+		if (icon === null || icon === '') {
 			return '\u25CF';
 		}
 		return ICON_MAP[icon] ?? icon;

--- a/src/lib/components/ActionButtonGroup.svelte
+++ b/src/lib/components/ActionButtonGroup.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	import type { Action } from '$lib/types/action';
+
+	interface Props {
+		actions: Action[];
+		on_execute: (action_id: string) => void;
+	}
+
+	let { actions, on_execute }: Props = $props();
+
+	const ICON_MAP: Record<string, string> = {
+		play: '\u25B6',
+		eye: '\uD83D\uDC41',
+		wrench: '\uD83D\uDD27',
+	};
+
+	function get_icon_display(icon: string | null): string {
+		if (!icon) {
+			return '\u25CF';
+		}
+		return ICON_MAP[icon] ?? icon;
+	}
+</script>
+
+<div class="flex items-center gap-0.5">
+	{#each actions as action (action.id)}
+		<button
+			onclick={(event) => {
+				event.stopPropagation();
+				on_execute(action.id);
+			}}
+			class="rounded px-1.5 py-0.5 text-xs text-neutral-400 transition-colors hover:bg-neutral-700 hover:text-neutral-200"
+			title={action.name}
+		>
+			<span class="text-[10px]">{get_icon_display(action.icon)}</span>
+		</button>
+	{/each}
+</div>

--- a/src/lib/components/IssueCard.svelte
+++ b/src/lib/components/IssueCard.svelte
@@ -1,14 +1,17 @@
 <script lang="ts">
 	import type { Issue } from '$lib/types/issue';
+	import type { Action } from '$lib/types/action';
 	import type { GitHubStatusCache } from '$lib/types/github';
 	import type { GitStatusCache } from '$lib/types/git_status';
 	import PullRequestBadge from './PullRequestBadge.svelte';
 	import GitHubIssueBadge from './GitHubIssueBadge.svelte';
 	import SyncStatusIndicator from './SyncStatusIndicator.svelte';
 	import GitBadgeGroup from './GitBadgeGroup.svelte';
+	import ActionButtonGroup from './ActionButtonGroup.svelte';
 
 	interface Props {
 		issue: Issue;
+		actions?: Action[];
 		github_cache?: GitHubStatusCache | null;
 		gh_available?: boolean;
 		git_status?: GitStatusCache | undefined;
@@ -20,10 +23,12 @@
 		on_unarchive: (id: string) => void;
 		on_edit: (issue: Issue) => void;
 		on_delete: (id: string) => void;
+		on_execute_action?: (action_id: string, issue_id: string) => void;
 	}
 
 	let {
 		issue,
+		actions = [],
 		github_cache = null,
 		gh_available = false,
 		git_status,
@@ -35,6 +40,7 @@
 		on_unarchive,
 		on_edit,
 		on_delete,
+		on_execute_action,
 	}: Props = $props();
 
 	let local_expanded = $state(false);
@@ -135,6 +141,16 @@
 			</div>
 
 			<!-- Action buttons -->
+			{#if actions.length > 0 && on_execute_action && !is_archived}
+				<div class="opacity-0 transition-opacity group-hover:opacity-100">
+					<ActionButtonGroup
+						{actions}
+						on_execute={(action_id) => on_execute_action(action_id, issue.id)}
+					/>
+				</div>
+			{/if}
+
+			<!-- Overflow menu -->
 			<div class="relative">
 				<button
 					onclick={() => (show_overflow = !show_overflow)}

--- a/src/lib/components/IssueCardList.svelte
+++ b/src/lib/components/IssueCardList.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { Issue } from '$lib/types/issue';
+	import type { Action } from '$lib/types/action';
 	import type { GitHubStatusCache } from '$lib/types/github';
 	import type { GitStatusCache } from '$lib/types/git_status';
 	import IssueCard from './IssueCard.svelte';
@@ -9,6 +10,7 @@
 		archived_issues: Issue[];
 		show_archived: boolean;
 		is_portfolio: boolean;
+		actions?: Action[];
 		force_expanded?: boolean;
 		github_cache_map?: Map<string, GitHubStatusCache>;
 		gh_available?: boolean;
@@ -18,6 +20,7 @@
 		on_unarchive: (id: string) => void;
 		on_edit: (issue: Issue) => void;
 		on_delete: (id: string) => void;
+		on_execute_action?: (action_id: string, issue_id: string) => void;
 	}
 
 	let {
@@ -25,6 +28,7 @@
 		archived_issues,
 		show_archived,
 		is_portfolio,
+		actions = [],
 		force_expanded,
 		github_cache_map = new Map(),
 		gh_available = false,
@@ -34,6 +38,7 @@
 		on_unarchive,
 		on_edit,
 		on_delete,
+		on_execute_action,
 	}: Props = $props();
 </script>
 
@@ -43,6 +48,7 @@
 
 		<IssueCard
 			{issue}
+			{actions}
 			github_cache={github_cache_map.get(issue.id)}
 			{gh_available}
 			git_status={get_git_status(issue.id)}
@@ -52,6 +58,7 @@
 			{on_unarchive}
 			{on_edit}
 			{on_delete}
+			{on_execute_action}
 		/>
 
 		<!-- Nested children for portfolio dashboards -->
@@ -59,6 +66,7 @@
 			{#each children as child, index (child.id)}
 				<IssueCard
 					issue={child}
+					{actions}
 					github_cache={github_cache_map.get(child.id)}
 					{gh_available}
 					git_status={get_git_status(child.id)}
@@ -69,6 +77,7 @@
 					{on_unarchive}
 					{on_edit}
 					{on_delete}
+					{on_execute_action}
 				/>
 			{/each}
 		{/if}

--- a/src/lib/stores/actions.svelte.ts
+++ b/src/lib/stores/actions.svelte.ts
@@ -1,0 +1,50 @@
+import type { Action } from '$lib/types/action';
+import { get_actions_for_dashboard } from '$lib/tauri/action_commands';
+
+let actions = $state<Action[]>([]);
+let loading = $state(false);
+let error = $state<string | null>(null);
+let current_dashboard_id = $state<string | null>(null);
+
+const visible_actions = $derived(actions.filter((action) => action.visible));
+
+export function get_action_store() {
+	return {
+		get actions() {
+			return actions;
+		},
+		get visible_actions() {
+			return visible_actions;
+		},
+		get loading() {
+			return loading;
+		},
+		get error() {
+			return error;
+		},
+
+		async load_actions(dashboard_id: string) {
+			try {
+				loading = true;
+				current_dashboard_id = dashboard_id;
+				actions = await get_actions_for_dashboard(dashboard_id);
+				error = null;
+			} catch (err) {
+				error = String(err);
+			} finally {
+				loading = false;
+			}
+		},
+
+		async refresh() {
+			if (current_dashboard_id) {
+				try {
+					actions = await get_actions_for_dashboard(current_dashboard_id);
+					error = null;
+				} catch (err) {
+					error = String(err);
+				}
+			}
+		},
+	};
+}

--- a/src/lib/tauri/action_commands.ts
+++ b/src/lib/tauri/action_commands.ts
@@ -1,0 +1,30 @@
+import { invoke } from '@tauri-apps/api/core';
+import type { Action, CreateActionRequest, UpdateActionRequest } from '$lib/types/action';
+
+export async function create_action(request: CreateActionRequest): Promise<Action> {
+	return invoke('create_action', { request });
+}
+
+export async function get_actions_for_dashboard(dashboard_id: string): Promise<Action[]> {
+	return invoke('get_actions_for_dashboard', { dashboardId: dashboard_id });
+}
+
+export async function get_action(id: string): Promise<Action> {
+	return invoke('get_action', { id });
+}
+
+export async function update_action(request: UpdateActionRequest): Promise<Action> {
+	return invoke('update_action', { request });
+}
+
+export async function delete_action(id: string): Promise<void> {
+	return invoke('delete_action', { id });
+}
+
+export async function reorder_actions(action_ids: string[]): Promise<void> {
+	return invoke('reorder_actions', { actionIds: action_ids });
+}
+
+export async function execute_action(action_id: string, issue_id: string): Promise<string> {
+	return invoke('execute_action', { actionId: action_id, issueId: issue_id });
+}

--- a/src/lib/types/action.ts
+++ b/src/lib/types/action.ts
@@ -1,0 +1,27 @@
+export interface Action {
+	id: string;
+	dashboard_id: string | null;
+	name: string;
+	icon: string | null;
+	command_template: string;
+	sort_order: number;
+	visible: boolean;
+}
+
+export interface CreateActionRequest {
+	dashboard_id?: string | null;
+	name: string;
+	icon?: string | null;
+	command_template: string;
+	sort_order?: number;
+	visible?: boolean;
+}
+
+export interface UpdateActionRequest {
+	id: string;
+	name?: string;
+	icon?: string | null;
+	command_template?: string;
+	sort_order?: number;
+	visible?: boolean;
+}

--- a/src/routes/issues/+page.svelte
+++ b/src/routes/issues/+page.svelte
@@ -3,6 +3,7 @@
 	import { get_git_status_store } from '$lib/stores/git_status.svelte';
 	import { get_issue_store } from '$lib/stores/issues.svelte';
 	import { get_github_store } from '$lib/stores/github.svelte';
+	import { get_action_store } from '$lib/stores/actions.svelte';
 	import {
 		create_issue,
 		archive_issue,
@@ -10,6 +11,7 @@
 		update_issue,
 		delete_issue,
 	} from '$lib/tauri/issue_commands';
+	import { execute_action } from '$lib/tauri/action_commands';
 	import type { Issue, CreateIssueRequest, UpdateIssueRequest } from '$lib/types/issue';
 	import OnboardingCard from '$lib/components/OnboardingCard.svelte';
 	import EmptyIssueState from '$lib/components/EmptyIssueState.svelte';
@@ -24,6 +26,7 @@
 	const git_status_store = get_git_status_store();
 	const issue_store = get_issue_store();
 	const github_store = get_github_store();
+	const action_store = get_action_store();
 
 	let create_dialog_open = $state(false);
 	let editing_issue = $state<Issue | null>(null);
@@ -58,6 +61,7 @@
 			issue_store.load_issues(dashboard_id);
 			github_store.load_caches(dashboard_id);
 			git_status_store.load_statuses_for_dashboard(dashboard_id);
+			action_store.load_actions(dashboard_id);
 			if (github_repo_parts) {
 				github_store.load_assigned_issues(github_repo_parts.owner, github_repo_parts.repo);
 			}
@@ -116,6 +120,14 @@
 			console.error('Failed to delete issue:', err);
 		}
 	}
+
+	async function handle_execute_action(action_id: string, issue_id: string) {
+		try {
+			await execute_action(action_id, issue_id);
+		} catch (err) {
+			console.error('Failed to execute action:', err);
+		}
+	}
 </script>
 
 {#if dashboard_store.loading}
@@ -171,6 +183,7 @@
 				archived_issues={issue_store.archived_issues}
 				show_archived={issue_store.show_archived}
 				is_portfolio={dashboard_store.active_dashboard.type === 'portfolio'}
+				actions={action_store.visible_actions}
 				force_expanded={all_expanded ? true : undefined}
 				github_cache_map={github_store.cache_map}
 				gh_available={github_store.is_available}
@@ -180,6 +193,7 @@
 				on_unarchive={handle_unarchive_issue}
 				on_edit={(issue) => (editing_issue = issue)}
 				on_delete={handle_delete_issue}
+				on_execute_action={handle_execute_action}
 			/>
 		{/if}
 

--- a/src/routes/sessions/+page.svelte
+++ b/src/routes/sessions/+page.svelte
@@ -19,7 +19,6 @@
 	let spawn_prompt = $state('');
 	let spawn_working_directory = $state('');
 	let spawning = $state(false);
-	let adopting_id = $state<string | null>(null);
 	let unlisten_session_event: UnlistenFn | null = null;
 	let unlisten_discovered: UnlistenFn | null = null;
 
@@ -83,7 +82,6 @@
 	}
 
 	async function handle_adopt(discovered: DiscoveredSession) {
-		adopting_id = discovered.id;
 		try {
 			await adopt_session({
 				cli_session_id: discovered.session_id,
@@ -96,8 +94,6 @@
 			await store.refresh();
 		} catch (err) {
 			console.error('Failed to adopt session:', err);
-		} finally {
-			adopting_id = null;
 		}
 	}
 


### PR DESCRIPTION
## Description
- Add `actions` table CRUD via 7 Tauri commands (create, get, get_for_dashboard, update, delete, reorder, execute)
- Implement command template engine with `{{variable}}` substitution (issue_number, branch_name, worktree_folder, base_branch, github_repo, issue_id, issue_name)
- Seed default actions (Execute, Review, Check & Fix) per-dashboard on first access
- Render action buttons on issue cards (hover-visible between badges and overflow menu)
- Clicking an action button spawns a Claude Code session with the resolved command template
- Support global actions (null dashboard_id) and dashboard-specific actions with visibility toggling and reordering
- Add migration v4 for existing users, ON DELETE CASCADE for actions.dashboard_id
- Extract shared `open_actor_connection` helper to eliminate duplication between session and action commands

## Resolves
Closes #12

## Testing
- [x] 146 Rust tests pass (5 template substitution + 8 action DB integration tests)
- [x] `pnpm run check` — 0 errors, 0 warnings
- [x] `pnpm run lint` — 0 errors, 0 warnings
- [x] `pnpm run build` — passes