### PR TITLE
feat(worktree): add worktree lifecycle setup/remove with state machine

### DIFF
--- a/src-tauri/src/commands/issue_commands.rs
+++ b/src-tauri/src/commands/issue_commands.rs
@@ -126,19 +126,29 @@ pub fn update_issue(
     let color = resolve_nullable_field(request.color, existing.color);
     let github_issue_url = resolve_nullable_field(request.github_issue_url, existing.github_issue_url);
     let github_issue_number = resolve_nullable_field(request.github_issue_number, existing.github_issue_number);
+    let branch_name = resolve_nullable_field(request.branch_name, existing.branch_name);
+    let base_branch = resolve_nullable_field(request.base_branch, existing.base_branch);
+    let worktree_folder = resolve_nullable_field(request.worktree_folder, existing.worktree_folder);
+    let worktree_state = request.worktree_state.unwrap_or(existing.worktree_state);
     let parent_issue_id = resolve_nullable_field(request.parent_issue_id, existing.parent_issue_id);
     let sort_order = request.sort_order.unwrap_or(existing.sort_order);
 
     connection
         .execute(
             "UPDATE issues SET name = ?1, priority = ?2, color = ?3, github_issue_url = ?4, \
-             github_issue_number = ?5, parent_issue_id = ?6, sort_order = ?7 WHERE id = ?8",
+             github_issue_number = ?5, branch_name = ?6, base_branch = ?7, \
+             worktree_folder = ?8, worktree_state = ?9, parent_issue_id = ?10, \
+             sort_order = ?11 WHERE id = ?12",
             rusqlite::params![
                 name,
                 priority,
                 color,
                 github_issue_url,
                 github_issue_number,
+                branch_name,
+                base_branch,
+                worktree_folder,
+                worktree_state,
                 parent_issue_id,
                 sort_order,
                 existing.id,

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -5,3 +5,4 @@ pub mod issue_commands;
 pub mod portfolio_commands;
 pub mod session_commands;
 pub mod shared;
+pub mod worktree_commands;

--- a/src-tauri/src/commands/worktree_commands.rs
+++ b/src-tauri/src/commands/worktree_commands.rs
@@ -1,0 +1,550 @@
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Emitter, State};
+use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader};
+use tokio::process::Command;
+use tokio::task::JoinHandle;
+
+use crate::database::connection::DatabaseState;
+
+// ─── Types ─────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct SetupWorktreeRequest {
+    pub issue_id: String,
+    pub branch_name: String,
+    pub color: Option<String>,
+    /// Dashboard's local_folder — the main repo root where setup-worktree.sh runs
+    pub working_directory: String,
+    /// Base branch to record (e.g. "dev")
+    pub base_branch: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RemoveWorktreeRequest {
+    pub issue_id: String,
+    pub branch_name: String,
+    /// Dashboard's local_folder — cwd for remove-worktree.sh
+    pub working_directory: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct WorktreeProgressPayload {
+    pub issue_id: String,
+    pub source: String,
+    pub line: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct WorktreeStateChangePayload {
+    pub issue_id: String,
+    pub old_state: String,
+    pub new_state: String,
+    pub worktree_folder: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PrunableIssue {
+    pub issue_id: String,
+    pub name: String,
+    pub branch_name: String,
+    pub worktree_folder: Option<String>,
+    pub pr_state: Option<String>,
+    pub github_issue_state: Option<String>,
+    pub branch_status: Option<String>,
+}
+
+// ─── Bash Detection ────────────────────────────────────────────────────────────
+
+/// Find bash executable. On Windows, use Git Bash; on Unix, use system bash.
+fn detect_bash_path() -> Result<PathBuf, String> {
+    if cfg!(windows) {
+        // Try git --exec-path to find Git installation
+        if let Ok(output) = std::process::Command::new("git")
+            .args(["--exec-path"])
+            .output()
+        {
+            if output.status.success() {
+                let exec_path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                // exec-path is like C:/Program Files/Git/mingw64/libexec/git-core
+                // bash is at C:/Program Files/Git/bin/bash.exe
+                let git_root = Path::new(&exec_path)
+                    .ancestors()
+                    .find(|p| p.join("bin/bash.exe").exists());
+                if let Some(root) = git_root {
+                    return Ok(root.join("bin/bash.exe"));
+                }
+            }
+        }
+
+        // Common fallback paths
+        let fallbacks = [
+            r"C:\Program Files\Git\bin\bash.exe",
+            r"C:\Program Files (x86)\Git\bin\bash.exe",
+        ];
+        for path in &fallbacks {
+            if Path::new(path).exists() {
+                return Ok(PathBuf::from(path));
+            }
+        }
+
+        Err("Could not find Git Bash. Ensure Git for Windows is installed.".into())
+    } else {
+        Ok(PathBuf::from("/bin/bash"))
+    }
+}
+
+/// Resolve the mpx-claude-code scripts directory from environment or relative path.
+fn resolve_scripts_directory() -> Result<PathBuf, String> {
+    // Check environment variable first
+    if let Ok(scripts_dir) = std::env::var("MPX_SCRIPTS_DIR") {
+        let path = PathBuf::from(&scripts_dir);
+        if path.exists() {
+            return Ok(path);
+        }
+    }
+
+    // Fallback: try relative to home directory
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    if let Some(home) = dirs::home_dir() {
+        candidates.push(home.join(".claude/scripts"));
+    }
+
+    // Dev-only fallback for local development
+    #[cfg(debug_assertions)]
+    candidates.push(PathBuf::from("C:/_MP_projects/mpx-claude-code/scripts"));
+
+    for candidate in &candidates {
+        if candidate.join("setup-worktree.sh").exists() {
+            return Ok(candidate.clone());
+        }
+    }
+
+    Err(
+        "Could not find mpx-claude-code scripts directory. \
+         Set MPX_SCRIPTS_DIR environment variable or ensure scripts exist."
+            .into(),
+    )
+}
+
+// ─── DB Helpers ────────────────────────────────────────────────────────────────
+
+fn get_worktree_state(
+    connection: &rusqlite::Connection,
+    issue_id: &str,
+) -> Result<String, String> {
+    connection
+        .query_row(
+            "SELECT worktree_state FROM issues WHERE id = ?1",
+            [issue_id],
+            |row| row.get::<_, String>(0),
+        )
+        .map_err(|error| format!("Issue not found: {error}"))
+}
+
+fn update_worktree_state(
+    connection: &rusqlite::Connection,
+    issue_id: &str,
+    new_state: &str,
+) -> Result<(), String> {
+    connection
+        .execute(
+            "UPDATE issues SET worktree_state = ?1 WHERE id = ?2",
+            rusqlite::params![new_state, issue_id],
+        )
+        .map_err(|error| format!("Failed to update worktree state: {error}"))?;
+    Ok(())
+}
+
+fn update_worktree_fields(
+    connection: &rusqlite::Connection,
+    issue_id: &str,
+    worktree_state: &str,
+    worktree_folder: Option<&str>,
+    branch_name: Option<&str>,
+    base_branch: Option<&str>,
+) -> Result<(), String> {
+    connection
+        .execute(
+            "UPDATE issues SET worktree_state = ?1, worktree_folder = ?2, \
+             branch_name = ?3, base_branch = ?4 WHERE id = ?5",
+            rusqlite::params![worktree_state, worktree_folder, branch_name, base_branch, issue_id],
+        )
+        .map_err(|error| format!("Failed to update worktree fields: {error}"))?;
+    Ok(())
+}
+
+// ─── Event Helpers ─────────────────────────────────────────────────────────────
+
+fn emit_state_change(
+    app_handle: &AppHandle,
+    issue_id: &str,
+    old_state: &str,
+    new_state: &str,
+    worktree_folder: Option<&str>,
+) {
+    let _ = app_handle.emit(
+        "worktree-state-change",
+        WorktreeStateChangePayload {
+            issue_id: issue_id.to_string(),
+            old_state: old_state.to_string(),
+            new_state: new_state.to_string(),
+            worktree_folder: worktree_folder.map(String::from),
+        },
+    );
+}
+
+fn emit_progress(app_handle: &AppHandle, issue_id: &str, source: &str, line: &str) {
+    let _ = app_handle.emit(
+        "worktree-progress",
+        WorktreeProgressPayload {
+            issue_id: issue_id.to_string(),
+            source: source.to_string(),
+            line: line.to_string(),
+        },
+    );
+}
+
+/// Spawn a tokio task that reads lines from `reader` and emits progress events.
+fn stream_output(
+    reader: impl AsyncRead + Send + Unpin + 'static,
+    app_handle: AppHandle,
+    issue_id: String,
+    source: &'static str,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut lines = BufReader::new(reader).lines();
+        while let Ok(Some(line)) = lines.next_line().await {
+            emit_progress(&app_handle, &issue_id, source, &line);
+        }
+    })
+}
+
+// ─── Commands ──────────────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub async fn setup_worktree(
+    state: State<'_, DatabaseState>,
+    app_handle: AppHandle,
+    request: SetupWorktreeRequest,
+) -> Result<String, String> {
+    let bash_path = detect_bash_path()?;
+    let scripts_dir = resolve_scripts_directory()?;
+    let setup_script = scripts_dir.join("setup-worktree.sh");
+
+    if !setup_script.exists() {
+        return Err(format!(
+            "setup-worktree.sh not found at {}",
+            setup_script.display()
+        ));
+    }
+
+    // Validate state transition: only setup from 'none' or 'failed'
+    let old_state = {
+        let connection = state.0.lock().map_err(|error| error.to_string())?;
+        let current_state = get_worktree_state(&connection, &request.issue_id)?;
+        if current_state != "none" && current_state != "failed" {
+            return Err(format!(
+                "Cannot setup worktree: current state is '{current_state}', expected 'none' or 'failed'"
+            ));
+        }
+        update_worktree_state(&connection, &request.issue_id, "pending")?;
+        current_state
+    };
+
+    emit_state_change(
+        &app_handle,
+        &request.issue_id,
+        &old_state,
+        "pending",
+        None,
+    );
+
+    // Build command arguments
+    let mut args = vec![
+        setup_script.to_string_lossy().to_string(),
+        request.branch_name.clone(),
+    ];
+    if let Some(ref color) = request.color {
+        args.push("--color".to_string());
+        args.push(color.clone());
+    }
+
+    // Spawn the script
+    let mut child = Command::new(&bash_path)
+        .args(&args)
+        .current_dir(&request.working_directory)
+        .env("BAMGIT", "1") // Signal to script it's being called from BamGit
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .map_err(|error| {
+            // Revert to old state on spawn failure
+            if let Ok(conn) = state.0.lock() {
+                let _ = update_worktree_state(&conn, &request.issue_id, &old_state);
+            }
+            format!("Failed to spawn setup-worktree.sh: {error}")
+        })?;
+
+    // Stream stdout/stderr as progress events
+    let stdout_handle = child
+        .stdout
+        .take()
+        .map(|s| stream_output(s, app_handle.clone(), request.issue_id.clone(), "stdout"));
+    let stderr_handle = child
+        .stderr
+        .take()
+        .map(|s| stream_output(s, app_handle.clone(), request.issue_id.clone(), "stderr"));
+
+    // Wait for process, then join readers so all progress lines are flushed
+    let exit_status = child
+        .wait()
+        .await
+        .map_err(|error| format!("Failed to wait for setup-worktree.sh: {error}"))?;
+
+    if let Some(handle) = stdout_handle {
+        let _ = handle.await;
+    }
+    if let Some(handle) = stderr_handle {
+        let _ = handle.await;
+    }
+
+    if exit_status.success() {
+        // Derive worktree folder path from the convention: <repo>/../worktrees/<branch_name>
+        let working_dir = Path::new(&request.working_directory);
+        let worktree_folder = working_dir
+            .parent()
+            .unwrap_or(working_dir)
+            .join("worktrees")
+            .join(&request.branch_name);
+        let worktree_folder_str = worktree_folder.to_string_lossy().to_string();
+
+        let connection = state.0.lock().map_err(|error| error.to_string())?;
+        update_worktree_fields(
+            &connection,
+            &request.issue_id,
+            "active",
+            Some(&worktree_folder_str),
+            Some(&request.branch_name),
+            request.base_branch.as_deref(),
+        )?;
+
+        emit_state_change(
+            &app_handle,
+            &request.issue_id,
+            "pending",
+            "active",
+            Some(&worktree_folder_str),
+        );
+
+        Ok(worktree_folder_str)
+    } else {
+        let exit_code = exit_status.code().unwrap_or(-1);
+        let connection = state.0.lock().map_err(|error| error.to_string())?;
+        update_worktree_state(&connection, &request.issue_id, "failed")?;
+
+        emit_state_change(&app_handle, &request.issue_id, "pending", "failed", None);
+
+        Err(format!(
+            "setup-worktree.sh exited with code {exit_code}"
+        ))
+    }
+}
+
+#[tauri::command]
+pub async fn remove_worktree(
+    state: State<'_, DatabaseState>,
+    app_handle: AppHandle,
+    request: RemoveWorktreeRequest,
+) -> Result<(), String> {
+    let bash_path = detect_bash_path()?;
+    let scripts_dir = resolve_scripts_directory()?;
+    let remove_script = scripts_dir.join("remove-worktree.sh");
+
+    if !remove_script.exists() {
+        return Err(format!(
+            "remove-worktree.sh not found at {}",
+            remove_script.display()
+        ));
+    }
+
+    // Validate state: only remove from 'active' or 'failed'
+    let old_state = {
+        let connection = state.0.lock().map_err(|error| error.to_string())?;
+        let current_state = get_worktree_state(&connection, &request.issue_id)?;
+        if current_state != "active" && current_state != "failed" {
+            return Err(format!(
+                "Cannot remove worktree: current state is '{current_state}', expected 'active' or 'failed'"
+            ));
+        }
+        update_worktree_state(&connection, &request.issue_id, "pending")?;
+        current_state
+    };
+
+    emit_state_change(
+        &app_handle,
+        &request.issue_id,
+        &old_state,
+        "pending",
+        None,
+    );
+
+    let args = vec![
+        remove_script.to_string_lossy().to_string(),
+        "--skip-confirmation".to_string(),
+        request.branch_name.clone(),
+    ];
+
+    let mut child = Command::new(&bash_path)
+        .args(&args)
+        .current_dir(&request.working_directory)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .map_err(|error| {
+            if let Ok(conn) = state.0.lock() {
+                let _ = update_worktree_state(&conn, &request.issue_id, &old_state);
+            }
+            format!("Failed to spawn remove-worktree.sh: {error}")
+        })?;
+
+    let stdout_handle = child
+        .stdout
+        .take()
+        .map(|s| stream_output(s, app_handle.clone(), request.issue_id.clone(), "stdout"));
+    let stderr_handle = child
+        .stderr
+        .take()
+        .map(|s| stream_output(s, app_handle.clone(), request.issue_id.clone(), "stderr"));
+
+    let exit_status = child
+        .wait()
+        .await
+        .map_err(|error| format!("Failed to wait for remove-worktree.sh: {error}"))?;
+
+    if let Some(handle) = stdout_handle {
+        let _ = handle.await;
+    }
+    if let Some(handle) = stderr_handle {
+        let _ = handle.await;
+    }
+
+    if exit_status.success() {
+        let connection = state.0.lock().map_err(|error| error.to_string())?;
+        update_worktree_fields(
+            &connection,
+            &request.issue_id,
+            "none",
+            None,
+            None,
+            None,
+        )?;
+
+        emit_state_change(&app_handle, &request.issue_id, "pending", "none", None);
+        Ok(())
+    } else {
+        let exit_code = exit_status.code().unwrap_or(-1);
+        let connection = state.0.lock().map_err(|error| error.to_string())?;
+        update_worktree_state(&connection, &request.issue_id, "failed")?;
+
+        emit_state_change(&app_handle, &request.issue_id, "pending", "failed", None);
+        Err(format!(
+            "remove-worktree.sh exited with code {exit_code}"
+        ))
+    }
+}
+
+#[tauri::command]
+pub fn refresh_worktree_state(
+    state: State<DatabaseState>,
+    app_handle: AppHandle,
+    issue_id: String,
+) -> Result<String, String> {
+    let connection = state.0.lock().map_err(|error| error.to_string())?;
+
+    let (current_state, worktree_folder): (String, Option<String>) = connection
+        .query_row(
+            "SELECT worktree_state, worktree_folder FROM issues WHERE id = ?1",
+            [&issue_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .map_err(|error| format!("Issue not found: {error}"))?;
+
+    // If state is 'active', verify the folder still exists
+    if current_state == "active" {
+        if let Some(ref folder) = worktree_folder {
+            if !Path::new(folder).exists() {
+                update_worktree_state(&connection, &issue_id, "failed")?;
+                emit_state_change(&app_handle, &issue_id, "active", "failed", None);
+                return Ok("failed".to_string());
+            }
+        } else {
+            // Active but no folder recorded — mark as failed
+            update_worktree_state(&connection, &issue_id, "failed")?;
+            emit_state_change(&app_handle, &issue_id, "active", "failed", None);
+            return Ok("failed".to_string());
+        }
+    }
+
+    // If state is 'none' but folder exists, mark as active
+    if current_state == "none" {
+        if let Some(ref folder) = worktree_folder {
+            if Path::new(folder).exists() {
+                update_worktree_state(&connection, &issue_id, "active")?;
+                emit_state_change(
+                    &app_handle,
+                    &issue_id,
+                    "none",
+                    "active",
+                    Some(folder),
+                );
+                return Ok("active".to_string());
+            }
+        }
+    }
+
+    Ok(current_state)
+}
+
+#[tauri::command]
+pub fn get_prunable_issues(
+    state: State<DatabaseState>,
+    dashboard_id: String,
+) -> Result<Vec<PrunableIssue>, String> {
+    let connection = state.0.lock().map_err(|error| error.to_string())?;
+
+    // Find issues with active worktrees that are fully closed:
+    // PR merged + GitHub issue closed + branch gone/deleted
+    let mut statement = connection
+        .prepare(
+            "SELECT i.id, i.name, i.branch_name, i.worktree_folder, \
+                    g.pr_state, g.github_issue_state, g.branch_status \
+             FROM issues i \
+             JOIN git_status_cache g ON i.id = g.issue_id \
+             WHERE i.dashboard_id = ?1 \
+               AND i.worktree_state = 'active' \
+               AND g.pr_state = 'merged' \
+               AND g.github_issue_state = 'closed' \
+               AND (g.branch_status IN ('remote-gone', 'deleted') OR g.branch_status IS NULL)",
+        )
+        .map_err(|error| format!("Failed to prepare query: {error}"))?;
+
+    let issues = statement
+        .query_map([&dashboard_id], |row| {
+            Ok(PrunableIssue {
+                issue_id: row.get(0)?,
+                name: row.get(1)?,
+                branch_name: row.get::<_, Option<String>>(2)?.unwrap_or_default(),
+                worktree_folder: row.get(3)?,
+                pr_state: row.get(4)?,
+                github_issue_state: row.get(5)?,
+                branch_status: row.get(6)?,
+            })
+        })
+        .map_err(|error| format!("Failed to query prunable issues: {error}"))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| format!("Failed to read prunable issue row: {error}"))?;
+
+    Ok(issues)
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,7 +6,7 @@ mod session;
 
 use commands::{
     dashboard_commands, git_status_commands, github_commands, issue_commands, portfolio_commands,
-    session_commands,
+    session_commands, worktree_commands,
 };
 use git::fetch_coordinator::FetchCoordinator;
 use session::discovery_polling::DiscoveryPoller;
@@ -73,6 +73,10 @@ pub fn run() {
             github_commands::fetch_pr_for_branch,
             github_commands::fetch_assigned_issues,
             github_commands::sync_all_github_state,
+            worktree_commands::setup_worktree,
+            worktree_commands::remove_worktree,
+            worktree_commands::refresh_worktree_state,
+            worktree_commands::get_prunable_issues,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/src-tauri/src/models/issue.rs
+++ b/src-tauri/src/models/issue.rs
@@ -47,6 +47,10 @@ pub struct UpdateIssueRequest {
     pub color: Option<Option<String>>,
     pub github_issue_url: Option<Option<String>>,
     pub github_issue_number: Option<Option<i64>>,
+    pub branch_name: Option<Option<String>>,
+    pub base_branch: Option<Option<String>>,
+    pub worktree_folder: Option<Option<String>>,
+    pub worktree_state: Option<String>,
     pub parent_issue_id: Option<Option<String>>,
     pub sort_order: Option<i64>,
 }

--- a/src/lib/components/DashboardToolbar.svelte
+++ b/src/lib/components/DashboardToolbar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { RefreshCw } from 'lucide-svelte';
+	import { RefreshCw, Scissors } from 'lucide-svelte';
 	import type { SortMode } from '$lib/stores/issues.svelte';
 
 	interface Props {
@@ -14,6 +14,7 @@
 		on_toggle_archived: () => void;
 		on_toggle_expand_all: () => void;
 		on_sync_all?: () => void;
+		on_prune_worktrees?: () => void;
 	}
 
 	let {
@@ -28,6 +29,7 @@
 		on_toggle_archived,
 		on_toggle_expand_all,
 		on_sync_all,
+		on_prune_worktrees,
 	}: Props = $props();
 </script>
 
@@ -49,6 +51,18 @@
 		>
 			<RefreshCw size={13} class={syncing ? 'animate-spin' : ''} />
 			{syncing ? 'Syncing...' : 'Sync All'}
+		</button>
+	{/if}
+
+	<!-- Prune Worktrees -->
+	{#if on_prune_worktrees}
+		<button
+			onclick={on_prune_worktrees}
+			class="inline-flex items-center gap-1.5 rounded border border-neutral-700 px-2.5 py-1.5 text-xs text-neutral-400 transition-colors hover:border-neutral-600 hover:text-neutral-300"
+			title="Prune worktrees for fully-closed issues"
+		>
+			<Scissors size={13} />
+			Prune
 		</button>
 	{/if}
 

--- a/src/lib/components/IssueCard.svelte
+++ b/src/lib/components/IssueCard.svelte
@@ -6,6 +6,7 @@
 	import GitHubIssueBadge from './GitHubIssueBadge.svelte';
 	import SyncStatusIndicator from './SyncStatusIndicator.svelte';
 	import GitBadgeGroup from './GitBadgeGroup.svelte';
+	import WorktreeProgressIndicator from './WorktreeProgressIndicator.svelte';
 
 	interface Props {
 		issue: Issue;
@@ -16,10 +17,13 @@
 		is_last_child?: boolean;
 		child_count?: number;
 		force_expanded?: boolean;
+		progress_lines?: readonly string[];
 		on_archive: (id: string) => void;
 		on_unarchive: (id: string) => void;
 		on_edit: (issue: Issue) => void;
 		on_delete: (id: string) => void;
+		on_setup_worktree?: (issue: Issue) => void;
+		on_remove_worktree?: (issue: Issue) => void;
 	}
 
 	let {
@@ -31,18 +35,37 @@
 		is_last_child = false,
 		child_count = 0,
 		force_expanded,
+		progress_lines = [],
 		on_archive,
 		on_unarchive,
 		on_edit,
 		on_delete,
+		on_setup_worktree,
+		on_remove_worktree,
 	}: Props = $props();
 
 	let local_expanded = $state(false);
-	const expanded = $derived(force_expanded ?? local_expanded);
+	// Auto-expand when worktree is being set up so progress is visible
+	const expanded = $derived(
+		force_expanded ?? (issue.worktree_state === 'pending' || local_expanded),
+	);
 	let show_overflow = $state(false);
 
 	const color = $derived(issue.color ?? '#525252');
 	const is_archived = $derived(issue.status === 'archived');
+
+	const worktree_badge = $derived.by(() => {
+		switch (issue.worktree_state) {
+			case 'pending':
+				return { label: 'Setting up...', class: 'bg-yellow-900/40 text-yellow-400' };
+			case 'active':
+				return { label: 'Worktree', class: 'bg-green-900/40 text-green-400' };
+			case 'failed':
+				return { label: 'WT Failed', class: 'bg-red-900/40 text-red-400' };
+			default:
+				return null;
+		}
+	});
 
 	const priority_border_class = $derived.by(() => {
 		switch (issue.priority) {
@@ -132,6 +155,18 @@
 				{#if issue.branch_name}
 					<GitBadgeGroup branch_name={issue.branch_name} {git_status} />
 				{/if}
+				{#if worktree_badge}
+					<span
+						class="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs {worktree_badge.class}"
+					>
+						{#if issue.worktree_state === 'pending'}
+							<span
+								class="inline-block h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent"
+							></span>
+						{/if}
+						{worktree_badge.label}
+					</span>
+				{/if}
 			</div>
 
 			<!-- Action buttons -->
@@ -158,6 +193,30 @@
 						>
 							Edit
 						</button>
+						{#if on_setup_worktree && issue.branch_name && (issue.worktree_state === 'none' || issue.worktree_state === 'failed')}
+							<button
+								onclick={() => {
+									on_setup_worktree(issue);
+									show_overflow = false;
+								}}
+								class="w-full px-3 py-1.5 text-left text-sm text-green-400 hover:bg-neutral-700"
+							>
+								{issue.worktree_state === 'failed'
+									? 'Retry Worktree'
+									: 'Add Worktree'}
+							</button>
+						{/if}
+						{#if on_remove_worktree && issue.worktree_state === 'active'}
+							<button
+								onclick={() => {
+									on_remove_worktree(issue);
+									show_overflow = false;
+								}}
+								class="w-full px-3 py-1.5 text-left text-sm text-orange-400 hover:bg-neutral-700"
+							>
+								Remove Worktree
+							</button>
+						{/if}
 						{#if is_archived}
 							<button
 								onclick={() => {
@@ -224,6 +283,9 @@
 						</div>
 					{/if}
 				</div>
+				{#if issue.worktree_state === 'pending' && progress_lines.length > 0}
+					<WorktreeProgressIndicator lines={progress_lines} />
+				{/if}
 			</div>
 		{/if}
 	</div>

--- a/src/lib/components/IssueCard.svelte
+++ b/src/lib/components/IssueCard.svelte
@@ -193,7 +193,7 @@
 						>
 							Edit
 						</button>
-						{#if on_setup_worktree && issue.branch_name && (issue.worktree_state === 'none' || issue.worktree_state === 'failed')}
+						{#if on_setup_worktree && issue.branch_name !== null && (issue.worktree_state === 'none' || issue.worktree_state === 'failed')}
 							<button
 								onclick={() => {
 									on_setup_worktree(issue);

--- a/src/lib/components/IssueCardList.svelte
+++ b/src/lib/components/IssueCardList.svelte
@@ -14,10 +14,13 @@
 		gh_available?: boolean;
 		get_children: (parent_id: string) => Issue[];
 		get_git_status: (issue_id: string) => GitStatusCache | undefined;
+		get_progress_lines?: (issue_id: string) => readonly string[];
 		on_archive: (id: string) => void;
 		on_unarchive: (id: string) => void;
 		on_edit: (issue: Issue) => void;
 		on_delete: (id: string) => void;
+		on_setup_worktree?: (issue: Issue) => void;
+		on_remove_worktree?: (issue: Issue) => void;
 	}
 
 	let {
@@ -30,10 +33,13 @@
 		gh_available = false,
 		get_children,
 		get_git_status,
+		get_progress_lines,
 		on_archive,
 		on_unarchive,
 		on_edit,
 		on_delete,
+		on_setup_worktree,
+		on_remove_worktree,
 	}: Props = $props();
 </script>
 
@@ -48,10 +54,13 @@
 			git_status={get_git_status(issue.id)}
 			child_count={children.length}
 			{force_expanded}
+			progress_lines={get_progress_lines?.(issue.id) ?? []}
 			{on_archive}
 			{on_unarchive}
 			{on_edit}
 			{on_delete}
+			{on_setup_worktree}
+			{on_remove_worktree}
 		/>
 
 		<!-- Nested children for portfolio dashboards -->
@@ -65,10 +74,13 @@
 					indented={true}
 					is_last_child={index === children.length - 1}
 					{force_expanded}
+					progress_lines={get_progress_lines?.(child.id) ?? []}
 					{on_archive}
 					{on_unarchive}
 					{on_edit}
 					{on_delete}
+					{on_setup_worktree}
+					{on_remove_worktree}
 				/>
 			{/each}
 		{/if}

--- a/src/lib/components/PruneWorktreesDialog.svelte
+++ b/src/lib/components/PruneWorktreesDialog.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { SvelteSet } from 'svelte/reactivity';
 	import type { PrunableIssue } from '$lib/types/worktree';
 
 	interface Props {
@@ -11,23 +12,21 @@
 
 	let { open, prunable_issues, removing, on_close, on_prune }: Props = $props();
 
-	let selected_ids = $state<Set<string>>(new Set());
+	let selected_ids = $state(new SvelteSet<string>());
 
 	// Reset selection when dialog opens with new data
 	$effect(() => {
 		if (open) {
-			selected_ids = new Set(prunable_issues.map((issue) => issue.issue_id));
+			selected_ids = new SvelteSet(prunable_issues.map((issue) => issue.issue_id));
 		}
 	});
 
 	function toggle_selection(issue_id: string) {
-		const next = new Set(selected_ids);
-		if (next.has(issue_id)) {
-			next.delete(issue_id);
+		if (selected_ids.has(issue_id)) {
+			selected_ids.delete(issue_id);
 		} else {
-			next.add(issue_id);
+			selected_ids.add(issue_id);
 		}
-		selected_ids = next;
 	}
 
 	function handle_prune() {

--- a/src/lib/components/PruneWorktreesDialog.svelte
+++ b/src/lib/components/PruneWorktreesDialog.svelte
@@ -1,0 +1,127 @@
+<script lang="ts">
+	import type { PrunableIssue } from '$lib/types/worktree';
+
+	interface Props {
+		open: boolean;
+		prunable_issues: PrunableIssue[];
+		removing: boolean;
+		on_close: () => void;
+		on_prune: (issue_ids: string[]) => void;
+	}
+
+	let { open, prunable_issues, removing, on_close, on_prune }: Props = $props();
+
+	let selected_ids = $state<Set<string>>(new Set());
+
+	// Reset selection when dialog opens with new data
+	$effect(() => {
+		if (open) {
+			selected_ids = new Set(prunable_issues.map((issue) => issue.issue_id));
+		}
+	});
+
+	function toggle_selection(issue_id: string) {
+		const next = new Set(selected_ids);
+		if (next.has(issue_id)) {
+			next.delete(issue_id);
+		} else {
+			next.add(issue_id);
+		}
+		selected_ids = next;
+	}
+
+	function handle_prune() {
+		on_prune([...selected_ids]);
+	}
+</script>
+
+{#if open}
+	<!-- svelte-ignore a11y_no_static_element_interactions -->
+	<div
+		class="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+		onkeydown={(e) => {
+			if (e.key === 'Escape') {
+				on_close();
+			}
+		}}
+	>
+		<!-- svelte-ignore a11y_click_events_have_key_events -->
+		<div class="absolute inset-0" onclick={on_close}></div>
+		<div
+			class="relative z-10 w-full max-w-lg rounded-lg border border-neutral-700 bg-neutral-900 shadow-xl"
+		>
+			<div class="border-b border-neutral-800 px-4 py-3">
+				<h2 class="text-sm font-semibold">Prune Worktrees</h2>
+				<p class="mt-1 text-xs text-neutral-500">
+					These issues have merged PRs and closed GitHub issues. Select which worktrees to
+					remove.
+				</p>
+			</div>
+
+			<div class="max-h-64 overflow-y-auto px-4 py-3">
+				{#if prunable_issues.length === 0}
+					<p class="text-sm text-neutral-500">No prunable worktrees found.</p>
+				{:else}
+					<div class="flex flex-col gap-2">
+						{#each prunable_issues as issue (issue.issue_id)}
+							<label
+								class="flex cursor-pointer items-center gap-3 rounded px-2 py-1.5 hover:bg-neutral-800"
+							>
+								<input
+									type="checkbox"
+									checked={selected_ids.has(issue.issue_id)}
+									onchange={() => toggle_selection(issue.issue_id)}
+									class="rounded border-neutral-600"
+								/>
+								<div class="min-w-0 flex-1">
+									<div class="truncate text-sm">{issue.name}</div>
+									<div class="text-xs text-neutral-500">
+										{issue.branch_name}
+										{#if issue.worktree_folder}
+											<span class="text-neutral-600">
+												— {issue.worktree_folder}
+											</span>
+										{/if}
+									</div>
+								</div>
+								<div class="flex items-center gap-1">
+									<span
+										class="rounded bg-purple-900/40 px-1.5 py-0.5 text-[10px] text-purple-400"
+									>
+										merged
+									</span>
+									<span
+										class="rounded bg-red-900/40 px-1.5 py-0.5 text-[10px] text-red-400"
+									>
+										closed
+									</span>
+								</div>
+							</label>
+						{/each}
+					</div>
+				{/if}
+			</div>
+
+			<div class="flex items-center justify-end gap-2 border-t border-neutral-800 px-4 py-3">
+				<button
+					onclick={on_close}
+					disabled={removing}
+					class="rounded px-3 py-1.5 text-sm text-neutral-400 hover:text-neutral-300"
+				>
+					Cancel
+				</button>
+				<button
+					onclick={handle_prune}
+					disabled={selected_ids.size === 0 || removing}
+					class="rounded bg-red-600 px-3 py-1.5 text-sm text-white transition-colors hover:bg-red-500 disabled:opacity-40"
+				>
+					{#if removing}
+						Removing...
+					{:else}
+						Remove {selected_ids.size} worktree{selected_ids.size !== 1 ? 's' : ''}
+					{/if}
+				</button>
+			</div>
+		</div>
+	</div>
+{/if}

--- a/src/lib/components/WorktreeProgressIndicator.svelte
+++ b/src/lib/components/WorktreeProgressIndicator.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+	interface Props {
+		lines: readonly string[];
+	}
+
+	let { lines }: Props = $props();
+
+	let scroll_container: HTMLDivElement | undefined = $state();
+
+	// Auto-scroll to bottom when new lines arrive
+	$effect(() => {
+		if (lines.length > 0 && scroll_container) {
+			scroll_container.scrollTop = scroll_container.scrollHeight;
+		}
+	});
+
+	/** Strip ANSI escape codes for display */
+	function strip_ansi(text: string): string {
+		// oxlint-disable-next-line no-control-regex -- intentional: stripping ANSI escape sequences
+		return text.replace(/\u001B\[[0-9;]*[a-zA-Z]/g, '');
+	}
+</script>
+
+<div class="mt-2 border-t border-neutral-800 pt-2">
+	<div class="mb-1 text-[10px] font-medium uppercase tracking-wider text-neutral-600">
+		Progress
+	</div>
+	<div
+		bind:this={scroll_container}
+		class="max-h-32 overflow-y-auto rounded bg-neutral-950 p-2 font-mono text-[11px] leading-4 text-neutral-400"
+	>
+		{#each lines as line}
+			<div class="whitespace-pre-wrap break-all">{strip_ansi(line)}</div>
+		{/each}
+	</div>
+</div>

--- a/src/lib/components/WorktreeProgressIndicator.svelte
+++ b/src/lib/components/WorktreeProgressIndicator.svelte
@@ -29,7 +29,7 @@
 		bind:this={scroll_container}
 		class="max-h-32 overflow-y-auto rounded bg-neutral-950 p-2 font-mono text-[11px] leading-4 text-neutral-400"
 	>
-		{#each lines as line}
+		{#each lines as line, index (index)}
 			<div class="whitespace-pre-wrap break-all">{strip_ansi(line)}</div>
 		{/each}
 	</div>

--- a/src/lib/stores/issues.svelte.ts
+++ b/src/lib/stores/issues.svelte.ts
@@ -1,5 +1,7 @@
 import type { Issue } from '$lib/types/issue';
+import type { WorktreeProgressPayload, WorktreeStateChangePayload } from '$lib/types/worktree';
 import { get_issues_for_dashboard } from '$lib/tauri/issue_commands';
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 
 export type SortMode = 'priority' | 'name' | 'date';
 
@@ -11,6 +13,9 @@ let show_archived = $state(false);
 let loading = $state(false);
 let error = $state<string | null>(null);
 let current_dashboard_id = $state<string | null>(null);
+
+// Worktree progress: per-issue log lines
+let worktree_progress = $state<Map<string, string[]>>(new Map());
 
 const sorted_issues = $derived.by(() => {
 	const list = [...issues];
@@ -37,6 +42,58 @@ const parent_issues = $derived(active_issues.filter((issue) => !issue.parent_iss
 
 function get_children(parent_id: string): Issue[] {
 	return active_issues.filter((issue) => issue.parent_issue_id === parent_id);
+}
+
+// Event listener cleanup handles
+let unlisten_progress: UnlistenFn | null = null;
+let unlisten_state_change: UnlistenFn | null = null;
+
+async function start_worktree_listeners() {
+	// Clean up any existing listeners to avoid double-registration on dashboard switch
+	stop_worktree_listeners();
+
+	unlisten_progress = await listen<WorktreeProgressPayload>('worktree-progress', (event) => {
+		const { issue_id, line } = event.payload;
+		const existing = worktree_progress.get(issue_id) ?? [];
+		worktree_progress = new Map(worktree_progress).set(issue_id, [...existing, line]);
+	});
+
+	unlisten_state_change = await listen<WorktreeStateChangePayload>(
+		'worktree-state-change',
+		(event) => {
+			const { issue_id, new_state, worktree_folder } = event.payload;
+			// Update the local issue state optimistically
+			issues = issues.map((issue) => {
+				if (issue.id !== issue_id) {
+					return issue;
+				}
+				return {
+					...issue,
+					worktree_state: new_state,
+					worktree_folder:
+						new_state === 'none' ? null : (worktree_folder ?? issue.worktree_folder),
+				};
+			});
+
+			// Clear progress log when transitioning out of pending
+			if (new_state !== 'pending') {
+				const updated = new Map(worktree_progress);
+				updated.delete(issue_id);
+				worktree_progress = updated;
+			}
+		},
+	);
+}
+
+function stop_worktree_listeners() {
+	unlisten_progress?.();
+	unlisten_state_change?.();
+	unlisten_progress = null;
+	unlisten_state_change = null;
+}
+
+function get_progress_lines(issue_id: string): readonly string[] {
+	return worktree_progress.get(issue_id) ?? [];
 }
 
 export function get_issue_store() {
@@ -67,6 +124,7 @@ export function get_issue_store() {
 		},
 
 		get_children,
+		get_progress_lines,
 
 		async load_issues(dashboard_id: string) {
 			try {
@@ -74,6 +132,7 @@ export function get_issue_store() {
 				current_dashboard_id = dashboard_id;
 				issues = await get_issues_for_dashboard(dashboard_id, true);
 				error = null;
+				await start_worktree_listeners();
 			} catch (err) {
 				error = String(err);
 			} finally {
@@ -98,6 +157,10 @@ export function get_issue_store() {
 
 		toggle_show_archived() {
 			show_archived = !show_archived;
+		},
+
+		cleanup() {
+			stop_worktree_listeners();
 		},
 	};
 }

--- a/src/lib/tauri/worktree_commands.ts
+++ b/src/lib/tauri/worktree_commands.ts
@@ -1,0 +1,22 @@
+import { invoke } from '@tauri-apps/api/core';
+import type {
+	SetupWorktreeRequest,
+	RemoveWorktreeRequest,
+	PrunableIssue,
+} from '$lib/types/worktree';
+
+export async function setup_worktree(request: SetupWorktreeRequest): Promise<string> {
+	return invoke('setup_worktree', { request });
+}
+
+export async function remove_worktree(request: RemoveWorktreeRequest): Promise<void> {
+	return invoke('remove_worktree', { request });
+}
+
+export async function refresh_worktree_state(issue_id: string): Promise<string> {
+	return invoke('refresh_worktree_state', { issueId: issue_id });
+}
+
+export async function get_prunable_issues(dashboard_id: string): Promise<PrunableIssue[]> {
+	return invoke('get_prunable_issues', { dashboardId: dashboard_id });
+}

--- a/src/lib/types/issue.ts
+++ b/src/lib/types/issue.ts
@@ -1,3 +1,5 @@
+import type { WorktreeState } from './worktree';
+
 export interface Issue {
 	id: string;
 	dashboard_id: string;
@@ -10,7 +12,7 @@ export interface Issue {
 	branch_name: string | null;
 	base_branch: string | null;
 	worktree_folder: string | null;
-	worktree_state: 'none' | 'pending' | 'active' | 'failed';
+	worktree_state: WorktreeState;
 	parent_issue_id: string | null;
 	editor_folder: string | null;
 	dev_server_command: string | null;
@@ -38,6 +40,10 @@ export interface UpdateIssueRequest {
 	color?: string | null;
 	github_issue_url?: string | null;
 	github_issue_number?: number | null;
+	branch_name?: string | null;
+	base_branch?: string | null;
+	worktree_folder?: string | null;
+	worktree_state?: WorktreeState;
 	parent_issue_id?: string | null;
 	sort_order?: number;
 }

--- a/src/lib/types/worktree.ts
+++ b/src/lib/types/worktree.ts
@@ -1,0 +1,38 @@
+export type WorktreeState = 'none' | 'pending' | 'active' | 'failed';
+
+export interface SetupWorktreeRequest {
+	issue_id: string;
+	branch_name: string;
+	color?: string | null;
+	working_directory: string;
+	base_branch?: string | null;
+}
+
+export interface RemoveWorktreeRequest {
+	issue_id: string;
+	branch_name: string;
+	working_directory: string;
+}
+
+export interface WorktreeProgressPayload {
+	issue_id: string;
+	source: 'stdout' | 'stderr';
+	line: string;
+}
+
+export interface WorktreeStateChangePayload {
+	issue_id: string;
+	old_state: WorktreeState;
+	new_state: WorktreeState;
+	worktree_folder: string | null;
+}
+
+export interface PrunableIssue {
+	issue_id: string;
+	name: string;
+	branch_name: string;
+	worktree_folder: string | null;
+	pr_state: string | null;
+	github_issue_state: string | null;
+	branch_status: string | null;
+}

--- a/src/routes/issues/+page.svelte
+++ b/src/routes/issues/+page.svelte
@@ -129,11 +129,11 @@
 
 	async function handle_setup_worktree(issue: Issue) {
 		const dashboard = dashboard_store.active_dashboard;
-		if (!dashboard?.local_folder) {
+		if (dashboard?.local_folder == null) {
 			console.error('Dashboard has no local_folder configured');
 			return;
 		}
-		if (!issue.branch_name) {
+		if (issue.branch_name == null) {
 			console.error('Issue has no branch_name set');
 			return;
 		}
@@ -152,11 +152,11 @@
 
 	async function handle_remove_worktree(issue: Issue) {
 		const dashboard = dashboard_store.active_dashboard;
-		if (!dashboard?.local_folder) {
+		if (dashboard?.local_folder == null) {
 			console.error('Dashboard has no local_folder configured');
 			return;
 		}
-		if (!issue.branch_name) {
+		if (issue.branch_name == null) {
 			console.error('Issue has no branch_name to remove');
 			return;
 		}
@@ -173,7 +173,7 @@
 
 	async function handle_open_prune_dialog() {
 		const dashboard_id = dashboard_store.active_dashboard_id;
-		if (!dashboard_id) {
+		if (dashboard_id == null) {
 			return;
 		}
 		try {
@@ -186,14 +186,14 @@
 
 	async function handle_prune(issue_ids: string[]) {
 		const dashboard = dashboard_store.active_dashboard;
-		if (!dashboard?.local_folder) {
+		if (dashboard?.local_folder == null) {
 			return;
 		}
 		prune_removing = true;
 		try {
 			for (const issue_id of issue_ids) {
 				const issue = issue_store.issues.find((i) => i.id === issue_id);
-				if (issue?.branch_name) {
+				if (issue?.branch_name != null) {
 					await remove_worktree({
 						issue_id,
 						branch_name: issue.branch_name,

--- a/src/routes/issues/+page.svelte
+++ b/src/routes/issues/+page.svelte
@@ -10,7 +10,13 @@
 		update_issue,
 		delete_issue,
 	} from '$lib/tauri/issue_commands';
+	import {
+		setup_worktree,
+		remove_worktree,
+		get_prunable_issues,
+	} from '$lib/tauri/worktree_commands';
 	import type { Issue, CreateIssueRequest, UpdateIssueRequest } from '$lib/types/issue';
+	import type { PrunableIssue } from '$lib/types/worktree';
 	import OnboardingCard from '$lib/components/OnboardingCard.svelte';
 	import EmptyIssueState from '$lib/components/EmptyIssueState.svelte';
 	import DashboardToolbar from '$lib/components/DashboardToolbar.svelte';
@@ -19,6 +25,7 @@
 	import IssueEditDialog from '$lib/components/IssueEditDialog.svelte';
 	import GhSetupBanner from '$lib/components/GhSetupBanner.svelte';
 	import AssignedIssuesPanel from '$lib/components/AssignedIssuesPanel.svelte';
+	import PruneWorktreesDialog from '$lib/components/PruneWorktreesDialog.svelte';
 
 	const dashboard_store = get_dashboard_store();
 	const git_status_store = get_git_status_store();
@@ -28,6 +35,9 @@
 	let create_dialog_open = $state(false);
 	let editing_issue = $state<Issue | null>(null);
 	let all_expanded = $state(false);
+	let prune_dialog_open = $state(false);
+	let prunable_issues = $state<PrunableIssue[]>([]);
+	let prune_removing = $state(false);
 
 	// Parse "owner/repo" from dashboard's github_repo field
 	const github_repo_parts = $derived.by(() => {
@@ -116,6 +126,88 @@
 			console.error('Failed to delete issue:', err);
 		}
 	}
+
+	async function handle_setup_worktree(issue: Issue) {
+		const dashboard = dashboard_store.active_dashboard;
+		if (!dashboard?.local_folder) {
+			console.error('Dashboard has no local_folder configured');
+			return;
+		}
+		if (!issue.branch_name) {
+			console.error('Issue has no branch_name set');
+			return;
+		}
+		try {
+			await setup_worktree({
+				issue_id: issue.id,
+				branch_name: issue.branch_name,
+				color: issue.color,
+				working_directory: dashboard.local_folder,
+				base_branch: issue.base_branch ?? dashboard.default_base_branch,
+			});
+		} catch (err) {
+			console.error('Failed to setup worktree:', err);
+		}
+	}
+
+	async function handle_remove_worktree(issue: Issue) {
+		const dashboard = dashboard_store.active_dashboard;
+		if (!dashboard?.local_folder) {
+			console.error('Dashboard has no local_folder configured');
+			return;
+		}
+		if (!issue.branch_name) {
+			console.error('Issue has no branch_name to remove');
+			return;
+		}
+		try {
+			await remove_worktree({
+				issue_id: issue.id,
+				branch_name: issue.branch_name,
+				working_directory: dashboard.local_folder,
+			});
+		} catch (err) {
+			console.error('Failed to remove worktree:', err);
+		}
+	}
+
+	async function handle_open_prune_dialog() {
+		const dashboard_id = dashboard_store.active_dashboard_id;
+		if (!dashboard_id) {
+			return;
+		}
+		try {
+			prunable_issues = await get_prunable_issues(dashboard_id);
+			prune_dialog_open = true;
+		} catch (err) {
+			console.error('Failed to fetch prunable issues:', err);
+		}
+	}
+
+	async function handle_prune(issue_ids: string[]) {
+		const dashboard = dashboard_store.active_dashboard;
+		if (!dashboard?.local_folder) {
+			return;
+		}
+		prune_removing = true;
+		try {
+			for (const issue_id of issue_ids) {
+				const issue = issue_store.issues.find((i) => i.id === issue_id);
+				if (issue?.branch_name) {
+					await remove_worktree({
+						issue_id,
+						branch_name: issue.branch_name,
+						working_directory: dashboard.local_folder,
+					});
+				}
+			}
+			prune_dialog_open = false;
+		} catch (err) {
+			console.error('Failed to prune worktrees:', err);
+		} finally {
+			prune_removing = false;
+		}
+	}
 </script>
 
 {#if dashboard_store.loading}
@@ -156,6 +248,7 @@
 			on_toggle_archived={() => issue_store.toggle_show_archived()}
 			on_toggle_expand_all={() => (all_expanded = !all_expanded)}
 			on_sync_all={github_repo_parts ? handle_sync_all : undefined}
+			on_prune_worktrees={handle_open_prune_dialog}
 		/>
 
 		<!-- Issue list or empty state -->
@@ -176,10 +269,13 @@
 				gh_available={github_store.is_available}
 				get_children={issue_store.get_children}
 				get_git_status={(issue_id) => git_status_store.get_status(issue_id)}
+				get_progress_lines={(issue_id) => issue_store.get_progress_lines(issue_id)}
 				on_archive={handle_archive_issue}
 				on_unarchive={handle_unarchive_issue}
 				on_edit={(issue) => (editing_issue = issue)}
 				on_delete={handle_delete_issue}
+				on_setup_worktree={handle_setup_worktree}
+				on_remove_worktree={handle_remove_worktree}
 			/>
 		{/if}
 
@@ -203,5 +299,13 @@
 		issue={editing_issue}
 		on_close={() => (editing_issue = null)}
 		on_update={handle_update_issue}
+	/>
+
+	<PruneWorktreesDialog
+		open={prune_dialog_open}
+		{prunable_issues}
+		removing={prune_removing}
+		on_close={() => (prune_dialog_open = false)}
+		on_prune={handle_prune}
 	/>
 {/if}

--- a/src/routes/sessions/+page.svelte
+++ b/src/routes/sessions/+page.svelte
@@ -19,7 +19,7 @@
 	let spawn_prompt = $state('');
 	let spawn_working_directory = $state('');
 	let spawning = $state(false);
-	let adopting_id = $state<string | null>(null);
+
 	let unlisten_session_event: UnlistenFn | null = null;
 	let unlisten_discovered: UnlistenFn | null = null;
 
@@ -83,7 +83,6 @@
 	}
 
 	async function handle_adopt(discovered: DiscoveredSession) {
-		adopting_id = discovered.id;
 		try {
 			await adopt_session({
 				cli_session_id: discovered.session_id,
@@ -96,8 +95,6 @@
 			await store.refresh();
 		} catch (err) {
 			console.error('Failed to adopt session:', err);
-		} finally {
-			adopting_id = null;
 		}
 	}
 


### PR DESCRIPTION
## Description
- Add Rust `worktree_commands` module with `setup_worktree`, `remove_worktree`, `refresh_worktree_state`, and `get_prunable_issues` commands
- Shell out to `setup-worktree.sh` / `remove-worktree.sh` with real-time stdout/stderr streaming via Tauri events (`worktree-progress`, `worktree-state-change`)
- Implement worktree state machine (none → pending → active / failed) with DB-level state transitions and validation guards
- Add IssueCard worktree badge (pending spinner, active green, failed red), overflow menu actions (Add/Retry/Remove Worktree), and auto-expanding progress display
- Add Prune button in toolbar + PruneWorktreesDialog for bulk removal of fully-closed worktrees (merged PR + closed issue + deleted branch)
- Wire `branch_name`, `base_branch`, `worktree_folder`, `worktree_state` through `UpdateIssueRequest` on both Rust and TS sides

## Resolves
Closes #10