### PR TITLE
#19 feat(viz): Tree State Engine + types

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"preview": "vite preview",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-		"check:all": "prettier --write . && oxlint && eslint . && stylelint \"src/**/*.{css,svelte}\" && knip && svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+		"check:all": "svelte-kit sync && prettier --write . && oxlint && eslint . && stylelint \"src/**/*.{css,svelte}\" && knip && svelte-check --tsconfig ./tsconfig.json",
 		"lint": "oxlint",
 		"lint:eslint": "eslint .",
 		"lint:css": "stylelint \"src/**/*.{css,svelte}\"",

--- a/src/lib/engine/aggregate_session_state.test.ts
+++ b/src/lib/engine/aggregate_session_state.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { aggregate_session_state } from './aggregate_session_state';
+import type { SessionState } from '$lib/types/session';
+
+describe('aggregate_session_state', () => {
+	it('returns no-session for empty array', () => {
+		expect(aggregate_session_state([])).toBe('no-session');
+	});
+
+	it('returns running for single running session', () => {
+		expect(aggregate_session_state(['running'])).toBe('running');
+	});
+
+	it('returns needs-input for single needs-input session', () => {
+		expect(aggregate_session_state(['needs-input'])).toBe('needs-input');
+	});
+
+	it('returns errored for single errored session', () => {
+		expect(aggregate_session_state(['errored'])).toBe('errored');
+	});
+
+	it('returns needs-review for single needs-review session', () => {
+		expect(aggregate_session_state(['needs-review'])).toBe('needs-review');
+	});
+
+	it('returns paused for single paused session', () => {
+		expect(aggregate_session_state(['paused'])).toBe('paused');
+	});
+
+	it('returns finished for single finished session', () => {
+		expect(aggregate_session_state(['finished'])).toBe('finished');
+	});
+
+	it('needs-input wins over running', () => {
+		expect(aggregate_session_state(['running', 'needs-input'])).toBe('needs-input');
+	});
+
+	it('errored wins over finished', () => {
+		expect(aggregate_session_state(['finished', 'errored'])).toBe('errored');
+	});
+
+	it('needs-review wins over paused and running', () => {
+		expect(aggregate_session_state(['paused', 'running', 'needs-review'])).toBe('needs-review');
+	});
+
+	it('needs-input is highest priority across all states', () => {
+		const sessions: readonly SessionState[] = [
+			'finished',
+			'paused',
+			'running',
+			'errored',
+			'needs-input',
+		];
+		expect(aggregate_session_state(sessions)).toBe('needs-input');
+	});
+
+	it('returns finished when all sessions are finished', () => {
+		expect(aggregate_session_state(['finished', 'finished', 'finished'])).toBe('finished');
+	});
+
+	it('running wins over finished', () => {
+		expect(aggregate_session_state(['finished', 'running'])).toBe('running');
+	});
+});

--- a/src/lib/engine/aggregate_session_state.test.ts
+++ b/src/lib/engine/aggregate_session_state.test.ts
@@ -43,6 +43,10 @@ describe('aggregate_session_state', () => {
 		expect(aggregate_session_state(['paused', 'running', 'needs-review'])).toBe('needs-review');
 	});
 
+	it('errored wins over needs-review', () => {
+		expect(aggregate_session_state(['needs-review', 'errored'])).toBe('errored');
+	});
+
 	it('needs-input is highest priority across all states', () => {
 		const sessions: readonly SessionState[] = [
 			'finished',

--- a/src/lib/engine/aggregate_session_state.ts
+++ b/src/lib/engine/aggregate_session_state.ts
@@ -1,0 +1,27 @@
+import type { SessionState } from '$lib/types/session';
+import type { AggregateSessionState } from '$lib/types/tree_visualization';
+
+const PRIORITY: readonly SessionState[] = [
+	'needs-input',
+	'errored',
+	'needs-review',
+	'running',
+	'paused',
+	'finished',
+];
+
+export function aggregate_session_state(sessions: readonly SessionState[]): AggregateSessionState {
+	if (sessions.length === 0) {
+		return 'no-session';
+	}
+
+	const state_set = new Set(sessions);
+
+	for (const state of PRIORITY) {
+		if (state_set.has(state)) {
+			return state;
+		}
+	}
+
+	return 'no-session';
+}

--- a/src/lib/engine/compute_tree_visualization.test.ts
+++ b/src/lib/engine/compute_tree_visualization.test.ts
@@ -1,0 +1,413 @@
+import { describe, it, expect } from 'vitest';
+import { compute_tree_visualization } from './compute_tree_visualization';
+import type {
+	StateDimensions,
+	TreeVisualizationTree,
+	TreeVisualizationPottedPlant,
+	TreeVisualizationOak,
+	TreeComputeContext,
+} from '$lib/types/tree_visualization';
+
+function create_dimensions(overrides: Partial<StateDimensions> = {}): StateDimensions {
+	return {
+		label: 'AFK',
+		worktreeState: 'none',
+		aggregateSessionState: 'no-session',
+		executionPhase: 'none',
+		branchStatus: 'no-branch',
+		pullRequestState: 'no-pr',
+		githubIssueState: 'open',
+		syncStatus: { type: 'up-to-date' },
+		bamgitStatus: 'active',
+		...overrides,
+	};
+}
+
+function create_context(overrides: Partial<TreeComputeContext> = {}): TreeComputeContext {
+	return {
+		isPrd: false,
+		hasCompletedSession: false,
+		hasCommitsOnBranch: false,
+		sessionCount: 0,
+		companionSaplings: [],
+		activeTools: [],
+		...overrides,
+	};
+}
+
+// ─── Kind Determination ──────────────────────────────────────────────────
+
+describe('compute_tree_visualization — kind determination', () => {
+	it('returns oak when isPrd is true', () => {
+		const result = compute_tree_visualization(
+			create_dimensions(),
+			create_context({ isPrd: true }),
+		);
+		expect(result.kind).toBe('oak');
+	});
+
+	it('returns tree when label is set', () => {
+		const result = compute_tree_visualization(create_dimensions({ label: 'HITL' }));
+		expect(result.kind).toBe('tree');
+	});
+
+	it('returns potted-plant when label is null', () => {
+		const result = compute_tree_visualization(create_dimensions({ label: null }));
+		expect(result.kind).toBe('potted-plant');
+	});
+});
+
+// ─── Tree Stages ─────────────────────────────────────────────────────────
+
+describe('compute_tree_visualization — tree stages', () => {
+	it('seed: label=HITL, worktreeState=none, no session', () => {
+		const result = compute_tree_visualization(
+			create_dimensions({
+				label: 'HITL',
+				worktreeState: 'none',
+				aggregateSessionState: 'no-session',
+			}),
+		) as TreeVisualizationTree;
+		expect(result.kind).toBe('tree');
+		expect(result.stage).toBe('seed');
+	});
+
+	it('sprouting: label=AFK, worktreeState=none', () => {
+		const result = compute_tree_visualization(
+			create_dimensions({ label: 'AFK', worktreeState: 'none' }),
+		) as TreeVisualizationTree;
+		expect(result.kind).toBe('tree');
+		expect(result.stage).toBe('sprouting');
+	});
+
+	it('sprouting: label=AFK, worktreeState=pending', () => {
+		const result = compute_tree_visualization(
+			create_dimensions({ label: 'AFK', worktreeState: 'pending' }),
+		) as TreeVisualizationTree;
+		expect(result.kind).toBe('tree');
+		expect(result.stage).toBe('sprouting');
+	});
+
+	it('sapling: worktreeState=active, branchStatus=active, no session', () => {
+		const result = compute_tree_visualization(
+			create_dimensions({
+				worktreeState: 'active',
+				branchStatus: 'active',
+				aggregateSessionState: 'no-session',
+			}),
+		) as TreeVisualizationTree;
+		expect(result.kind).toBe('tree');
+		expect(result.stage).toBe('sapling');
+	});
+
+	it('growing: aggregateSessionState=running, no completed session', () => {
+		const result = compute_tree_visualization(
+			create_dimensions({
+				worktreeState: 'active',
+				branchStatus: 'active',
+				aggregateSessionState: 'running',
+			}),
+			create_context({ hasCompletedSession: false }),
+		) as TreeVisualizationTree;
+		expect(result.kind).toBe('tree');
+		expect(result.stage).toBe('growing');
+	});
+
+	it('leafy: aggregateSessionState=finished, hasCommitsOnBranch=true', () => {
+		const result = compute_tree_visualization(
+			create_dimensions({
+				worktreeState: 'active',
+				branchStatus: 'active',
+				aggregateSessionState: 'finished',
+			}),
+			create_context({ hasCommitsOnBranch: true }),
+		) as TreeVisualizationTree;
+		expect(result.kind).toBe('tree');
+		expect(result.stage).toBe('leafy');
+	});
+
+	it('fruiting: pullRequestState=draft', () => {
+		const result = compute_tree_visualization(
+			create_dimensions({
+				worktreeState: 'active',
+				branchStatus: 'active',
+				pullRequestState: 'draft',
+			}),
+		) as TreeVisualizationTree;
+		expect(result.kind).toBe('tree');
+		expect(result.stage).toBe('fruiting');
+	});
+
+	it('fruiting: pullRequestState=open', () => {
+		const result = compute_tree_visualization(
+			create_dimensions({
+				worktreeState: 'active',
+				branchStatus: 'active',
+				pullRequestState: 'open',
+			}),
+		) as TreeVisualizationTree;
+		expect(result.kind).toBe('tree');
+		expect(result.stage).toBe('fruiting');
+	});
+
+	it('autumn: pullRequestState=review-requested', () => {
+		const result = compute_tree_visualization(
+			create_dimensions({ pullRequestState: 'review-requested' }),
+		) as TreeVisualizationTree;
+		expect(result.kind).toBe('tree');
+		expect(result.stage).toBe('autumn');
+	});
+
+	it('autumn: pullRequestState=changes-requested', () => {
+		const result = compute_tree_visualization(
+			create_dimensions({ pullRequestState: 'changes-requested' }),
+		) as TreeVisualizationTree;
+		expect(result.kind).toBe('tree');
+		expect(result.stage).toBe('autumn');
+	});
+
+	it('autumn: pullRequestState=approved', () => {
+		const result = compute_tree_visualization(
+			create_dimensions({ pullRequestState: 'approved' }),
+		) as TreeVisualizationTree;
+		expect(result.kind).toBe('tree');
+		expect(result.stage).toBe('autumn');
+	});
+
+	it('ready: pullRequestState=ready-to-merge', () => {
+		const result = compute_tree_visualization(
+			create_dimensions({ pullRequestState: 'ready-to-merge' }),
+		) as TreeVisualizationTree;
+		expect(result.kind).toBe('tree');
+		expect(result.stage).toBe('ready');
+	});
+
+	it('bare: pullRequestState=merged, githubIssueState=closed', () => {
+		const result = compute_tree_visualization(
+			create_dimensions({ pullRequestState: 'merged', githubIssueState: 'closed' }),
+		) as TreeVisualizationTree;
+		expect(result.kind).toBe('tree');
+		expect(result.stage).toBe('bare');
+	});
+
+	it('dead: branchStatus=deleted', () => {
+		const result = compute_tree_visualization(
+			create_dimensions({ branchStatus: 'deleted', worktreeState: 'active' }),
+		) as TreeVisualizationTree;
+		expect(result.kind).toBe('tree');
+		expect(result.stage).toBe('dead');
+	});
+
+	it('stump: worktreeState=removed, bamgitStatus=archived', () => {
+		const result = compute_tree_visualization(
+			create_dimensions({ worktreeState: 'removed', bamgitStatus: 'archived' }),
+		) as TreeVisualizationTree;
+		expect(result.kind).toBe('tree');
+		expect(result.stage).toBe('stump');
+	});
+});
+
+// ─── Tree Stage Priority ─────────────────────────────────────────────────
+
+describe('compute_tree_visualization — tree stage priority', () => {
+	it('bare wins over sapling when PR merged and issue closed', () => {
+		const result = compute_tree_visualization(
+			create_dimensions({
+				worktreeState: 'active',
+				branchStatus: 'active',
+				pullRequestState: 'merged',
+				githubIssueState: 'closed',
+				aggregateSessionState: 'no-session',
+			}),
+		) as TreeVisualizationTree;
+		expect(result.stage).toBe('bare');
+	});
+});
+
+// ─── Potted Plant Stages ─────────────────────────────────────────────────
+
+describe('compute_tree_visualization — potted plant stages', () => {
+	it('pot-with-soil: default for label=null', () => {
+		const result = compute_tree_visualization(
+			create_dimensions({ label: null }),
+		) as TreeVisualizationPottedPlant;
+		expect(result.kind).toBe('potted-plant');
+		expect(result.stage).toBe('pot-with-soil');
+	});
+
+	it('sprout: has session activity but no completed session', () => {
+		const result = compute_tree_visualization(
+			create_dimensions({ label: null, aggregateSessionState: 'running' }),
+			create_context({ hasCompletedSession: false }),
+		) as TreeVisualizationPottedPlant;
+		expect(result.kind).toBe('potted-plant');
+		expect(result.stage).toBe('sprout');
+	});
+
+	it('small-plant: hasCompletedSession=true', () => {
+		const result = compute_tree_visualization(
+			create_dimensions({ label: null, aggregateSessionState: 'finished' }),
+			create_context({ hasCompletedSession: true }),
+		) as TreeVisualizationPottedPlant;
+		expect(result.kind).toBe('potted-plant');
+		expect(result.stage).toBe('small-plant');
+	});
+
+	it('flowering: has PR activity', () => {
+		const result = compute_tree_visualization(
+			create_dimensions({ label: null, pullRequestState: 'draft' }),
+			create_context({ hasCompletedSession: true }),
+		) as TreeVisualizationPottedPlant;
+		expect(result.kind).toBe('potted-plant');
+		expect(result.stage).toBe('flowering');
+	});
+
+	it('dried: githubIssueState=closed', () => {
+		const result = compute_tree_visualization(
+			create_dimensions({ label: null, githubIssueState: 'closed' }),
+		) as TreeVisualizationPottedPlant;
+		expect(result.kind).toBe('potted-plant');
+		expect(result.stage).toBe('dried');
+	});
+});
+
+// ─── Oak ─────────────────────────────────────────────────────────────────
+
+describe('compute_tree_visualization — oak', () => {
+	it('isPrd=true returns oak with overlays array', () => {
+		const result = compute_tree_visualization(
+			create_dimensions(),
+			create_context({ isPrd: true }),
+		) as TreeVisualizationOak;
+		expect(result.kind).toBe('oak');
+		expect(result.overlays).toEqual([]);
+	});
+});
+
+// ─── Overlays ────────────────────────────────────────────────────────────
+
+describe('compute_tree_visualization — overlays', () => {
+	it('error-damage when worktreeState=failed', () => {
+		const result = compute_tree_visualization(create_dimensions({ worktreeState: 'failed' }));
+		expect(result.overlays).toContain('error-damage');
+	});
+
+	it('error-damage when aggregateSessionState=errored', () => {
+		const result = compute_tree_visualization(
+			create_dimensions({ aggregateSessionState: 'errored' }),
+		);
+		expect(result.overlays).toContain('error-damage');
+	});
+
+	it('merge-conflict when syncStatus.type=merge-conflict', () => {
+		const result = compute_tree_visualization(
+			create_dimensions({ syncStatus: { type: 'merge-conflict' } }),
+		);
+		expect(result.overlays).toContain('merge-conflict');
+	});
+
+	it('behind-base when syncStatus.type=behind-base', () => {
+		const result = compute_tree_visualization(
+			create_dimensions({ syncStatus: { type: 'behind-base', count: 3 } }),
+		);
+		expect(result.overlays).toContain('behind-base');
+	});
+
+	it('needs-input when aggregateSessionState=needs-input', () => {
+		const result = compute_tree_visualization(
+			create_dimensions({ aggregateSessionState: 'needs-input' }),
+		);
+		expect(result.overlays).toContain('needs-input');
+	});
+
+	it('changes-requested when pullRequestState=changes-requested', () => {
+		const result = compute_tree_visualization(
+			create_dimensions({ pullRequestState: 'changes-requested' }),
+		);
+		expect(result.overlays).toContain('changes-requested');
+	});
+
+	it('approved when pullRequestState=approved', () => {
+		const result = compute_tree_visualization(
+			create_dimensions({ pullRequestState: 'approved' }),
+		);
+		expect(result.overlays).toContain('approved');
+	});
+
+	it('multiple overlays can stack', () => {
+		const result = compute_tree_visualization(
+			create_dimensions({
+				worktreeState: 'failed',
+				aggregateSessionState: 'needs-input',
+				syncStatus: { type: 'merge-conflict' },
+			}),
+		);
+		expect(result.overlays).toContain('error-damage');
+		expect(result.overlays).toContain('needs-input');
+		expect(result.overlays).toContain('merge-conflict');
+	});
+
+	it('no overlays when all clear', () => {
+		const result = compute_tree_visualization(create_dimensions());
+		expect(result.overlays).toEqual([]);
+	});
+});
+
+// ─── Fruit Types ─────────────────────────────────────────────────────────
+
+describe('compute_tree_visualization — fruit types', () => {
+	it('no fruit when sessionCount=0', () => {
+		const result = compute_tree_visualization(
+			create_dimensions(),
+			create_context({ sessionCount: 0 }),
+		) as TreeVisualizationTree;
+		expect(result.fruitTypes).toEqual([]);
+	});
+
+	it('assigns fruit types based on sessionCount', () => {
+		const result = compute_tree_visualization(
+			create_dimensions(),
+			create_context({ sessionCount: 3 }),
+		) as TreeVisualizationTree;
+		expect(result.fruitTypes).toHaveLength(3);
+	});
+
+	it('fruit types rotate through available types', () => {
+		const result = compute_tree_visualization(
+			create_dimensions(),
+			create_context({ sessionCount: 7 }),
+		) as TreeVisualizationTree;
+		expect(result.fruitTypes).toHaveLength(7);
+		expect(result.fruitTypes[5]).toBe(result.fruitTypes[0]);
+	});
+});
+
+// ─── Context Passthrough ─────────────────────────────────────────────────
+
+describe('compute_tree_visualization — context passthrough', () => {
+	it('companion saplings passed through in tree kind', () => {
+		const saplings = [{ agentType: 'coder', state: 'active' as const }];
+		const result = compute_tree_visualization(
+			create_dimensions(),
+			create_context({ companionSaplings: saplings }),
+		) as TreeVisualizationTree;
+		expect(result.companionSaplings).toEqual(saplings);
+	});
+
+	it('active tools passed through in tree kind', () => {
+		const tools = ['bash' as const, 'grep' as const];
+		const result = compute_tree_visualization(
+			create_dimensions(),
+			create_context({ activeTools: tools }),
+		) as TreeVisualizationTree;
+		expect(result.activeTools).toEqual(tools);
+	});
+
+	it('uses default context when context not provided', () => {
+		const result = compute_tree_visualization(create_dimensions()) as TreeVisualizationTree;
+		expect(result.kind).toBe('tree');
+		expect(result.companionSaplings).toEqual([]);
+		expect(result.activeTools).toEqual([]);
+		expect(result.fruitTypes).toEqual([]);
+	});
+});

--- a/src/lib/engine/compute_tree_visualization.ts
+++ b/src/lib/engine/compute_tree_visualization.ts
@@ -1,0 +1,147 @@
+import type {
+	StateDimensions,
+	TreeComputeContext,
+	TreeVisualization,
+	TreeStage,
+	PottedPlantStage,
+	TreeOverlay,
+	FruitType,
+} from '$lib/types/tree_visualization';
+
+export const DEFAULT_COMPUTE_CONTEXT: TreeComputeContext = {
+	isPrd: false,
+	hasCompletedSession: false,
+	hasCommitsOnBranch: false,
+	sessionCount: 0,
+	companionSaplings: [],
+	activeTools: [],
+};
+
+const FRUIT_ROTATION: readonly FruitType[] = ['apple', 'pear', 'orange', 'cherry', 'plum'];
+
+function compute_overlays(dimensions: StateDimensions): readonly TreeOverlay[] {
+	const overlays: TreeOverlay[] = [];
+
+	if (dimensions.worktreeState === 'failed' || dimensions.aggregateSessionState === 'errored') {
+		overlays.push('error-damage');
+	}
+	if (dimensions.syncStatus.type === 'merge-conflict') {
+		overlays.push('merge-conflict');
+	}
+	if (dimensions.syncStatus.type === 'behind-base') {
+		overlays.push('behind-base');
+	}
+	if (dimensions.aggregateSessionState === 'needs-input') {
+		overlays.push('needs-input');
+	}
+	if (dimensions.pullRequestState === 'changes-requested') {
+		overlays.push('changes-requested');
+	}
+	if (dimensions.pullRequestState === 'approved') {
+		overlays.push('approved');
+	}
+
+	return overlays;
+}
+
+function compute_fruit_types(session_count: number): readonly FruitType[] {
+	return Array.from(
+		{ length: session_count },
+		(_, i) => FRUIT_ROTATION[i % FRUIT_ROTATION.length],
+	);
+}
+
+function compute_tree_stage(dimensions: StateDimensions, context: TreeComputeContext): TreeStage {
+	if (dimensions.worktreeState === 'removed' && dimensions.bamgitStatus === 'archived') {
+		return 'stump';
+	}
+	if (dimensions.branchStatus === 'deleted') {
+		return 'dead';
+	}
+	if (dimensions.pullRequestState === 'merged' && dimensions.githubIssueState === 'closed') {
+		return 'bare';
+	}
+	if (dimensions.pullRequestState === 'ready-to-merge') {
+		return 'ready';
+	}
+	if (
+		dimensions.pullRequestState === 'review-requested' ||
+		dimensions.pullRequestState === 'changes-requested' ||
+		dimensions.pullRequestState === 'approved'
+	) {
+		return 'autumn';
+	}
+	if (dimensions.pullRequestState === 'draft' || dimensions.pullRequestState === 'open') {
+		return 'fruiting';
+	}
+	if (dimensions.aggregateSessionState === 'finished' && context.hasCommitsOnBranch) {
+		return 'leafy';
+	}
+	if (dimensions.aggregateSessionState === 'running' && !context.hasCompletedSession) {
+		return 'growing';
+	}
+	if (
+		dimensions.worktreeState === 'active' &&
+		dimensions.branchStatus !== 'no-branch' &&
+		dimensions.aggregateSessionState === 'no-session'
+	) {
+		return 'sapling';
+	}
+	if (
+		dimensions.label === 'AFK' &&
+		(dimensions.worktreeState === 'none' || dimensions.worktreeState === 'pending')
+	) {
+		return 'sprouting';
+	}
+
+	return 'seed';
+}
+
+function compute_potted_plant_stage(
+	dimensions: StateDimensions,
+	context: TreeComputeContext,
+): PottedPlantStage {
+	if (dimensions.githubIssueState === 'closed') {
+		return 'dried';
+	}
+	if (dimensions.pullRequestState !== 'no-pr') {
+		return 'flowering';
+	}
+	if (context.hasCompletedSession) {
+		return 'small-plant';
+	}
+	if (dimensions.aggregateSessionState !== 'no-session') {
+		return 'sprout';
+	}
+
+	return 'pot-with-soil';
+}
+
+export function compute_tree_visualization(
+	dimensions: StateDimensions,
+	context?: TreeComputeContext,
+): TreeVisualization {
+	const resolved_context = context ?? DEFAULT_COMPUTE_CONTEXT;
+	const overlays = compute_overlays(dimensions);
+
+	if (resolved_context.isPrd) {
+		return { kind: 'oak', overlays };
+	}
+
+	if (dimensions.label === null) {
+		return {
+			kind: 'potted-plant',
+			stage: compute_potted_plant_stage(dimensions, resolved_context),
+			overlays,
+		};
+	}
+
+	return {
+		kind: 'tree',
+		stage: compute_tree_stage(dimensions, resolved_context),
+		overlays,
+		companionSaplings: resolved_context.companionSaplings,
+		activeTools: resolved_context.activeTools,
+		fruitTypes: compute_fruit_types(resolved_context.sessionCount),
+	};
+}

--- a/src/lib/types/tree_visualization.ts
+++ b/src/lib/types/tree_visualization.ts
@@ -1,0 +1,130 @@
+// ─── R12 State Dimensions ─────────────────────────────────────────────────
+// Forest-prefixed types: superset of existing types to avoid breaking backend contracts.
+// The engine operates on these types; mappers convert from existing types at the boundary.
+
+import type { SessionState } from './session';
+import type { WorktreeState } from './worktree';
+
+export type GitHubLabel = 'HITL' | 'AFK';
+
+export type ForestWorktreeState = WorktreeState | 'removing' | 'removed';
+
+export type AggregateSessionState = SessionState | 'no-session';
+
+export type ExecutionPhase =
+	| 'none'
+	| 'analyzing'
+	| 'tdd'
+	| 'reviewing'
+	| 'verifying'
+	| 'committing';
+
+export type ForestBranchStatus = 'no-branch' | 'active' | 'local-only' | 'remote-gone' | 'deleted';
+
+export type ForestPullRequestState =
+	| 'no-pr'
+	| 'draft'
+	| 'open'
+	| 'review-requested'
+	| 'changes-requested'
+	| 'approved'
+	| 'ready-to-merge'
+	| 'merged'
+	| 'closed';
+
+export type ForestGitHubIssueState = 'open' | 'closed';
+
+export type ForestSyncStatus =
+	| { readonly type: 'up-to-date' }
+	| { readonly type: 'behind-base'; readonly count: number }
+	| { readonly type: 'merge-conflict' };
+
+export type ForestBamGitStatus = 'active' | 'archived';
+
+export interface StateDimensions {
+	readonly label: GitHubLabel | null;
+	readonly worktreeState: ForestWorktreeState;
+	readonly aggregateSessionState: AggregateSessionState;
+	readonly executionPhase: ExecutionPhase;
+	readonly branchStatus: ForestBranchStatus;
+	readonly pullRequestState: ForestPullRequestState;
+	readonly githubIssueState: ForestGitHubIssueState;
+	readonly syncStatus: ForestSyncStatus;
+	readonly bamgitStatus: ForestBamGitStatus;
+}
+
+// ─── Tree Lifecycle Stages ────────────────────────────────────────────────
+
+export type TreeStage =
+	| 'seed'
+	| 'sprouting'
+	| 'sapling'
+	| 'growing'
+	| 'leafy'
+	| 'fruiting'
+	| 'autumn'
+	| 'ready'
+	| 'bare'
+	| 'dead'
+	| 'stump';
+
+export type PottedPlantStage = 'pot-with-soil' | 'sprout' | 'small-plant' | 'flowering' | 'dried';
+
+// ─── Overlays ─────────────────────────────────────────────────────────────
+
+export type TreeOverlay =
+	| 'error-damage'
+	| 'merge-conflict'
+	| 'behind-base'
+	| 'needs-input'
+	| 'changes-requested'
+	| 'approved';
+
+// ─── Session Overlays ─────────────────────────────────────────────────────
+
+export type FruitType = 'apple' | 'pear' | 'orange' | 'cherry' | 'plum';
+
+export interface CompanionSapling {
+	readonly agentType: string;
+	readonly state: 'active' | 'wilted';
+}
+
+export type ActiveTool = 'bash' | 'grep' | 'write' | 'edit';
+
+// ─── Tree Visualization Descriptor ────────────────────────────────────────
+
+export interface TreeVisualizationTree {
+	readonly kind: 'tree';
+	readonly stage: TreeStage;
+	readonly overlays: readonly TreeOverlay[];
+	readonly companionSaplings: readonly CompanionSapling[];
+	readonly activeTools: readonly ActiveTool[];
+	readonly fruitTypes: readonly FruitType[];
+}
+
+export interface TreeVisualizationPottedPlant {
+	readonly kind: 'potted-plant';
+	readonly stage: PottedPlantStage;
+	readonly overlays: readonly TreeOverlay[];
+}
+
+export interface TreeVisualizationOak {
+	readonly kind: 'oak';
+	readonly overlays: readonly TreeOverlay[];
+}
+
+export type TreeVisualization =
+	| TreeVisualizationTree
+	| TreeVisualizationPottedPlant
+	| TreeVisualizationOak;
+
+// ─── Engine Context (supplemental data not in StateDimensions) ────────────
+
+export interface TreeComputeContext {
+	readonly isPrd: boolean;
+	readonly hasCompletedSession: boolean;
+	readonly hasCommitsOnBranch: boolean;
+	readonly sessionCount: number;
+	readonly companionSaplings: readonly CompanionSapling[];
+	readonly activeTools: readonly ActiveTool[];
+}

--- a/src/lib/types/tree_visualization.ts
+++ b/src/lib/types/tree_visualization.ts
@@ -122,6 +122,7 @@ export type TreeVisualization =
 
 export interface TreeComputeContext {
 	readonly isPrd: boolean;
+	/** Whether any session on this branch has previously reached 'finished' state. */
 	readonly hasCompletedSession: boolean;
 	readonly hasCommitsOnBranch: boolean;
 	readonly sessionCount: number;


### PR DESCRIPTION
## Description
- Pure function `compute_tree_visualization()` maps 9 R12 state dimensions to `TreeVisualization` descriptor
- Priority cascading `aggregate_session_state()` for multi-session aggregation
- Forest-prefixed types (superset of existing) to avoid breaking backend contracts
- Discriminated union output: `tree` (11 stages) | `potted-plant` (5 stages) | `oak`
- 6 overlay types computed from cross-cutting state dimensions
- Session overlays: fruit types, companion saplings, active tools

## Resolves
Closes #19

## Testing
- [x] 62 unit tests covering all lifecycle stages, overlays, edge cases
- [x] `pnpm run check:all` passes (0 errors, 0 warnings)
- [x] `pnpm test --project server` passes