### PR TITLE
#17 feat(theme): dark mode toggle + semantic color token migration

### DIFF
--- a/src/lib/components/ActionButtonGroup.svelte
+++ b/src/lib/components/ActionButtonGroup.svelte
@@ -29,7 +29,7 @@
 				event.stopPropagation();
 				on_execute(action.id);
 			}}
-			class="rounded px-1.5 py-0.5 text-xs text-neutral-400 transition-colors hover:bg-neutral-700 hover:text-neutral-200"
+			class="rounded px-1.5 py-0.5 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
 			title={action.name}
 		>
 			<span class="text-[10px]">{get_icon_display(action.icon)}</span>

--- a/src/lib/components/AssignedIssuesPanel.svelte
+++ b/src/lib/components/AssignedIssuesPanel.svelte
@@ -19,14 +19,14 @@
 
 {#if issues.length > 0}
 	<div class="flex flex-col gap-1">
-		<h3 class="text-xs font-semibold uppercase tracking-wider text-neutral-600">
+		<h3 class="text-xs font-semibold uppercase tracking-wider text-muted-foreground/60">
 			Assigned to me ({issues.length})
 		</h3>
 		<div class="flex flex-col gap-0.5">
 			{#each issues as issue (issue.number)}
 				<button
 					onclick={() => handle_click(issue.url)}
-					class="flex items-center gap-2 rounded px-2 py-1 text-left text-xs text-neutral-400 transition-colors hover:bg-neutral-800 hover:text-neutral-300"
+					class="flex items-center gap-2 rounded px-2 py-1 text-left text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
 					class:cursor-not-allowed={disabled}
 					class:opacity-50={disabled}
 					{disabled}

--- a/src/lib/components/DashboardCreateDialog.svelte
+++ b/src/lib/components/DashboardCreateDialog.svelte
@@ -86,7 +86,7 @@
 <dialog
 	bind:this={dialog_element}
 	onclose={handle_cancel}
-	class="w-full max-w-md rounded-lg border border-neutral-700 bg-neutral-900 p-0 text-neutral-100 shadow-xl backdrop:bg-black/50"
+	class="w-full max-w-md rounded-lg border border-border bg-popover p-0 text-popover-foreground shadow-xl backdrop:bg-black/50"
 >
 	<form onsubmit={handle_submit} class="flex flex-col gap-4 p-6">
 		<h2 class="text-lg font-semibold">Create Dashboard</h2>
@@ -97,8 +97,8 @@
 				type="button"
 				onclick={() => (dashboard_type = 'repo')}
 				class="flex-1 rounded px-3 py-2 text-sm transition-colors {dashboard_type === 'repo'
-					? 'bg-blue-600 text-white'
-					: 'bg-neutral-800 text-neutral-400 hover:text-neutral-200'}"
+					? 'bg-primary text-primary-foreground'
+					: 'bg-muted text-muted-foreground hover:text-foreground'}"
 			>
 				◆ Repo
 			</button>
@@ -107,8 +107,8 @@
 				onclick={() => (dashboard_type = 'portfolio')}
 				class="flex-1 rounded px-3 py-2 text-sm transition-colors {dashboard_type ===
 				'portfolio'
-					? 'bg-blue-600 text-white'
-					: 'bg-neutral-800 text-neutral-400 hover:text-neutral-200'}"
+					? 'bg-primary text-primary-foreground'
+					: 'bg-muted text-muted-foreground hover:text-foreground'}"
 			>
 				◇ Portfolio
 			</button>
@@ -116,11 +116,11 @@
 
 		<!-- Name (always shown) -->
 		<label class="flex flex-col gap-1">
-			<span class="text-xs text-neutral-400">Name *</span>
+			<span class="text-xs text-muted-foreground">Name *</span>
 			<input
 				bind:value={name}
 				required
-				class="rounded border border-neutral-700 bg-neutral-800 px-3 py-2 text-sm text-neutral-100 outline-none focus:border-blue-500"
+				class="rounded border border-input bg-muted px-3 py-2 text-sm text-foreground outline-none focus:border-ring"
 				placeholder="My Project"
 			/>
 		</label>
@@ -136,18 +136,16 @@
 		{#if dashboard_type === 'portfolio'}
 			<!-- Portfolio repo picker -->
 			<fieldset class="flex flex-col gap-1">
-				<legend class="text-xs text-neutral-400">Repo Dashboards</legend>
+				<legend class="text-xs text-muted-foreground">Repo Dashboards</legend>
 				{#if repo_dashboards.length === 0}
-					<p class="text-xs text-neutral-500">
+					<p class="text-xs text-muted-foreground">
 						No repo dashboards yet. Create one first.
 					</p>
 				{:else}
-					<div
-						class="flex flex-col gap-1 rounded border border-neutral-700 bg-neutral-800 p-2"
-					>
+					<div class="flex flex-col gap-1 rounded border border-input bg-muted p-2">
 						{#each repo_dashboards as repo (repo.id)}
 							<label
-								class="flex items-center gap-2 rounded px-2 py-1 text-sm hover:bg-neutral-700"
+								class="flex items-center gap-2 rounded px-2 py-1 text-sm hover:bg-accent"
 							>
 								<input
 									type="checkbox"
@@ -161,11 +159,13 @@
 										}
 										selected_repo_ids = next;
 									}}
-									class="accent-blue-500"
+									class="accent-primary"
 								/>
-								<span class="text-neutral-300">{repo.name}</span>
+								<span class="text-foreground">{repo.name}</span>
 								{#if repo.github_repo}
-									<span class="text-xs text-neutral-500">{repo.github_repo}</span>
+									<span class="text-xs text-muted-foreground"
+										>{repo.github_repo}</span
+									>
 								{/if}
 							</label>
 						{/each}
@@ -174,34 +174,34 @@
 			</fieldset>
 		{:else if dashboard_type === 'repo'}
 			<label class="flex flex-col gap-1">
-				<span class="text-xs text-neutral-400">GitHub Repo</span>
+				<span class="text-xs text-muted-foreground">GitHub Repo</span>
 				<input
 					bind:value={github_repo}
-					class="rounded border border-neutral-700 bg-neutral-800 px-3 py-2 text-sm text-neutral-100 outline-none focus:border-blue-500"
+					class="rounded border border-input bg-muted px-3 py-2 text-sm text-foreground outline-none focus:border-ring"
 					placeholder="owner/repo"
 				/>
 			</label>
 			<label class="flex flex-col gap-1">
-				<span class="text-xs text-neutral-400">Local Folder</span>
+				<span class="text-xs text-muted-foreground">Local Folder</span>
 				<input
 					bind:value={local_folder}
-					class="rounded border border-neutral-700 bg-neutral-800 px-3 py-2 text-sm text-neutral-100 outline-none focus:border-blue-500"
+					class="rounded border border-input bg-muted px-3 py-2 text-sm text-foreground outline-none focus:border-ring"
 					placeholder="C:/projects/my-project"
 				/>
 			</label>
 			<label class="flex flex-col gap-1">
-				<span class="text-xs text-neutral-400">Default Base Branch</span>
+				<span class="text-xs text-muted-foreground">Default Base Branch</span>
 				<input
 					bind:value={default_base_branch}
-					class="rounded border border-neutral-700 bg-neutral-800 px-3 py-2 text-sm text-neutral-100 outline-none focus:border-blue-500"
+					class="rounded border border-input bg-muted px-3 py-2 text-sm text-foreground outline-none focus:border-ring"
 					placeholder="main"
 				/>
 			</label>
 			<label class="flex flex-col gap-1">
-				<span class="text-xs text-neutral-400">Worktree Parent Folder</span>
+				<span class="text-xs text-muted-foreground">Worktree Parent Folder</span>
 				<input
 					bind:value={worktree_parent_folder}
-					class="rounded border border-neutral-700 bg-neutral-800 px-3 py-2 text-sm text-neutral-100 outline-none focus:border-blue-500"
+					class="rounded border border-input bg-muted px-3 py-2 text-sm text-foreground outline-none focus:border-ring"
 					placeholder="C:/worktrees/my-project"
 				/>
 			</label>
@@ -212,13 +212,13 @@
 			<button
 				type="button"
 				onclick={handle_cancel}
-				class="rounded px-4 py-2 text-sm text-neutral-400 transition-colors hover:text-neutral-200"
+				class="rounded px-4 py-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
 			>
 				Cancel
 			</button>
 			<button
 				type="submit"
-				class="rounded bg-blue-600 px-4 py-2 text-sm text-white transition-colors hover:bg-blue-500"
+				class="rounded bg-primary px-4 py-2 text-sm text-primary-foreground transition-colors hover:bg-primary/90"
 			>
 				Create
 			</button>

--- a/src/lib/components/DashboardEditDialog.svelte
+++ b/src/lib/components/DashboardEditDialog.svelte
@@ -76,18 +76,18 @@
 <dialog
 	bind:this={dialog_element}
 	onclose={on_close}
-	class="w-full max-w-md rounded-lg border border-neutral-700 bg-neutral-900 p-0 text-neutral-100 shadow-xl backdrop:bg-black/50"
+	class="w-full max-w-md rounded-lg border border-border bg-popover p-0 text-popover-foreground shadow-xl backdrop:bg-black/50"
 >
 	{#if dashboard}
 		<form onsubmit={handle_submit} class="flex flex-col gap-4 p-6">
 			<h2 class="text-lg font-semibold">Edit Dashboard</h2>
 
 			<label class="flex flex-col gap-1">
-				<span class="text-xs text-neutral-400">Name *</span>
+				<span class="text-xs text-muted-foreground">Name *</span>
 				<input
 					bind:value={name}
 					required
-					class="rounded border border-neutral-700 bg-neutral-800 px-3 py-2 text-sm text-neutral-100 outline-none focus:border-blue-500"
+					class="rounded border border-input bg-muted px-3 py-2 text-sm text-foreground outline-none focus:border-ring"
 				/>
 			</label>
 
@@ -100,32 +100,32 @@
 
 			{#if dashboard.type === 'repo'}
 				<label class="flex flex-col gap-1">
-					<span class="text-xs text-neutral-400">GitHub Repo</span>
+					<span class="text-xs text-muted-foreground">GitHub Repo</span>
 					<input
 						bind:value={github_repo}
-						class="rounded border border-neutral-700 bg-neutral-800 px-3 py-2 text-sm text-neutral-100 outline-none focus:border-blue-500"
+						class="rounded border border-input bg-muted px-3 py-2 text-sm text-foreground outline-none focus:border-ring"
 						placeholder="owner/repo"
 					/>
 				</label>
 				<label class="flex flex-col gap-1">
-					<span class="text-xs text-neutral-400">Local Folder</span>
+					<span class="text-xs text-muted-foreground">Local Folder</span>
 					<input
 						bind:value={local_folder}
-						class="rounded border border-neutral-700 bg-neutral-800 px-3 py-2 text-sm text-neutral-100 outline-none focus:border-blue-500"
+						class="rounded border border-input bg-muted px-3 py-2 text-sm text-foreground outline-none focus:border-ring"
 					/>
 				</label>
 				<label class="flex flex-col gap-1">
-					<span class="text-xs text-neutral-400">Default Base Branch</span>
+					<span class="text-xs text-muted-foreground">Default Base Branch</span>
 					<input
 						bind:value={default_base_branch}
-						class="rounded border border-neutral-700 bg-neutral-800 px-3 py-2 text-sm text-neutral-100 outline-none focus:border-blue-500"
+						class="rounded border border-input bg-muted px-3 py-2 text-sm text-foreground outline-none focus:border-ring"
 					/>
 				</label>
 				<label class="flex flex-col gap-1">
-					<span class="text-xs text-neutral-400">Worktree Parent Folder</span>
+					<span class="text-xs text-muted-foreground">Worktree Parent Folder</span>
 					<input
 						bind:value={worktree_parent_folder}
-						class="rounded border border-neutral-700 bg-neutral-800 px-3 py-2 text-sm text-neutral-100 outline-none focus:border-blue-500"
+						class="rounded border border-input bg-muted px-3 py-2 text-sm text-foreground outline-none focus:border-ring"
 					/>
 				</label>
 			{/if}
@@ -135,8 +135,8 @@
 					type="button"
 					onclick={handle_delete}
 					class="rounded px-3 py-2 text-sm transition-colors {confirm_delete
-						? 'bg-red-600 text-white'
-						: 'text-red-400 hover:text-red-300'}"
+						? 'bg-destructive text-destructive-foreground'
+						: 'text-destructive hover:text-destructive/80'}"
 				>
 					{confirm_delete ? 'Confirm Delete' : 'Delete'}
 				</button>
@@ -144,13 +144,13 @@
 					<button
 						type="button"
 						onclick={on_close}
-						class="rounded px-4 py-2 text-sm text-neutral-400 transition-colors hover:text-neutral-200"
+						class="rounded px-4 py-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
 					>
 						Cancel
 					</button>
 					<button
 						type="submit"
-						class="rounded bg-blue-600 px-4 py-2 text-sm text-white transition-colors hover:bg-blue-500"
+						class="rounded bg-primary px-4 py-2 text-sm text-primary-foreground transition-colors hover:bg-primary/90"
 					>
 						Save
 					</button>

--- a/src/lib/components/DashboardSidebar.svelte
+++ b/src/lib/components/DashboardSidebar.svelte
@@ -2,6 +2,7 @@
 	import { page } from '$app/state';
 	import { resolve } from '$app/paths';
 	import type { Dashboard } from '$lib/types/dashboard';
+	import ThemeToggle from './ThemeToggle.svelte';
 
 	interface Props {
 		dashboards: Dashboard[];
@@ -31,18 +32,18 @@
 </script>
 
 <aside
-	class="flex h-full flex-col border-r border-neutral-800 bg-neutral-950 transition-all {collapsed
+	class="flex h-full flex-col border-r border-sidebar-border bg-sidebar transition-all {collapsed
 		? 'w-12'
 		: 'w-60'}"
 >
 	<!-- Header -->
-	<div class="flex items-center justify-between border-b border-neutral-800 px-3 py-2">
+	<div class="flex items-center justify-between border-b border-sidebar-border px-3 py-2">
 		{#if !collapsed}
-			<span class="text-sm font-bold tracking-wide text-neutral-400">BamGit</span>
+			<span class="text-sm font-bold tracking-wide text-sidebar-foreground">BamGit</span>
 		{/if}
 		<button
 			onclick={on_toggle_sidebar}
-			class="rounded p-1 text-neutral-500 transition-colors hover:bg-neutral-800 hover:text-neutral-300"
+			class="rounded p-1 text-sidebar-foreground transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
 			title={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
 		>
 			{collapsed ? '▸' : '◂'}
@@ -50,14 +51,14 @@
 	</div>
 
 	<!-- Navigation -->
-	<nav class="flex flex-col gap-0.5 border-b border-neutral-800 p-2">
+	<nav class="flex flex-col gap-0.5 border-b border-sidebar-border p-2">
 		{#each navigation_items as item (item.href)}
 			<a
 				href={resolve(item.href)}
 				class="flex items-center gap-2 rounded px-2 py-1.5 text-sm transition-colors {page
 					.url.pathname === item.href || page.url.pathname.startsWith(item.href + '/')
-					? 'bg-neutral-800 text-white'
-					: 'text-neutral-400 hover:bg-neutral-800/50 hover:text-neutral-200'}"
+					? 'bg-sidebar-accent text-sidebar-accent-foreground'
+					: 'text-sidebar-foreground hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground'}"
 				title={collapsed ? item.label : undefined}
 			>
 				<span class="text-xs">{item.icon}</span>
@@ -71,12 +72,12 @@
 	<!-- Dashboard List -->
 	{#if !collapsed}
 		<div class="flex items-center justify-between px-3 pt-3 pb-1">
-			<span class="text-xs font-semibold uppercase tracking-wider text-neutral-500"
+			<span class="text-xs font-semibold uppercase tracking-wider text-sidebar-foreground"
 				>Dashboards</span
 			>
 			<button
 				onclick={on_create_dashboard}
-				class="rounded p-0.5 text-neutral-500 transition-colors hover:bg-neutral-800 hover:text-neutral-300"
+				class="rounded p-0.5 text-sidebar-foreground transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
 				title="Create dashboard"
 			>
 				<span class="text-sm">+</span>
@@ -90,10 +91,10 @@
 					ondblclick={() => on_edit_dashboard(dashboard)}
 					class="group flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm transition-colors {dashboard.id ===
 					active_dashboard_id
-						? 'bg-neutral-800 text-white'
-						: 'text-neutral-400 hover:bg-neutral-800/50 hover:text-neutral-200'}"
+						? 'bg-sidebar-accent text-sidebar-accent-foreground'
+						: 'text-sidebar-foreground hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground'}"
 				>
-					<span class="text-xs text-neutral-500" title={dashboard.type}>
+					<span class="text-xs text-sidebar-foreground" title={dashboard.type}>
 						{dashboard.type === 'repo' ? '◆' : '◇'}
 					</span>
 					<span class="truncate">{dashboard.name}</span>
@@ -101,4 +102,9 @@
 			{/each}
 		</div>
 	{/if}
+
+	<!-- Theme Toggle -->
+	<div class="mt-auto border-t border-sidebar-border p-2">
+		<ThemeToggle {collapsed} />
+	</div>
 </aside>

--- a/src/lib/components/DashboardToolbar.svelte
+++ b/src/lib/components/DashboardToolbar.svelte
@@ -36,7 +36,7 @@
 <div class="flex items-center gap-2">
 	<button
 		onclick={on_add_issue}
-		class="rounded bg-blue-600 px-3 py-1.5 text-sm text-white transition-colors hover:bg-blue-500"
+		class="rounded bg-primary px-3 py-1.5 text-sm text-primary-foreground transition-colors hover:bg-primary/90"
 	>
 		+ Add Issue
 	</button>
@@ -46,7 +46,7 @@
 		<button
 			onclick={on_sync_all}
 			disabled={!gh_available || syncing}
-			class="inline-flex items-center gap-1.5 rounded border border-neutral-700 px-2.5 py-1.5 text-xs text-neutral-400 transition-colors hover:border-neutral-600 hover:text-neutral-300 disabled:cursor-not-allowed disabled:opacity-40"
+			class="inline-flex items-center gap-1.5 rounded border border-border px-2.5 py-1.5 text-xs text-muted-foreground transition-colors hover:border-input hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
 			title={gh_available ? 'Sync GitHub state for all issues' : 'gh CLI not available'}
 		>
 			<RefreshCw size={13} class={syncing ? 'animate-spin' : ''} />
@@ -58,7 +58,7 @@
 	{#if on_prune_worktrees}
 		<button
 			onclick={on_prune_worktrees}
-			class="inline-flex items-center gap-1.5 rounded border border-neutral-700 px-2.5 py-1.5 text-xs text-neutral-400 transition-colors hover:border-neutral-600 hover:text-neutral-300"
+			class="inline-flex items-center gap-1.5 rounded border border-border px-2.5 py-1.5 text-xs text-muted-foreground transition-colors hover:border-input hover:text-foreground"
 			title="Prune worktrees for fully-closed issues"
 		>
 			<Scissors size={13} />
@@ -71,19 +71,19 @@
 	<!-- Collapse/expand all -->
 	<button
 		onclick={on_toggle_expand_all}
-		class="rounded px-2 py-1 text-xs text-neutral-500 transition-colors hover:text-neutral-300"
+		class="rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
 		title={all_expanded ? 'Collapse all' : 'Expand all'}
 	>
 		{all_expanded ? '▾ Collapse' : '▸ Expand'}
 	</button>
 
 	<!-- Sort control -->
-	<label class="flex items-center gap-1.5 text-sm text-neutral-400">
+	<label class="flex items-center gap-1.5 text-sm text-muted-foreground">
 		<span class="text-xs">Sort:</span>
 		<select
 			value={sort_mode}
 			onchange={(e) => on_sort_change(e.currentTarget.value as SortMode)}
-			class="rounded border border-neutral-700 bg-neutral-800 px-2 py-1 text-xs text-neutral-300 outline-none focus:border-blue-500"
+			class="rounded border border-border bg-muted px-2 py-1 text-xs text-foreground outline-none focus:border-ring"
 		>
 			<option value="date">Date</option>
 			<option value="priority">Priority</option>
@@ -96,8 +96,8 @@
 		<button
 			onclick={on_toggle_archived}
 			class="rounded px-2 py-1 text-xs transition-colors {show_archived
-				? 'bg-neutral-800 text-neutral-300'
-				: 'text-neutral-500 hover:text-neutral-300'}"
+				? 'bg-muted text-foreground'
+				: 'text-muted-foreground hover:text-foreground'}"
 		>
 			{show_archived ? 'Hide' : 'Show'} archived ({archived_count})
 		</button>

--- a/src/lib/components/DiscoveredSessionCard.svelte
+++ b/src/lib/components/DiscoveredSessionCard.svelte
@@ -21,23 +21,21 @@
 	const formatted_cost = $derived(session.cost_usd > 0 ? `$${session.cost_usd.toFixed(3)}` : '');
 </script>
 
-<div
-	class="w-full rounded-lg border border-dashed border-neutral-600 bg-neutral-800/50 p-3 text-left"
->
+<div class="w-full rounded-lg border border-dashed border-input bg-muted/50 p-3 text-left">
 	<div class="flex items-start justify-between gap-2">
 		<div class="min-w-0 flex-1">
 			<div class="flex items-center gap-2">
-				<p class="truncate text-sm font-medium text-neutral-200">
+				<p class="truncate text-sm font-medium text-foreground">
 					{session.project_name}
 				</p>
 				{#if session.git_branch}
-					<span class="shrink-0 text-xs text-neutral-500">
+					<span class="shrink-0 text-xs text-muted-foreground">
 						{session.git_branch}
 					</span>
 				{/if}
 			</div>
 			{#if session.first_prompt}
-				<p class="mt-1 truncate text-xs text-neutral-400">
+				<p class="mt-1 truncate text-xs text-muted-foreground">
 					{session.first_prompt}
 				</p>
 			{/if}
@@ -55,7 +53,7 @@
 		</div>
 	</div>
 
-	<div class="mt-2 flex items-center gap-3 text-xs text-neutral-500">
+	<div class="mt-2 flex items-center gap-3 text-xs text-muted-foreground">
 		<span>PID {session.pid}</span>
 		<span>{session.message_count} msgs</span>
 		{#if formatted_cost}
@@ -66,7 +64,7 @@
 		{/if}
 
 		<button
-			class="ml-auto rounded-md bg-indigo-600 px-2.5 py-1 text-xs font-medium text-white hover:bg-indigo-500"
+			class="ml-auto rounded-md bg-primary px-2.5 py-1 text-xs font-medium text-primary-foreground hover:bg-primary/90"
 			onclick={(e) => {
 				e.stopPropagation();
 				on_adopt(session);

--- a/src/lib/components/EmptyIssueState.svelte
+++ b/src/lib/components/EmptyIssueState.svelte
@@ -7,14 +7,14 @@
 </script>
 
 <div class="flex flex-col items-center gap-3 py-12 text-center">
-	<p class="text-neutral-400">No issues yet</p>
+	<p class="text-muted-foreground">No issues yet</p>
 	<button
 		onclick={on_add_issue}
-		class="rounded bg-blue-600 px-4 py-2 text-sm text-white transition-colors hover:bg-blue-500"
+		class="rounded bg-primary px-4 py-2 text-sm text-primary-foreground transition-colors hover:bg-primary/90"
 	>
 		+ Add Issue
 	</button>
-	<p class="text-xs text-neutral-600">
+	<p class="text-xs text-muted-foreground/60">
 		Create issues manually or quick-add from assigned GitHub issues.
 	</p>
 </div>

--- a/src/lib/components/GhSetupBanner.svelte
+++ b/src/lib/components/GhSetupBanner.svelte
@@ -32,7 +32,7 @@
 		<AlertTriangle size={14} />
 		<span>
 			GitHub CLI not authenticated. Run
-			<code class="rounded bg-neutral-800 px-1 py-0.5 font-mono">gh auth login</code>
+			<code class="rounded bg-muted px-1 py-0.5 font-mono">gh auth login</code>
 			to connect.
 		</span>
 	</div>

--- a/src/lib/components/IssueCard.svelte
+++ b/src/lib/components/IssueCard.svelte
@@ -92,19 +92,19 @@
 </script>
 
 <div
-	class="group flex rounded border border-l-[3px] border-neutral-800 transition-colors {priority_border_class} {is_archived
+	class="group flex rounded border border-l-[3px] border-border transition-colors {priority_border_class} {is_archived
 		? 'opacity-50'
-		: 'hover:border-neutral-700'}"
+		: 'hover:border-input'}"
 	class:ml-6={indented}
 >
 	<!-- Tree connector for nested children -->
 	{#if indented}
 		<div class="relative -ml-6 w-6 flex-shrink-0">
 			<div
-				class="absolute top-0 left-3 h-1/2 w-px bg-neutral-700"
+				class="absolute top-0 left-3 h-1/2 w-px bg-border"
 				class:h-full={!is_last_child}
 			></div>
-			<div class="absolute top-1/2 left-3 h-px w-3 bg-neutral-700"></div>
+			<div class="absolute top-1/2 left-3 h-px w-3 bg-border"></div>
 		</div>
 	{/if}
 
@@ -117,7 +117,10 @@
 					title="Session needs attention"
 				></span>
 			{:else}
-				<div class="h-2 w-2 rounded-full bg-white/30" title="Session state: idle"></div>
+				<div
+					class="h-2 w-2 rounded-full bg-foreground/30"
+					title="Session state: idle"
+				></div>
 			{/if}
 		</div>
 	</div>
@@ -128,9 +131,9 @@
 		<div class="flex items-center gap-2 px-3 py-2">
 			<button
 				onclick={() => (local_expanded = !local_expanded)}
-				class="text-xs text-neutral-500 transition-transform {expanded
+				class="text-xs text-muted-foreground transition-transform {expanded
 					? 'rotate-90'
-					: ''} hover:text-neutral-300"
+					: ''} hover:text-foreground"
 				title={expanded ? 'Collapse' : 'Expand'}
 			>
 				▸
@@ -140,7 +143,7 @@
 
 			<!-- Child count for parent issues -->
 			{#if child_count > 0}
-				<span class="rounded bg-neutral-800 px-1.5 py-0.5 text-xs text-neutral-400">
+				<span class="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
 					{child_count} child{child_count > 1 ? 'ren' : ''}
 				</span>
 			{/if}
@@ -155,7 +158,7 @@
 						disabled={!gh_available}
 					/>
 				{:else if issue.github_issue_number}
-					<span class="rounded bg-neutral-800 px-1.5 py-0.5 text-xs text-neutral-400">
+					<span class="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
 						#{issue.github_issue_number}
 					</span>
 				{/if}
@@ -198,7 +201,7 @@
 			<div class="relative">
 				<button
 					onclick={() => (show_overflow = !show_overflow)}
-					class="rounded p-1 text-neutral-500 opacity-0 transition-opacity hover:bg-neutral-800 hover:text-neutral-300 group-hover:opacity-100"
+					class="rounded p-1 text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground group-hover:opacity-100"
 				>
 					⋯
 				</button>
@@ -206,7 +209,7 @@
 				{#if show_overflow}
 					<!-- svelte-ignore a11y_no_static_element_interactions -->
 					<div
-						class="absolute right-0 z-10 mt-1 min-w-[140px] rounded border border-neutral-700 bg-neutral-800 py-1 shadow-lg"
+						class="absolute right-0 z-10 mt-1 min-w-[140px] rounded border border-border bg-popover py-1 shadow-lg"
 						onmouseleave={() => (show_overflow = false)}
 					>
 						<button
@@ -214,7 +217,7 @@
 								on_edit(issue);
 								show_overflow = false;
 							}}
-							class="w-full px-3 py-1.5 text-left text-sm text-neutral-300 hover:bg-neutral-700"
+							class="w-full px-3 py-1.5 text-left text-sm text-popover-foreground hover:bg-accent"
 						>
 							Edit
 						</button>
@@ -224,7 +227,7 @@
 									on_setup_worktree(issue);
 									show_overflow = false;
 								}}
-								class="w-full px-3 py-1.5 text-left text-sm text-green-400 hover:bg-neutral-700"
+								class="w-full px-3 py-1.5 text-left text-sm text-green-400 hover:bg-accent"
 							>
 								{issue.worktree_state === 'failed'
 									? 'Retry Worktree'
@@ -237,7 +240,7 @@
 									on_remove_worktree(issue);
 									show_overflow = false;
 								}}
-								class="w-full px-3 py-1.5 text-left text-sm text-orange-400 hover:bg-neutral-700"
+								class="w-full px-3 py-1.5 text-left text-sm text-orange-400 hover:bg-accent"
 							>
 								Remove Worktree
 							</button>
@@ -248,7 +251,7 @@
 									on_unarchive(issue.id);
 									show_overflow = false;
 								}}
-								class="w-full px-3 py-1.5 text-left text-sm text-neutral-300 hover:bg-neutral-700"
+								class="w-full px-3 py-1.5 text-left text-sm text-popover-foreground hover:bg-accent"
 							>
 								Unarchive
 							</button>
@@ -258,7 +261,7 @@
 									on_archive(issue.id);
 									show_overflow = false;
 								}}
-								class="w-full px-3 py-1.5 text-left text-sm text-neutral-300 hover:bg-neutral-700"
+								class="w-full px-3 py-1.5 text-left text-sm text-popover-foreground hover:bg-accent"
 							>
 								Archive
 							</button>
@@ -268,7 +271,7 @@
 								on_delete(issue.id);
 								show_overflow = false;
 							}}
-							class="w-full px-3 py-1.5 text-left text-sm text-red-400 hover:bg-neutral-700"
+							class="w-full px-3 py-1.5 text-left text-sm text-destructive hover:bg-accent"
 						>
 							Delete
 						</button>
@@ -279,31 +282,31 @@
 
 		<!-- Expanded section -->
 		{#if expanded}
-			<div class="border-t border-neutral-800 px-3 py-3 text-xs text-neutral-500">
+			<div class="border-t border-border px-3 py-3 text-xs text-muted-foreground">
 				<div class="grid grid-cols-2 gap-2">
 					<div>
-						<span class="text-neutral-600">Status:</span>
+						<span class="text-muted-foreground/60">Status:</span>
 						{issue.status}
 					</div>
 					<div>
-						<span class="text-neutral-600">Worktree:</span>
+						<span class="text-muted-foreground/60">Worktree:</span>
 						{issue.worktree_state}
 					</div>
 					{#if issue.priority}
 						<div>
-							<span class="text-neutral-600">Priority:</span>
+							<span class="text-muted-foreground/60">Priority:</span>
 							{issue.priority}
 						</div>
 					{/if}
 					{#if issue.created_at}
 						<div>
-							<span class="text-neutral-600">Created:</span>
+							<span class="text-muted-foreground/60">Created:</span>
 							{new Date(issue.created_at).toLocaleDateString()}
 						</div>
 					{/if}
 					{#if github_cache}
 						<div>
-							<span class="text-neutral-600">Synced:</span>
+							<span class="text-muted-foreground/60">Synced:</span>
 							<SyncStatusIndicator fetched_at={github_cache.fetched_at} />
 						</div>
 					{/if}

--- a/src/lib/components/IssueCardList.svelte
+++ b/src/lib/components/IssueCardList.svelte
@@ -101,8 +101,10 @@
 
 	<!-- Archived section -->
 	{#if show_archived && archived_issues.length > 0}
-		<div class="mt-4 border-t border-neutral-800 pt-4">
-			<h3 class="mb-2 text-xs font-semibold uppercase tracking-wider text-neutral-600">
+		<div class="mt-4 border-t border-border pt-4">
+			<h3
+				class="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground/60"
+			>
 				Archived ({archived_issues.length})
 			</h3>
 			<div class="flex flex-col gap-2">

--- a/src/lib/components/IssueCreateDialog.svelte
+++ b/src/lib/components/IssueCreateDialog.svelte
@@ -73,26 +73,26 @@
 <dialog
 	bind:this={dialog_element}
 	onclose={handle_cancel}
-	class="w-full max-w-md rounded-lg border border-neutral-700 bg-neutral-900 p-0 text-neutral-100 shadow-xl backdrop:bg-black/50"
+	class="w-full max-w-md rounded-lg border border-border bg-popover p-0 text-popover-foreground shadow-xl backdrop:bg-black/50"
 >
 	<form onsubmit={handle_submit} class="flex flex-col gap-4 p-6">
 		<h2 class="text-lg font-semibold">Create Issue</h2>
 
 		<label class="flex flex-col gap-1">
-			<span class="text-xs text-neutral-400">Name *</span>
+			<span class="text-xs text-muted-foreground">Name *</span>
 			<input
 				bind:value={name}
 				required
-				class="rounded border border-neutral-700 bg-neutral-800 px-3 py-2 text-sm text-neutral-100 outline-none focus:border-blue-500"
+				class="rounded border border-input bg-muted px-3 py-2 text-sm text-foreground outline-none focus:border-ring"
 				placeholder="Issue name"
 			/>
 		</label>
 
 		<label class="flex flex-col gap-1">
-			<span class="text-xs text-neutral-400">Priority</span>
+			<span class="text-xs text-muted-foreground">Priority</span>
 			<select
 				bind:value={priority}
-				class="rounded border border-neutral-700 bg-neutral-800 px-3 py-2 text-sm text-neutral-100 outline-none focus:border-blue-500"
+				class="rounded border border-input bg-muted px-3 py-2 text-sm text-foreground outline-none focus:border-ring"
 			>
 				<option value="">None</option>
 				<option value="low">Low</option>
@@ -110,10 +110,10 @@
 		/>
 
 		<label class="flex flex-col gap-1">
-			<span class="text-xs text-neutral-400">GitHub Issue URL</span>
+			<span class="text-xs text-muted-foreground">GitHub Issue URL</span>
 			<input
 				bind:value={github_issue_url}
-				class="rounded border border-neutral-700 bg-neutral-800 px-3 py-2 text-sm text-neutral-100 outline-none focus:border-blue-500"
+				class="rounded border border-input bg-muted px-3 py-2 text-sm text-foreground outline-none focus:border-ring"
 				placeholder="https://github.com/owner/repo/issues/42"
 			/>
 		</label>
@@ -122,13 +122,13 @@
 			<button
 				type="button"
 				onclick={handle_cancel}
-				class="rounded px-4 py-2 text-sm text-neutral-400 transition-colors hover:text-neutral-200"
+				class="rounded px-4 py-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
 			>
 				Cancel
 			</button>
 			<button
 				type="submit"
-				class="rounded bg-blue-600 px-4 py-2 text-sm text-white transition-colors hover:bg-blue-500"
+				class="rounded bg-primary px-4 py-2 text-sm text-primary-foreground transition-colors hover:bg-primary/90"
 			>
 				Create
 			</button>

--- a/src/lib/components/IssueEditDialog.svelte
+++ b/src/lib/components/IssueEditDialog.svelte
@@ -52,26 +52,26 @@
 <dialog
 	bind:this={dialog_element}
 	onclose={on_close}
-	class="w-full max-w-md rounded-lg border border-neutral-700 bg-neutral-900 p-0 text-neutral-100 shadow-xl backdrop:bg-black/50"
+	class="w-full max-w-md rounded-lg border border-border bg-popover p-0 text-popover-foreground shadow-xl backdrop:bg-black/50"
 >
 	{#if issue}
 		<form onsubmit={handle_submit} class="flex flex-col gap-4 p-6">
 			<h2 class="text-lg font-semibold">Edit Issue</h2>
 
 			<label class="flex flex-col gap-1">
-				<span class="text-xs text-neutral-400">Name *</span>
+				<span class="text-xs text-muted-foreground">Name *</span>
 				<input
 					bind:value={name}
 					required
-					class="rounded border border-neutral-700 bg-neutral-800 px-3 py-2 text-sm text-neutral-100 outline-none focus:border-blue-500"
+					class="rounded border border-input bg-muted px-3 py-2 text-sm text-foreground outline-none focus:border-ring"
 				/>
 			</label>
 
 			<label class="flex flex-col gap-1">
-				<span class="text-xs text-neutral-400">Priority</span>
+				<span class="text-xs text-muted-foreground">Priority</span>
 				<select
 					bind:value={priority}
-					class="rounded border border-neutral-700 bg-neutral-800 px-3 py-2 text-sm text-neutral-100 outline-none focus:border-blue-500"
+					class="rounded border border-input bg-muted px-3 py-2 text-sm text-foreground outline-none focus:border-ring"
 				>
 					<option value="">None</option>
 					<option value="low">Low</option>
@@ -88,10 +88,10 @@
 			/>
 
 			<label class="flex flex-col gap-1">
-				<span class="text-xs text-neutral-400">GitHub Issue URL</span>
+				<span class="text-xs text-muted-foreground">GitHub Issue URL</span>
 				<input
 					bind:value={github_issue_url}
-					class="rounded border border-neutral-700 bg-neutral-800 px-3 py-2 text-sm text-neutral-100 outline-none focus:border-blue-500"
+					class="rounded border border-input bg-muted px-3 py-2 text-sm text-foreground outline-none focus:border-ring"
 				/>
 			</label>
 
@@ -99,13 +99,13 @@
 				<button
 					type="button"
 					onclick={on_close}
-					class="rounded px-4 py-2 text-sm text-neutral-400 transition-colors hover:text-neutral-200"
+					class="rounded px-4 py-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
 				>
 					Cancel
 				</button>
 				<button
 					type="submit"
-					class="rounded bg-blue-600 px-4 py-2 text-sm text-white transition-colors hover:bg-blue-500"
+					class="rounded bg-primary px-4 py-2 text-sm text-primary-foreground transition-colors hover:bg-primary/90"
 				>
 					Save
 				</button>

--- a/src/lib/components/NotificationSettingsPanel.svelte
+++ b/src/lib/components/NotificationSettingsPanel.svelte
@@ -56,17 +56,19 @@
 
 <div class="space-y-4">
 	<div>
-		<h2 class="text-lg font-semibold text-neutral-100">Notifications</h2>
-		<p class="text-sm text-neutral-500">Configure how you're notified for each event type.</p>
+		<h2 class="text-lg font-semibold text-foreground">Notifications</h2>
+		<p class="text-sm text-muted-foreground">
+			Configure how you're notified for each event type.
+		</p>
 	</div>
 
 	{#if notification_store.loading}
-		<p class="text-neutral-500">Loading notification settings...</p>
+		<p class="text-muted-foreground">Loading notification settings...</p>
 	{:else}
-		<div class="overflow-hidden rounded-lg border border-neutral-700">
+		<div class="overflow-hidden rounded-lg border border-border">
 			<!-- Header -->
 			<div
-				class="grid grid-cols-[1fr_80px_80px_80px_60px] gap-2 border-b border-neutral-700 bg-neutral-800/50 px-4 py-2 text-xs font-medium uppercase tracking-wider text-neutral-500"
+				class="grid grid-cols-[1fr_80px_80px_80px_60px] gap-2 border-b border-border bg-muted/50 px-4 py-2 text-xs font-medium uppercase tracking-wider text-muted-foreground"
 			>
 				<span>Event</span>
 				<span class="text-center">Sound</span>
@@ -78,14 +80,14 @@
 			<!-- Rows -->
 			{#each notification_store.configs as config (config.event_type)}
 				<div
-					class="grid grid-cols-[1fr_80px_80px_80px_60px] items-center gap-2 border-b border-neutral-800 px-4 py-3 last:border-b-0"
+					class="grid grid-cols-[1fr_80px_80px_80px_60px] items-center gap-2 border-b border-border px-4 py-3 last:border-b-0"
 				>
 					<!-- Event label and description -->
 					<div>
-						<span class="text-sm font-medium text-neutral-200">
+						<span class="text-sm font-medium text-foreground">
 							{EVENT_LABELS[config.event_type] ?? config.event_type}
 						</span>
-						<p class="text-xs text-neutral-500">
+						<p class="text-xs text-muted-foreground">
 							{EVENT_DESCRIPTIONS[config.event_type] ?? ''}
 						</p>
 					</div>
@@ -95,8 +97,8 @@
 						<button
 							class="h-5 w-9 rounded-full transition-colors {config.sound_enabled ===
 							true
-								? 'bg-blue-600'
-								: 'bg-neutral-600'}"
+								? 'bg-primary'
+								: 'bg-muted'}"
 							onclick={() =>
 								toggle_channel(
 									config.event_type,
@@ -119,8 +121,8 @@
 						<button
 							class="h-5 w-9 rounded-full transition-colors {config.toast_enabled ===
 							true
-								? 'bg-blue-600'
-								: 'bg-neutral-600'}"
+								? 'bg-primary'
+								: 'bg-muted'}"
 							onclick={() =>
 								toggle_channel(
 									config.event_type,
@@ -143,8 +145,8 @@
 						<button
 							class="h-5 w-9 rounded-full transition-colors {config.window_flash_enabled ===
 							true
-								? 'bg-blue-600'
-								: 'bg-neutral-600'}"
+								? 'bg-primary'
+								: 'bg-muted'}"
 							onclick={() =>
 								toggle_channel(
 									config.event_type,
@@ -168,14 +170,14 @@
 					<div class="flex justify-center">
 						{#if config.sound_file}
 							<button
-								class="rounded px-2 py-1 text-xs text-neutral-400 transition-colors hover:bg-neutral-700 hover:text-neutral-200"
+								class="rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
 								onclick={() => handle_test_sound(config.event_type)}
 								title="Play test sound"
 							>
 								&#9654;
 							</button>
 						{:else}
-							<span class="text-xs text-neutral-600">—</span>
+							<span class="text-xs text-muted-foreground/60">—</span>
 						{/if}
 					</div>
 				</div>

--- a/src/lib/components/OnboardingCard.svelte
+++ b/src/lib/components/OnboardingCard.svelte
@@ -8,18 +8,18 @@
 
 <div class="flex h-full items-center justify-center">
 	<div
-		class="flex max-w-sm flex-col items-center gap-4 rounded-lg border border-neutral-800 bg-neutral-900 p-8 text-center"
+		class="flex max-w-sm flex-col items-center gap-4 rounded-lg border border-border bg-card p-8 text-center"
 	>
-		<div class="text-3xl text-neutral-600">◆</div>
+		<div class="text-3xl text-muted-foreground/60">◆</div>
 		<h2 class="text-lg font-semibold">Create your first dashboard</h2>
-		<p class="text-sm text-neutral-400">
-			A <strong class="text-neutral-300">repo dashboard</strong> tracks issues for a single
-			repository. A <strong class="text-neutral-300">portfolio dashboard</strong> groups multiple
+		<p class="text-sm text-muted-foreground">
+			A <strong class="text-foreground">repo dashboard</strong> tracks issues for a single
+			repository. A <strong class="text-foreground">portfolio dashboard</strong> groups multiple
 			repos together.
 		</p>
 		<button
 			onclick={on_create_dashboard}
-			class="rounded bg-blue-600 px-4 py-2 text-sm text-white transition-colors hover:bg-blue-500"
+			class="rounded bg-primary px-4 py-2 text-sm text-primary-foreground transition-colors hover:bg-primary/90"
 		>
 			Create Dashboard
 		</button>

--- a/src/lib/components/PaletteColorPicker.svelte
+++ b/src/lib/components/PaletteColorPicker.svelte
@@ -12,14 +12,14 @@
 </script>
 
 <fieldset class="flex flex-col gap-1">
-	<legend class="text-xs text-neutral-400">Color</legend>
+	<legend class="text-xs text-muted-foreground">Color</legend>
 	<div class="flex flex-wrap gap-1.5">
 		{#each colors as swatch (swatch)}
 			<button
 				type="button"
 				onclick={() => on_select(swatch)}
 				class="h-6 w-6 rounded-sm transition-transform {selected_color === swatch
-					? 'scale-125 ring-2 ring-white ring-offset-1 ring-offset-neutral-900'
+					? 'scale-125 ring-2 ring-foreground ring-offset-1 ring-offset-background'
 					: 'hover:scale-110'}"
 				style="background-color: {swatch}"
 				title={swatch}
@@ -34,7 +34,7 @@
 					custom_color_input = selected_color;
 				}
 			}}
-			class="flex h-6 w-6 items-center justify-center rounded-sm border border-dashed border-neutral-600 text-xs text-neutral-500 transition-colors hover:border-neutral-400 hover:text-neutral-300"
+			class="flex h-6 w-6 items-center justify-center rounded-sm border border-dashed border-input text-xs text-muted-foreground transition-colors hover:border-border hover:text-foreground"
 			title="Custom color"
 		>
 			#
@@ -50,13 +50,13 @@
 					custom_color_input = target.value;
 					on_select(target.value);
 				}}
-				class="h-8 w-8 cursor-pointer rounded border border-neutral-700 bg-neutral-800"
+				class="h-8 w-8 cursor-pointer rounded border border-border bg-muted"
 			/>
 			<input
 				type="text"
 				bind:value={custom_color_input}
 				placeholder="#ff0000"
-				class="w-24 rounded border border-neutral-700 bg-neutral-800 px-2 py-1 text-xs text-neutral-100 outline-none focus:border-blue-500"
+				class="w-24 rounded border border-input bg-muted px-2 py-1 text-xs text-foreground outline-none focus:border-ring"
 				onkeydown={(event) => {
 					if (event.key === 'Enter') {
 						event.preventDefault();

--- a/src/lib/components/PaletteSelector.svelte
+++ b/src/lib/components/PaletteSelector.svelte
@@ -15,14 +15,14 @@
 </script>
 
 <label class="flex flex-col gap-1">
-	<span class="text-xs text-neutral-400">Color Palette</span>
+	<span class="text-xs text-muted-foreground">Color Palette</span>
 	<select
 		value={selected_palette_id ?? ''}
 		onchange={(event) => {
 			const value = event.currentTarget.value;
 			on_select(value || null);
 		}}
-		class="rounded border border-neutral-700 bg-neutral-800 px-3 py-2 text-sm text-neutral-100 outline-none focus:border-blue-500"
+		class="rounded border border-input bg-muted px-3 py-2 text-sm text-foreground outline-none focus:border-ring"
 	>
 		<option value="">Default ({default_palette_label})</option>
 		{#each palettes as palette (palette.id)}

--- a/src/lib/components/PruneWorktreesDialog.svelte
+++ b/src/lib/components/PruneWorktreesDialog.svelte
@@ -47,11 +47,11 @@
 		<!-- svelte-ignore a11y_click_events_have_key_events -->
 		<div class="absolute inset-0" onclick={on_close}></div>
 		<div
-			class="relative z-10 w-full max-w-lg rounded-lg border border-neutral-700 bg-neutral-900 shadow-xl"
+			class="relative z-10 w-full max-w-lg rounded-lg border border-border bg-popover shadow-xl"
 		>
-			<div class="border-b border-neutral-800 px-4 py-3">
+			<div class="border-b border-border px-4 py-3">
 				<h2 class="text-sm font-semibold">Prune Worktrees</h2>
-				<p class="mt-1 text-xs text-neutral-500">
+				<p class="mt-1 text-xs text-muted-foreground">
 					These issues have merged PRs and closed GitHub issues. Select which worktrees to
 					remove.
 				</p>
@@ -59,25 +59,25 @@
 
 			<div class="max-h-64 overflow-y-auto px-4 py-3">
 				{#if prunable_issues.length === 0}
-					<p class="text-sm text-neutral-500">No prunable worktrees found.</p>
+					<p class="text-sm text-muted-foreground">No prunable worktrees found.</p>
 				{:else}
 					<div class="flex flex-col gap-2">
 						{#each prunable_issues as issue (issue.issue_id)}
 							<label
-								class="flex cursor-pointer items-center gap-3 rounded px-2 py-1.5 hover:bg-neutral-800"
+								class="flex cursor-pointer items-center gap-3 rounded px-2 py-1.5 hover:bg-accent"
 							>
 								<input
 									type="checkbox"
 									checked={selected_ids.has(issue.issue_id)}
 									onchange={() => toggle_selection(issue.issue_id)}
-									class="rounded border-neutral-600"
+									class="rounded border-input"
 								/>
 								<div class="min-w-0 flex-1">
 									<div class="truncate text-sm">{issue.name}</div>
-									<div class="text-xs text-neutral-500">
+									<div class="text-xs text-muted-foreground">
 										{issue.branch_name}
 										{#if issue.worktree_folder}
-											<span class="text-neutral-600">
+											<span class="text-muted-foreground/60">
 												— {issue.worktree_folder}
 											</span>
 										{/if}
@@ -101,18 +101,18 @@
 				{/if}
 			</div>
 
-			<div class="flex items-center justify-end gap-2 border-t border-neutral-800 px-4 py-3">
+			<div class="flex items-center justify-end gap-2 border-t border-border px-4 py-3">
 				<button
 					onclick={on_close}
 					disabled={removing}
-					class="rounded px-3 py-1.5 text-sm text-neutral-400 hover:text-neutral-300"
+					class="rounded px-3 py-1.5 text-sm text-muted-foreground hover:text-foreground"
 				>
 					Cancel
 				</button>
 				<button
 					onclick={handle_prune}
 					disabled={selected_ids.size === 0 || removing}
-					class="rounded bg-red-600 px-3 py-1.5 text-sm text-white transition-colors hover:bg-red-500 disabled:opacity-40"
+					class="rounded bg-destructive px-3 py-1.5 text-sm text-destructive-foreground transition-colors hover:bg-destructive/90 disabled:opacity-40"
 				>
 					{#if removing}
 						Removing...

--- a/src/lib/components/SessionCard.svelte
+++ b/src/lib/components/SessionCard.svelte
@@ -57,7 +57,7 @@
 
 <!-- Using div instead of button to allow nested Stop button -->
 <div
-	class="w-full cursor-pointer rounded-lg border border-neutral-700 bg-neutral-800 p-3 text-left transition hover:border-neutral-600 hover:bg-neutral-750"
+	class="w-full cursor-pointer rounded-lg border border-border bg-card p-3 text-left transition hover:border-input hover:bg-accent"
 	role="button"
 	tabindex="0"
 	onclick={() => on_click(session)}
@@ -76,12 +76,12 @@
 						title="Pending notification"
 					></span>
 				{/if}
-				<p class="truncate text-sm font-medium text-neutral-200">
+				<p class="truncate text-sm font-medium text-foreground">
 					{session.original_intent ?? 'Session'}
 				</p>
 			</div>
 			{#if session.last_response_summary}
-				<p class="mt-1 truncate text-xs text-neutral-400">
+				<p class="mt-1 truncate text-xs text-muted-foreground">
 					{session.last_response_summary}
 				</p>
 			{/if}
@@ -99,7 +99,7 @@
 		</div>
 	</div>
 
-	<div class="mt-2 flex items-center gap-3 text-xs text-neutral-500">
+	<div class="mt-2 flex items-center gap-3 text-xs text-muted-foreground">
 		<span>{session.provider}</span>
 		<span>{relative_time}</span>
 		{#if formatted_cost}
@@ -111,7 +111,7 @@
 
 		{#if is_active}
 			<button
-				class="ml-auto text-red-400 hover:text-red-300"
+				class="ml-auto text-destructive hover:text-destructive/80"
 				onclick={(e) => {
 					e.stopPropagation();
 					on_terminate(session.id);

--- a/src/lib/components/SessionChatView.svelte
+++ b/src/lib/components/SessionChatView.svelte
@@ -181,18 +181,18 @@
 		{#each messages as message (message.content + message.role)}
 			<div
 				class="rounded-lg p-3 text-sm {message.role === 'user'
-					? 'ml-8 bg-blue-900/30 text-blue-200'
+					? 'ml-8 bg-primary/10 text-primary'
 					: message.role === 'tool'
-						? 'bg-neutral-800 font-mono text-xs text-neutral-300'
+						? 'bg-muted font-mono text-xs text-foreground'
 						: message.role === 'system'
-							? 'bg-neutral-900 text-center text-xs text-neutral-500'
-							: 'mr-8 bg-neutral-800 text-neutral-200'}"
+							? 'bg-card text-center text-xs text-muted-foreground'
+							: 'mr-8 bg-muted text-foreground'}"
 			>
 				{#if message.role === 'tool' && message.tool_name !== undefined}
 					<div
 						class="mb-1 text-xs font-medium {message.is_error === true
-							? 'text-red-400'
-							: 'text-neutral-500'}"
+							? 'text-destructive'
+							: 'text-muted-foreground'}"
 					>
 						{message.tool_name}
 						{message.is_error === true ? ' (error)' : ''}
@@ -203,7 +203,7 @@
 		{/each}
 
 		{#if current_streaming_text}
-			<div class="mr-8 rounded-lg bg-neutral-800 p-3 text-sm text-neutral-200">
+			<div class="mr-8 rounded-lg bg-muted p-3 text-sm text-foreground">
 				<pre class="whitespace-pre-wrap">{current_streaming_text}<span class="animate-pulse"
 						>|</span
 					></pre>
@@ -212,7 +212,7 @@
 	</div>
 
 	<!-- Input bar -->
-	<div class="border-t border-neutral-700 p-3">
+	<div class="border-t border-border p-3">
 		<div class="flex items-center gap-2">
 			{#if session.state === 'running'}
 				<button
@@ -225,7 +225,7 @@
 
 			<input
 				type="text"
-				class="flex-1 rounded-md border border-neutral-600 bg-neutral-800 px-3 py-2 text-sm text-neutral-200 placeholder-neutral-500 focus:border-blue-500 focus:outline-none"
+				class="flex-1 rounded-md border border-input bg-muted px-3 py-2 text-sm text-foreground placeholder-muted-foreground focus:border-ring focus:outline-none"
 				placeholder={is_active ? 'Send a message...' : 'Session ended'}
 				bind:value={prompt_input}
 				onkeydown={handle_keydown}
@@ -233,7 +233,7 @@
 			/>
 
 			<button
-				class="shrink-0 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-500 disabled:opacity-50"
+				class="shrink-0 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
 				onclick={handle_send}
 				disabled={!can_send}
 			>

--- a/src/lib/components/SyncStatusIndicator.svelte
+++ b/src/lib/components/SyncStatusIndicator.svelte
@@ -19,6 +19,6 @@
 	});
 </script>
 
-<span class="text-[10px] text-neutral-500" title="Last synced: {fetched_at ?? 'never'}">
+<span class="text-[10px] text-muted-foreground" title="Last synced: {fetched_at ?? 'never'}">
 	{display_text}
 </span>

--- a/src/lib/components/ThemeToggle.svelte
+++ b/src/lib/components/ThemeToggle.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+	import { get_theme_store } from '$lib/stores/theme.svelte';
+	import { Sun, Moon, Monitor } from 'lucide-svelte';
+
+	interface Props {
+		collapsed?: boolean;
+	}
+
+	let { collapsed = false }: Props = $props();
+
+	const theme = get_theme_store();
+
+	const modes = [
+		{ value: 'light' as const, Icon: Sun, label: 'Light' },
+		{ value: 'dark' as const, Icon: Moon, label: 'Dark' },
+		{ value: 'system' as const, Icon: Monitor, label: 'System' },
+	];
+
+	function cycle_mode() {
+		const current_index = modes.findIndex((m) => m.value === theme.mode);
+		theme.mode = modes[(current_index + 1) % modes.length].value;
+	}
+
+	const current_mode = $derived(modes.find((m) => m.value === theme.mode)!);
+</script>
+
+{#if collapsed}
+	<button
+		onclick={cycle_mode}
+		class="flex w-full items-center justify-center rounded p-2 text-sidebar-foreground transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+		aria-label="{current_mode.label} theme"
+		title="{current_mode.label} mode"
+	>
+		<current_mode.Icon class="size-4" />
+	</button>
+{:else}
+	<div class="flex items-center gap-1 rounded-md bg-secondary p-1">
+		{#each modes as { value, Icon, label } (value)}
+			<button
+				onclick={() => (theme.mode = value)}
+				class="flex flex-1 items-center justify-center gap-1.5 rounded px-2 py-1 text-xs transition-colors {theme.mode ===
+				value
+					? 'bg-background text-foreground shadow-sm'
+					: 'text-muted-foreground hover:text-foreground'}"
+				title="{label} mode"
+			>
+				<Icon class="size-3.5" />
+				<span>{label}</span>
+			</button>
+		{/each}
+	</div>
+{/if}

--- a/src/lib/components/WorktreeProgressIndicator.svelte
+++ b/src/lib/components/WorktreeProgressIndicator.svelte
@@ -21,13 +21,13 @@
 	}
 </script>
 
-<div class="mt-2 border-t border-neutral-800 pt-2">
-	<div class="mb-1 text-[10px] font-medium uppercase tracking-wider text-neutral-600">
+<div class="mt-2 border-t border-border pt-2">
+	<div class="mb-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60">
 		Progress
 	</div>
 	<div
 		bind:this={scroll_container}
-		class="max-h-32 overflow-y-auto rounded bg-neutral-950 p-2 font-mono text-[11px] leading-4 text-neutral-400"
+		class="max-h-32 overflow-y-auto rounded bg-background p-2 font-mono text-[11px] leading-4 text-muted-foreground"
 	>
 		{#each lines as line, index (index)}
 			<div class="whitespace-pre-wrap break-all">{strip_ansi(line)}</div>

--- a/src/lib/types/git_status.ts
+++ b/src/lib/types/git_status.ts
@@ -17,7 +17,7 @@ export const BRANCH_STATUS_COLOR: Record<BranchStatus, string> = {
 	local: 'bg-blue-900/60 text-blue-300',
 	'remote-gone': 'bg-orange-900/60 text-orange-300',
 	deleted: 'bg-red-900/60 text-red-300 line-through',
-	unknown: 'bg-neutral-800 text-neutral-400',
+	unknown: 'bg-muted text-muted-foreground',
 };
 
 export const BRANCH_STATUS_TOOLTIP: Record<BranchStatus, string> = {

--- a/src/routes/issues/+page.svelte
+++ b/src/routes/issues/+page.svelte
@@ -267,7 +267,7 @@
 </script>
 
 {#if dashboard_store.loading}
-	<p class="text-neutral-500">Loading...</p>
+	<p class="text-muted-foreground">Loading...</p>
 {:else if dashboard_store.dashboards.length === 0}
 	<OnboardingCard
 		on_create_dashboard={() => {
@@ -275,13 +275,13 @@
 		}}
 	/>
 {:else if dashboard_store.active_dashboard === null}
-	<p class="text-neutral-500">Select a dashboard from the sidebar.</p>
+	<p class="text-muted-foreground">Select a dashboard from the sidebar.</p>
 {:else}
 	<div class="flex flex-col gap-4">
 		<!-- Dashboard header -->
 		<div class="flex items-center gap-2">
 			<h1 class="text-xl font-semibold">{dashboard_store.active_dashboard.name}</h1>
-			<span class="rounded bg-neutral-800 px-2 py-0.5 text-xs text-neutral-400">
+			<span class="rounded bg-muted px-2 py-0.5 text-xs text-muted-foreground">
 				{dashboard_store.active_dashboard.type}
 			</span>
 		</div>
@@ -309,9 +309,9 @@
 
 		<!-- Issue list or empty state -->
 		{#if issue_store.loading}
-			<p class="text-neutral-500">Loading issues...</p>
+			<p class="text-muted-foreground">Loading issues...</p>
 		{:else if issue_store.error}
-			<p class="text-red-400">Error: {issue_store.error}</p>
+			<p class="text-destructive">Error: {issue_store.error}</p>
 		{:else if issue_store.active_issues.length === 0 && issue_store.archived_issues.length === 0}
 			<EmptyIssueState on_add_issue={open_create_dialog} />
 		{:else}

--- a/src/routes/sessions/+page.svelte
+++ b/src/routes/sessions/+page.svelte
@@ -109,11 +109,14 @@
 {#if selected_session}
 	<!-- Chat view for selected session -->
 	<div class="flex h-full flex-col">
-		<div class="flex items-center gap-3 border-b border-neutral-700 px-4 py-3">
-			<button class="text-sm text-neutral-400 hover:text-neutral-200" onclick={handle_back}>
+		<div class="flex items-center gap-3 border-b border-border px-4 py-3">
+			<button
+				class="text-sm text-muted-foreground hover:text-foreground"
+				onclick={handle_back}
+			>
 				&larr; Back
 			</button>
-			<h2 class="truncate text-sm font-medium text-neutral-200">
+			<h2 class="truncate text-sm font-medium text-foreground">
 				{selected_session.original_intent ?? 'Session'}
 			</h2>
 		</div>
@@ -125,22 +128,22 @@
 	<!-- Session list -->
 	<div class="space-y-4 p-4">
 		<div class="flex items-center justify-between">
-			<h1 class="text-xl font-semibold text-neutral-100">Sessions</h1>
+			<h1 class="text-xl font-semibold text-foreground">Sessions</h1>
 		</div>
 
 		<!-- Spawn form -->
-		<div class="space-y-2 rounded-lg border border-neutral-700 bg-neutral-800/50 p-4">
-			<h3 class="text-sm font-medium text-neutral-300">New Session</h3>
+		<div class="space-y-2 rounded-lg border border-border bg-muted/50 p-4">
+			<h3 class="text-sm font-medium text-foreground">New Session</h3>
 			<input
 				type="text"
-				class="w-full rounded-md border border-neutral-600 bg-neutral-800 px-3 py-2 text-sm text-neutral-200 placeholder-neutral-500 focus:border-blue-500 focus:outline-none"
+				class="w-full rounded-md border border-input bg-muted px-3 py-2 text-sm text-foreground placeholder-muted-foreground focus:border-ring focus:outline-none"
 				placeholder="Working directory (e.g., C:\projects\my-app)"
 				bind:value={spawn_working_directory}
 			/>
 			<div class="flex gap-2">
 				<input
 					type="text"
-					class="flex-1 rounded-md border border-neutral-600 bg-neutral-800 px-3 py-2 text-sm text-neutral-200 placeholder-neutral-500 focus:border-blue-500 focus:outline-none"
+					class="flex-1 rounded-md border border-input bg-muted px-3 py-2 text-sm text-foreground placeholder-muted-foreground focus:border-ring focus:outline-none"
 					placeholder="Prompt (e.g., Fix the login bug in auth.ts)"
 					bind:value={spawn_prompt}
 					onkeydown={(e) => {
@@ -150,7 +153,7 @@
 					}}
 				/>
 				<button
-					class="shrink-0 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-500 disabled:opacity-50"
+					class="shrink-0 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
 					onclick={handle_spawn}
 					disabled={spawning || !spawn_prompt.trim() || !spawn_working_directory.trim()}
 				>
@@ -162,7 +165,7 @@
 		<!-- Discovered external sessions -->
 		{#if store.discovered_sessions.length > 0}
 			<div class="space-y-2">
-				<h3 class="text-sm font-medium text-neutral-400">
+				<h3 class="text-sm font-medium text-muted-foreground">
 					External Sessions ({store.discovered_sessions.length})
 				</h3>
 				{#each store.discovered_sessions as session (session.id)}
@@ -174,7 +177,7 @@
 		<!-- Active sessions -->
 		{#if store.active_sessions.length > 0}
 			<div class="space-y-2">
-				<h3 class="text-sm font-medium text-neutral-400">Active</h3>
+				<h3 class="text-sm font-medium text-muted-foreground">Active</h3>
 				{#each store.active_sessions as session (session.id)}
 					<SessionCard
 						{session}
@@ -188,7 +191,7 @@
 		<!-- Finished sessions -->
 		{#if store.finished_sessions.length > 0}
 			<div class="space-y-2">
-				<h3 class="text-sm font-medium text-neutral-400">Completed</h3>
+				<h3 class="text-sm font-medium text-muted-foreground">Completed</h3>
 				{#each store.finished_sessions as session (session.id)}
 					<SessionCard
 						{session}
@@ -202,13 +205,15 @@
 		<!-- Empty state -->
 		{#if store.loading === false && store.sessions.length === 0 && store.discovered_sessions.length === 0}
 			<div class="py-12 text-center">
-				<p class="text-neutral-500">No sessions yet. Spawn one above to get started.</p>
+				<p class="text-muted-foreground">
+					No sessions yet. Spawn one above to get started.
+				</p>
 			</div>
 		{/if}
 
 		{#if store.loading}
 			<div class="py-12 text-center">
-				<p class="text-neutral-500">Loading sessions...</p>
+				<p class="text-muted-foreground">Loading sessions...</p>
 			</div>
 		{/if}
 	</div>

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -101,20 +101,22 @@
 	<!-- Color Palettes Section -->
 	<section class="space-y-4">
 		<h2 class="text-lg font-medium">Color Palettes</h2>
-		<p class="text-sm text-neutral-500">
+		<p class="text-sm text-muted-foreground">
 			Manage color palettes for issue visual identity. Built-in palettes cannot be modified.
 		</p>
 
 		{#if operation_error}
-			<p class="rounded bg-red-900/30 px-3 py-2 text-sm text-red-400">{operation_error}</p>
+			<p class="rounded bg-destructive/20 px-3 py-2 text-sm text-destructive">
+				{operation_error}
+			</p>
 		{/if}
 
 		<!-- Built-in palettes (read-only) -->
 		{#each built_in_palettes as palette (palette.id)}
-			<div class="rounded border border-neutral-700 bg-neutral-800/50 p-3">
+			<div class="rounded border border-border bg-muted/50 p-3">
 				<div class="mb-2 flex items-center gap-2">
 					<span class="text-sm font-medium">{palette.name}</span>
-					<span class="rounded bg-neutral-700 px-1.5 py-0.5 text-xs text-neutral-400"
+					<span class="rounded bg-secondary px-1.5 py-0.5 text-xs text-muted-foreground"
 						>built-in</span
 					>
 				</div>
@@ -132,26 +134,26 @@
 
 		<!-- Custom palettes (editable) -->
 		{#each custom_palettes as palette (palette.id)}
-			<div class="rounded border border-neutral-700 bg-neutral-800/50 p-3">
+			<div class="rounded border border-border bg-muted/50 p-3">
 				{#if editing_palette_id === palette.id}
 					<!-- Edit mode -->
 					<div class="space-y-2">
 						<input
 							bind:value={edit_name}
-							class="w-full rounded border border-neutral-600 bg-neutral-800 px-2 py-1 text-sm text-neutral-100 outline-none focus:border-blue-500"
+							class="w-full rounded border border-input bg-muted px-2 py-1 text-sm text-foreground outline-none focus:border-ring"
 							placeholder="Palette name"
 						/>
 						<textarea
 							bind:value={edit_colors_input}
 							rows="2"
-							class="w-full rounded border border-neutral-600 bg-neutral-800 px-2 py-1 text-xs text-neutral-300 outline-none focus:border-blue-500"
+							class="w-full rounded border border-input bg-muted px-2 py-1 text-xs text-foreground outline-none focus:border-ring"
 							placeholder="#ff0000, #00ff00, #0000ff"
 						></textarea>
 						<div class="flex gap-2">
 							<button
 								type="button"
 								onclick={handle_save_edit}
-								class="rounded bg-blue-600 px-3 py-1 text-xs text-white hover:bg-blue-500"
+								class="rounded bg-primary px-3 py-1 text-xs text-primary-foreground hover:bg-primary/90"
 							>
 								Save
 							</button>
@@ -161,7 +163,7 @@
 									editing_palette_id = null;
 									operation_error = null;
 								}}
-								class="rounded px-3 py-1 text-xs text-neutral-400 hover:text-neutral-200"
+								class="rounded px-3 py-1 text-xs text-muted-foreground hover:text-foreground"
 							>
 								Cancel
 							</button>
@@ -175,14 +177,14 @@
 							<button
 								type="button"
 								onclick={() => start_editing(palette)}
-								class="text-xs text-neutral-400 hover:text-neutral-200"
+								class="text-xs text-muted-foreground hover:text-foreground"
 							>
 								Edit
 							</button>
 							<button
 								type="button"
 								onclick={() => handle_delete(palette.id)}
-								class="text-xs text-red-400 hover:text-red-300"
+								class="text-xs text-destructive hover:text-destructive/80"
 							>
 								Delete
 							</button>
@@ -203,24 +205,24 @@
 
 		<!-- Create new palette -->
 		{#if creating}
-			<div class="rounded border border-dashed border-neutral-600 p-3">
+			<div class="rounded border border-dashed border-input p-3">
 				<div class="space-y-2">
 					<input
 						bind:value={new_palette_name}
-						class="w-full rounded border border-neutral-600 bg-neutral-800 px-2 py-1 text-sm text-neutral-100 outline-none focus:border-blue-500"
+						class="w-full rounded border border-input bg-muted px-2 py-1 text-sm text-foreground outline-none focus:border-ring"
 						placeholder="Palette name"
 					/>
 					<textarea
 						bind:value={new_palette_colors_input}
 						rows="3"
-						class="w-full rounded border border-neutral-600 bg-neutral-800 px-2 py-1 text-xs text-neutral-300 outline-none focus:border-blue-500"
+						class="w-full rounded border border-input bg-muted px-2 py-1 text-xs text-foreground outline-none focus:border-ring"
 						placeholder="Paste hex colors separated by commas or spaces: #ff0000, #00ff00, #0000ff"
 					></textarea>
 					<div class="flex gap-2">
 						<button
 							type="button"
 							onclick={handle_create}
-							class="rounded bg-blue-600 px-3 py-1 text-xs text-white hover:bg-blue-500"
+							class="rounded bg-primary px-3 py-1 text-xs text-primary-foreground hover:bg-primary/90"
 						>
 							Create Palette
 						</button>
@@ -230,7 +232,7 @@
 								creating = false;
 								operation_error = null;
 							}}
-							class="rounded px-3 py-1 text-xs text-neutral-400 hover:text-neutral-200"
+							class="rounded px-3 py-1 text-xs text-muted-foreground hover:text-foreground"
 						>
 							Cancel
 						</button>
@@ -244,7 +246,7 @@
 					creating = true;
 					operation_error = null;
 				}}
-				class="rounded border border-dashed border-neutral-600 px-4 py-2 text-sm text-neutral-400 transition-colors hover:border-neutral-500 hover:text-neutral-300"
+				class="rounded border border-dashed border-input px-4 py-2 text-sm text-muted-foreground transition-colors hover:border-border hover:text-foreground"
 			>
 				+ Add Custom Palette
 			</button>


### PR DESCRIPTION
## Description
- Add `ThemeToggle` component to sidebar footer with system/light/dark mode switching
- Migrate 26 components + 3 pages from hardcoded Tailwind colors to OKLCH semantic tokens
- Status indicator colors (green/red/amber/purple) intentionally kept for semantic meaning
- All surfaces, borders, text, inputs, and buttons now respond to `.dark` class toggle

## Resolves
Closes #17

## Testing
- [ ] Toggle light/dark/system in sidebar, verify all surfaces change correctly
- [ ] Verify localStorage key `bamgit_theme_mode` persists across reload
- [ ] Verify dialogs render correctly in both themes
- [ ] Verify status badges remain visible in both themes
- [ ] `pnpm check:all` passes with zero errors