### PR TITLE
#21 feat(viz): SVG tree components for all 11 lifecycle stages

### DIFF
--- a/src/lib/components/tree/DeadTree.svelte
+++ b/src/lib/components/tree/DeadTree.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+	import type { TreeStage } from '$lib/types/tree_visualization';
+	import type { AccentColors, AttachmentPoints } from './types';
+	import { compute_attachment_points } from './attachment_points';
+
+	interface Props {
+		stage: Extract<TreeStage, 'bare' | 'dead' | 'stump'>;
+		accent: AccentColors;
+		trunk_color: string;
+		ground_color: string;
+	}
+
+	let { stage, accent, trunk_color, ground_color }: Props = $props();
+
+	const attachment_points: AttachmentPoints = $derived(compute_attachment_points(stage));
+
+	const muted_fill = $derived(stage === 'bare' ? accent.shadow : ground_color);
+</script>
+
+<g data-stage={stage} data-attachment-points={JSON.stringify(attachment_points)}>
+	<!-- Ground shadow -->
+	<polygon points="25,120 75,120 70,115 30,115" fill={ground_color} />
+
+	{#if stage === 'stump'}
+		<!-- Stump: short truncated trunk polygon -->
+		<polygon points="40,100 60,100 62,118 38,118" fill={trunk_color} />
+		<!-- Top face -->
+		<polygon points="40,100 60,100 58,103 42,103" fill={muted_fill} />
+		<!-- Ring detail -->
+		<ellipse cx="50" cy="102" rx="6" ry="1.5" fill={ground_color} opacity="0.4" />
+	{:else if stage === 'dead'}
+		<!-- Dead: tilted/broken trunk + few fallen branches -->
+		<!-- Main trunk (tilted) -->
+		<polygon points="46,45 54,42 56,110 44,110" fill={trunk_color} />
+		<!-- Break point -->
+		<polygon points="46,45 54,42 58,50 48,52" fill={muted_fill} />
+
+		<!-- Remaining branch stubs -->
+		<line x1="48" y1="60" x2="32" y2="50" stroke={trunk_color} stroke-width="2.5" />
+		<line x1="54" y1="70" x2="68" y2="62" stroke={trunk_color} stroke-width="2" />
+
+		<!-- Fallen branch on ground -->
+		<line x1="25" y1="116" x2="45" y2="114" stroke={trunk_color} stroke-width="2" />
+		<line x1="60" y1="118" x2="78" y2="115" stroke={trunk_color} stroke-width="1.5" />
+	{:else}
+		<!-- Bare: trunk + angular bare branches radiating from top -->
+		<!-- Trunk -->
+		<rect x="46" y="50" width="8" height="60" fill={trunk_color} />
+
+		<!-- Bare branches (line-like polygons, no canopy fill) -->
+		<!-- Main left branch -->
+		<line x1="47" y1="55" x2="22" y2="30" stroke={trunk_color} stroke-width="2.5" />
+		<!-- Left sub-branch -->
+		<line x1="32" y1="40" x2="20" y2="25" stroke={trunk_color} stroke-width="1.5" />
+		<!-- Main right branch -->
+		<line x1="53" y1="55" x2="78" y2="28" stroke={trunk_color} stroke-width="2.5" />
+		<!-- Right sub-branch -->
+		<line x1="68" y1="38" x2="80" y2="22" stroke={trunk_color} stroke-width="1.5" />
+		<!-- Center top branch -->
+		<line x1="50" y1="50" x2="50" y2="20" stroke={trunk_color} stroke-width="2" />
+		<!-- Top sub-branches -->
+		<line x1="50" y1="25" x2="40" y2="15" stroke={trunk_color} stroke-width="1.5" />
+		<line x1="50" y1="28" x2="62" y2="18" stroke={trunk_color} stroke-width="1.5" />
+	{/if}
+</g>

--- a/src/lib/components/tree/MatureTree.svelte
+++ b/src/lib/components/tree/MatureTree.svelte
@@ -1,0 +1,115 @@
+<script lang="ts">
+	import type { TreeStage, FruitType } from '$lib/types/tree_visualization';
+	import type { AccentColors, AttachmentPoints } from './types';
+	import { compute_attachment_points } from './attachment_points';
+
+	interface Props {
+		stage: Extract<TreeStage, 'leafy' | 'fruiting' | 'autumn' | 'ready'>;
+		accent: AccentColors;
+		trunk_color: string;
+		ground_color: string;
+		fruit_types: readonly FruitType[];
+	}
+
+	let { stage, accent, trunk_color, ground_color, fruit_types }: Props = $props();
+
+	const attachment_points: AttachmentPoints = $derived(compute_attachment_points(stage));
+
+	const FRUIT_COLORS: Record<FruitType, string> = {
+		apple: 'oklch(0.58 0.22 28)',
+		pear: 'oklch(0.78 0.15 110)',
+		orange: 'oklch(0.72 0.18 60)',
+		cherry: 'oklch(0.45 0.25 15)',
+		plum: 'oklch(0.45 0.2 310)',
+	};
+
+	// Deterministic fruit positions within canopy
+	const FRUIT_POSITIONS = [
+		{ x: 38, y: 35 },
+		{ x: 62, y: 32 },
+		{ x: 30, y: 45 },
+		{ x: 55, y: 25 },
+		{ x: 70, y: 42 },
+		{ x: 42, y: 22 },
+		{ x: 58, y: 48 },
+	];
+
+	// Autumn: warm hue shift for "falling leaves"
+	const AUTUMN_LEAF_POSITIONS = [
+		{ x: 25, y: 65, rotation: 30 },
+		{ x: 72, y: 70, rotation: -20 },
+		{ x: 35, y: 75, rotation: 45 },
+	];
+</script>
+
+<g data-stage={stage} data-attachment-points={JSON.stringify(attachment_points)}>
+	{#if stage === 'ready'}
+		<!-- Glow filter for ready stage -->
+		<defs>
+			<filter id="ready-glow" x="-20%" y="-20%" width="140%" height="140%">
+				<feGaussianBlur in="SourceGraphic" stdDeviation="3" result="blur" />
+				<feMerge>
+					<feMergeNode in="blur" />
+					<feMergeNode in="SourceGraphic" />
+				</feMerge>
+			</filter>
+		</defs>
+	{/if}
+
+	<!-- Ground shadow -->
+	<polygon points="20,120 80,120 75,115 25,115" fill={ground_color} />
+
+	<!-- Trunk -->
+	<rect x="45" y="50" width="10" height="60" fill={trunk_color} />
+	<!-- Trunk detail -->
+	<rect x="47" y="55" width="2" height="50" fill={ground_color} opacity="0.3" />
+
+	<!-- Canopy group (with glow filter on ready stage) -->
+	<g filter={stage === 'ready' ? 'url(#ready-glow)' : undefined}>
+		<!-- Layer 1: bottom wide -->
+		<polygon points="50,48 20,58 80,58" fill={accent.front} />
+		<polygon points="50,48 80,58 65,53" fill={accent.shadow} />
+
+		<!-- Layer 2: middle -->
+		<polygon points="50,32 25,48 75,48" fill={accent.front} />
+		<polygon points="50,32 75,48 60,40" fill={accent.shadow} />
+		<polygon points="50,32 35,42 50,39" fill={accent.highlight} />
+
+		<!-- Layer 3: top -->
+		<polygon points="50,15 30,35 70,35" fill={accent.front} />
+		<polygon points="50,15 70,35 58,25" fill={accent.shadow} />
+		<polygon points="50,15 40,26 50,23" fill={accent.highlight} />
+
+		<!-- Layer 4: peak -->
+		<polygon points="50,8 38,22 62,22" fill={accent.front} />
+		<polygon points="50,8 62,22 55,15" fill={accent.shadow} />
+	</g>
+
+	{#if stage === 'fruiting'}
+		<!-- Fruit elements -->
+		{#each fruit_types as fruit, index (index)}
+			{@const position = FRUIT_POSITIONS[index % FRUIT_POSITIONS.length]}
+			<circle
+				cx={position.x}
+				cy={position.y}
+				r="3"
+				fill={FRUIT_COLORS[fruit]}
+				data-fruit={fruit}
+			/>
+		{/each}
+	{/if}
+
+	{#if stage === 'autumn'}
+		<!-- Falling leaf polygons -->
+		{#each AUTUMN_LEAF_POSITIONS as leaf, index (index)}
+			<polygon
+				points="{leaf.x},{leaf.y} {leaf.x + 5},{leaf.y - 3} {leaf.x + 8},{leaf.y +
+					2} {leaf.x + 3},{leaf.y + 4}"
+				fill={accent.front}
+				opacity="0.7"
+				transform="rotate({leaf.rotation} {leaf.x + 4} {leaf.y})"
+				data-falling-leaf="true"
+			/>
+		{/each}
+	{/if}
+</g>

--- a/src/lib/components/tree/Sapling.svelte
+++ b/src/lib/components/tree/Sapling.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+	import type { TreeStage } from '$lib/types/tree_visualization';
+	import type { AccentColors, AttachmentPoints } from './types';
+	import { compute_attachment_points } from './attachment_points';
+
+	interface Props {
+		stage: Extract<TreeStage, 'sapling' | 'growing'>;
+		accent: AccentColors;
+		trunk_color: string;
+		ground_color: string;
+	}
+
+	let { stage, accent, trunk_color, ground_color }: Props = $props();
+
+	const attachment_points: AttachmentPoints = $derived(compute_attachment_points(stage));
+</script>
+
+<g data-stage={stage} data-attachment-points={JSON.stringify(attachment_points)}>
+	<!-- Ground shadow -->
+	<polygon points="25,120 75,120 70,115 30,115" fill={ground_color} />
+
+	<!-- Trunk -->
+	<rect x="47" y="55" width="6" height="55" fill={trunk_color} />
+
+	{#if stage === 'sapling'}
+		<!-- Sapling: small triangular canopy (3–4 facets) -->
+		<!-- Front face -->
+		<polygon points="50,25 30,55 50,50" fill={accent.front} />
+		<!-- Right face -->
+		<polygon points="50,25 70,55 50,50" fill={accent.shadow} />
+		<!-- Highlight facet -->
+		<polygon points="50,25 38,42 50,38" fill={accent.highlight} />
+		<!-- Lower front -->
+		<polygon points="30,55 50,50 35,58" fill={accent.front} />
+	{:else}
+		<!-- Growing: larger canopy (5–6 facets) + support stakes -->
+		<!-- Main front face -->
+		<polygon points="50,18 25,55 50,48" fill={accent.front} />
+		<!-- Right face -->
+		<polygon points="50,18 75,55 50,48" fill={accent.shadow} />
+		<!-- Top highlight -->
+		<polygon points="50,18 35,38 50,33" fill={accent.highlight} />
+		<!-- Lower left face -->
+		<polygon points="25,55 50,48 30,60" fill={accent.front} />
+		<!-- Lower right face -->
+		<polygon points="75,55 50,48 70,60" fill={accent.shadow} />
+		<!-- Mid highlight -->
+		<polygon points="50,33 40,48 50,45" fill={accent.highlight} />
+
+		<!-- Support stakes -->
+		<line
+			x1="35"
+			y1="108"
+			x2="45"
+			y2="70"
+			stroke={trunk_color}
+			stroke-width="2"
+			data-support="left"
+		/>
+		<line
+			x1="65"
+			y1="108"
+			x2="55"
+			y2="70"
+			stroke={trunk_color}
+			stroke-width="2"
+			data-support="right"
+		/>
+	{/if}
+</g>

--- a/src/lib/components/tree/SeedSprout.svelte
+++ b/src/lib/components/tree/SeedSprout.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+	import type { TreeStage } from '$lib/types/tree_visualization';
+	import type { AccentColors, AttachmentPoints } from './types';
+	import { compute_attachment_points } from './attachment_points';
+
+	interface Props {
+		stage: Extract<TreeStage, 'seed' | 'sprouting'>;
+		accent: AccentColors;
+		trunk_color: string;
+		ground_color: string;
+	}
+
+	let { stage, accent, trunk_color, ground_color }: Props = $props();
+
+	const attachment_points: AttachmentPoints = $derived(compute_attachment_points(stage));
+</script>
+
+<g data-stage={stage} data-attachment-points={JSON.stringify(attachment_points)}>
+	<!-- Ground shadow -->
+	<polygon points="30,120 70,120 65,115 35,115" fill={ground_color} />
+
+	{#if stage === 'seed'}
+		<!-- Seed: angular pentagon at ground level -->
+		<polygon points="50,100 58,105 56,114 44,114 42,105" fill={accent.front} />
+		<polygon points="50,100 42,105 44,114 50,107" fill={accent.shadow} />
+		<!-- Seed highlight facet -->
+		<polygon points="50,100 58,105 54,103" fill={accent.highlight} />
+	{:else}
+		<!-- Sprouting: seed body + angular leaves emerging -->
+		<!-- Seed body (slightly open) -->
+		<polygon points="50,105 58,110 56,118 44,118 42,110" fill={accent.shadow} />
+		<polygon points="50,105 42,110 44,118 48,112" fill={ground_color} />
+
+		<!-- Stem -->
+		<rect x="48" y="85" width="4" height="20" fill={trunk_color} />
+
+		<!-- Left leaf (angular) -->
+		<polygon points="48,90 38,82 42,88" fill={accent.front} />
+		<polygon points="48,90 38,82 40,85" fill={accent.highlight} />
+
+		<!-- Right leaf (angular) -->
+		<polygon points="52,86 62,78 58,84" fill={accent.front} />
+		<polygon points="52,86 62,78 60,81" fill={accent.shadow} />
+	{/if}
+</g>

--- a/src/lib/components/tree/TreeRenderer.stories.svelte
+++ b/src/lib/components/tree/TreeRenderer.stories.svelte
@@ -1,0 +1,208 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import { TreeRenderer } from './index';
+	import ThemeDecorator from '$lib/storybook/ThemeDecorator.svelte';
+
+	const { Story } = defineMeta({
+		title: 'Viz/TreeRenderer',
+		component: TreeRenderer,
+		// @ts-expect-error — Storybook decorator typing doesn't match Svelte 5 Component type
+		decorators: [() => ThemeDecorator],
+		tags: ['autodocs'],
+		argTypes: {
+			accent_color: { control: 'color' },
+			is_dark: { control: 'boolean' },
+		},
+	});
+</script>
+
+<script lang="ts">
+	import type { TreeVisualizationTree, TreeStage } from '$lib/types/tree_visualization';
+
+	const ALL_STAGES: TreeStage[] = [
+		'seed',
+		'sprouting',
+		'sapling',
+		'growing',
+		'leafy',
+		'fruiting',
+		'autumn',
+		'ready',
+		'bare',
+		'dead',
+		'stump',
+	];
+
+	function make_tree(
+		stage: TreeVisualizationTree['stage'],
+		extras: Partial<TreeVisualizationTree> = {},
+	): TreeVisualizationTree {
+		return {
+			kind: 'tree',
+			stage,
+			overlays: [],
+			companionSaplings: [],
+			activeTools: [],
+			fruitTypes: [],
+			...extras,
+		};
+	}
+</script>
+
+<Story name="Seed" args={{ accent_color: '#22c55e', is_dark: false }}>
+	{#snippet template(args: { accent_color: string; is_dark?: boolean })}
+		<div class="w-32">
+			<TreeRenderer
+				visualization={make_tree('seed')}
+				accent_color={args.accent_color}
+				is_dark={args.is_dark}
+			/>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Sprouting" args={{ accent_color: '#22c55e', is_dark: false }}>
+	{#snippet template(args: { accent_color: string; is_dark?: boolean })}
+		<div class="w-32">
+			<TreeRenderer
+				visualization={make_tree('sprouting')}
+				accent_color={args.accent_color}
+				is_dark={args.is_dark}
+			/>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Sapling" args={{ accent_color: '#3b82f6', is_dark: false }}>
+	{#snippet template(args: { accent_color: string; is_dark?: boolean })}
+		<div class="w-32">
+			<TreeRenderer
+				visualization={make_tree('sapling')}
+				accent_color={args.accent_color}
+				is_dark={args.is_dark}
+			/>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Growing" args={{ accent_color: '#3b82f6', is_dark: false }}>
+	{#snippet template(args: { accent_color: string; is_dark?: boolean })}
+		<div class="w-32">
+			<TreeRenderer
+				visualization={make_tree('growing')}
+				accent_color={args.accent_color}
+				is_dark={args.is_dark}
+			/>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Leafy" args={{ accent_color: '#10b981', is_dark: false }}>
+	{#snippet template(args: { accent_color: string; is_dark?: boolean })}
+		<div class="w-32">
+			<TreeRenderer
+				visualization={make_tree('leafy')}
+				accent_color={args.accent_color}
+				is_dark={args.is_dark}
+			/>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Fruiting" args={{ accent_color: '#10b981', is_dark: false }}>
+	{#snippet template(args: { accent_color: string; is_dark?: boolean })}
+		<div class="w-32">
+			<TreeRenderer
+				visualization={make_tree('fruiting', {
+					fruitTypes: ['apple', 'pear', 'cherry', 'orange'],
+				})}
+				accent_color={args.accent_color}
+				is_dark={args.is_dark}
+			/>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Autumn" args={{ accent_color: '#f59e0b', is_dark: false }}>
+	{#snippet template(args: { accent_color: string; is_dark?: boolean })}
+		<div class="w-32">
+			<TreeRenderer
+				visualization={make_tree('autumn')}
+				accent_color={args.accent_color}
+				is_dark={args.is_dark}
+			/>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Ready" args={{ accent_color: '#8b5cf6', is_dark: false }}>
+	{#snippet template(args: { accent_color: string; is_dark?: boolean })}
+		<div class="w-32">
+			<TreeRenderer
+				visualization={make_tree('ready')}
+				accent_color={args.accent_color}
+				is_dark={args.is_dark}
+			/>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Bare" args={{ accent_color: '#6b7280', is_dark: false }}>
+	{#snippet template(args: { accent_color: string; is_dark?: boolean })}
+		<div class="w-32">
+			<TreeRenderer
+				visualization={make_tree('bare')}
+				accent_color={args.accent_color}
+				is_dark={args.is_dark}
+			/>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Dead" args={{ accent_color: '#6b7280', is_dark: false }}>
+	{#snippet template(args: { accent_color: string; is_dark?: boolean })}
+		<div class="w-32">
+			<TreeRenderer
+				visualization={make_tree('dead')}
+				accent_color={args.accent_color}
+				is_dark={args.is_dark}
+			/>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Stump" args={{ accent_color: '#6b7280', is_dark: false }}>
+	{#snippet template(args: { accent_color: string; is_dark?: boolean })}
+		<div class="w-32">
+			<TreeRenderer
+				visualization={make_tree('stump')}
+				accent_color={args.accent_color}
+				is_dark={args.is_dark}
+			/>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="All Stages Gallery" args={{ accent_color: '#3b82f6', is_dark: false }}>
+	{#snippet template(args: { accent_color: string; is_dark?: boolean })}
+		<div class="grid grid-cols-4 gap-4">
+			{#each ALL_STAGES as stage (stage)}
+				<div class="flex flex-col items-center gap-1">
+					<div class="w-24">
+						<TreeRenderer
+							visualization={make_tree(
+								stage,
+								stage === 'fruiting'
+									? { fruitTypes: ['apple', 'pear', 'cherry'] }
+									: {},
+							)}
+							accent_color={args.accent_color}
+							is_dark={args.is_dark}
+						/>
+					</div>
+					<span class="text-xs text-muted-foreground">{stage}</span>
+				</div>
+			{/each}
+		</div>
+	{/snippet}
+</Story>

--- a/src/lib/components/tree/TreeRenderer.stories.svelte
+++ b/src/lib/components/tree/TreeRenderer.stories.svelte
@@ -19,6 +19,12 @@
 <script lang="ts">
 	import type { TreeVisualizationTree, TreeStage } from '$lib/types/tree_visualization';
 
+	interface StoryArgs {
+		visualization?: TreeVisualizationTree;
+		accent_color: string;
+		is_dark?: boolean;
+	}
+
 	const ALL_STAGES: TreeStage[] = [
 		'seed',
 		'sprouting',
@@ -49,11 +55,14 @@
 	}
 </script>
 
-<Story name="Seed" args={{ accent_color: '#22c55e', is_dark: false }}>
-	{#snippet template(args: { accent_color: string; is_dark?: boolean })}
+<Story
+	name="Seed"
+	args={{ visualization: make_tree('seed'), accent_color: '#22c55e', is_dark: false }}
+>
+	{#snippet template(args: StoryArgs)}
 		<div class="w-32">
 			<TreeRenderer
-				visualization={make_tree('seed')}
+				visualization={args.visualization}
 				accent_color={args.accent_color}
 				is_dark={args.is_dark}
 			/>
@@ -61,11 +70,14 @@
 	{/snippet}
 </Story>
 
-<Story name="Sprouting" args={{ accent_color: '#22c55e', is_dark: false }}>
-	{#snippet template(args: { accent_color: string; is_dark?: boolean })}
+<Story
+	name="Sprouting"
+	args={{ visualization: make_tree('sprouting'), accent_color: '#22c55e', is_dark: false }}
+>
+	{#snippet template(args: StoryArgs)}
 		<div class="w-32">
 			<TreeRenderer
-				visualization={make_tree('sprouting')}
+				visualization={args.visualization}
 				accent_color={args.accent_color}
 				is_dark={args.is_dark}
 			/>
@@ -73,11 +85,14 @@
 	{/snippet}
 </Story>
 
-<Story name="Sapling" args={{ accent_color: '#3b82f6', is_dark: false }}>
-	{#snippet template(args: { accent_color: string; is_dark?: boolean })}
+<Story
+	name="Sapling"
+	args={{ visualization: make_tree('sapling'), accent_color: '#3b82f6', is_dark: false }}
+>
+	{#snippet template(args: StoryArgs)}
 		<div class="w-32">
 			<TreeRenderer
-				visualization={make_tree('sapling')}
+				visualization={args.visualization}
 				accent_color={args.accent_color}
 				is_dark={args.is_dark}
 			/>
@@ -85,11 +100,14 @@
 	{/snippet}
 </Story>
 
-<Story name="Growing" args={{ accent_color: '#3b82f6', is_dark: false }}>
-	{#snippet template(args: { accent_color: string; is_dark?: boolean })}
+<Story
+	name="Growing"
+	args={{ visualization: make_tree('growing'), accent_color: '#3b82f6', is_dark: false }}
+>
+	{#snippet template(args: StoryArgs)}
 		<div class="w-32">
 			<TreeRenderer
-				visualization={make_tree('growing')}
+				visualization={args.visualization}
 				accent_color={args.accent_color}
 				is_dark={args.is_dark}
 			/>
@@ -97,11 +115,14 @@
 	{/snippet}
 </Story>
 
-<Story name="Leafy" args={{ accent_color: '#10b981', is_dark: false }}>
-	{#snippet template(args: { accent_color: string; is_dark?: boolean })}
+<Story
+	name="Leafy"
+	args={{ visualization: make_tree('leafy'), accent_color: '#10b981', is_dark: false }}
+>
+	{#snippet template(args: StoryArgs)}
 		<div class="w-32">
 			<TreeRenderer
-				visualization={make_tree('leafy')}
+				visualization={args.visualization}
 				accent_color={args.accent_color}
 				is_dark={args.is_dark}
 			/>
@@ -109,13 +130,18 @@
 	{/snippet}
 </Story>
 
-<Story name="Fruiting" args={{ accent_color: '#10b981', is_dark: false }}>
-	{#snippet template(args: { accent_color: string; is_dark?: boolean })}
+<Story
+	name="Fruiting"
+	args={{
+		visualization: make_tree('fruiting', { fruitTypes: ['apple', 'pear', 'cherry', 'orange'] }),
+		accent_color: '#10b981',
+		is_dark: false,
+	}}
+>
+	{#snippet template(args: StoryArgs)}
 		<div class="w-32">
 			<TreeRenderer
-				visualization={make_tree('fruiting', {
-					fruitTypes: ['apple', 'pear', 'cherry', 'orange'],
-				})}
+				visualization={args.visualization}
 				accent_color={args.accent_color}
 				is_dark={args.is_dark}
 			/>
@@ -123,11 +149,14 @@
 	{/snippet}
 </Story>
 
-<Story name="Autumn" args={{ accent_color: '#f59e0b', is_dark: false }}>
-	{#snippet template(args: { accent_color: string; is_dark?: boolean })}
+<Story
+	name="Autumn"
+	args={{ visualization: make_tree('autumn'), accent_color: '#f59e0b', is_dark: false }}
+>
+	{#snippet template(args: StoryArgs)}
 		<div class="w-32">
 			<TreeRenderer
-				visualization={make_tree('autumn')}
+				visualization={args.visualization}
 				accent_color={args.accent_color}
 				is_dark={args.is_dark}
 			/>
@@ -135,11 +164,14 @@
 	{/snippet}
 </Story>
 
-<Story name="Ready" args={{ accent_color: '#8b5cf6', is_dark: false }}>
-	{#snippet template(args: { accent_color: string; is_dark?: boolean })}
+<Story
+	name="Ready"
+	args={{ visualization: make_tree('ready'), accent_color: '#8b5cf6', is_dark: false }}
+>
+	{#snippet template(args: StoryArgs)}
 		<div class="w-32">
 			<TreeRenderer
-				visualization={make_tree('ready')}
+				visualization={args.visualization}
 				accent_color={args.accent_color}
 				is_dark={args.is_dark}
 			/>
@@ -147,11 +179,14 @@
 	{/snippet}
 </Story>
 
-<Story name="Bare" args={{ accent_color: '#6b7280', is_dark: false }}>
-	{#snippet template(args: { accent_color: string; is_dark?: boolean })}
+<Story
+	name="Bare"
+	args={{ visualization: make_tree('bare'), accent_color: '#6b7280', is_dark: false }}
+>
+	{#snippet template(args: StoryArgs)}
 		<div class="w-32">
 			<TreeRenderer
-				visualization={make_tree('bare')}
+				visualization={args.visualization}
 				accent_color={args.accent_color}
 				is_dark={args.is_dark}
 			/>
@@ -159,11 +194,14 @@
 	{/snippet}
 </Story>
 
-<Story name="Dead" args={{ accent_color: '#6b7280', is_dark: false }}>
-	{#snippet template(args: { accent_color: string; is_dark?: boolean })}
+<Story
+	name="Dead"
+	args={{ visualization: make_tree('dead'), accent_color: '#6b7280', is_dark: false }}
+>
+	{#snippet template(args: StoryArgs)}
 		<div class="w-32">
 			<TreeRenderer
-				visualization={make_tree('dead')}
+				visualization={args.visualization}
 				accent_color={args.accent_color}
 				is_dark={args.is_dark}
 			/>
@@ -171,11 +209,14 @@
 	{/snippet}
 </Story>
 
-<Story name="Stump" args={{ accent_color: '#6b7280', is_dark: false }}>
-	{#snippet template(args: { accent_color: string; is_dark?: boolean })}
+<Story
+	name="Stump"
+	args={{ visualization: make_tree('stump'), accent_color: '#6b7280', is_dark: false }}
+>
+	{#snippet template(args: StoryArgs)}
 		<div class="w-32">
 			<TreeRenderer
-				visualization={make_tree('stump')}
+				visualization={args.visualization}
 				accent_color={args.accent_color}
 				is_dark={args.is_dark}
 			/>
@@ -183,8 +224,11 @@
 	{/snippet}
 </Story>
 
-<Story name="All Stages Gallery" args={{ accent_color: '#3b82f6', is_dark: false }}>
-	{#snippet template(args: { accent_color: string; is_dark?: boolean })}
+<Story
+	name="All Stages Gallery"
+	args={{ visualization: make_tree('seed'), accent_color: '#3b82f6', is_dark: false }}
+>
+	{#snippet template(args: StoryArgs)}
 		<div class="grid grid-cols-4 gap-4">
 			{#each ALL_STAGES as stage (stage)}
 				<div class="flex flex-col items-center gap-1">

--- a/src/lib/components/tree/TreeRenderer.svelte
+++ b/src/lib/components/tree/TreeRenderer.svelte
@@ -1,0 +1,69 @@
+<script lang="ts">
+	import type { TreeVisualizationTree } from '$lib/types/tree_visualization';
+	import { STAGE_TO_GROUP, VIEWBOX_WIDTH, VIEWBOX_HEIGHT } from './types';
+	import {
+		compute_accent_colors,
+		compute_trunk_color,
+		compute_ground_color,
+	} from './color_utils';
+	import SeedSprout from './SeedSprout.svelte';
+	import Sapling from './Sapling.svelte';
+	import MatureTree from './MatureTree.svelte';
+	import DeadTree from './DeadTree.svelte';
+	import { fade } from 'svelte/transition';
+
+	interface Props {
+		visualization: TreeVisualizationTree;
+		accent_color: string;
+		is_dark?: boolean;
+	}
+
+	let { visualization, accent_color, is_dark = false }: Props = $props();
+
+	const group = $derived(STAGE_TO_GROUP[visualization.stage]);
+	const accent = $derived(compute_accent_colors(accent_color));
+	const trunk_color = $derived(compute_trunk_color(is_dark));
+	const ground_color = $derived(compute_ground_color(is_dark));
+</script>
+
+<svg
+	viewBox="0 0 {VIEWBOX_WIDTH} {VIEWBOX_HEIGHT}"
+	xmlns="http://www.w3.org/2000/svg"
+	role="img"
+	aria-label="Tree visualization: {visualization.stage} stage"
+>
+	{#key group}
+		<g transition:fade={{ duration: 200 }}>
+			{#if group === 'seed-sprout'}
+				<SeedSprout
+					stage={visualization.stage as 'seed' | 'sprouting'}
+					{accent}
+					{trunk_color}
+					{ground_color}
+				/>
+			{:else if group === 'sapling'}
+				<Sapling
+					stage={visualization.stage as 'sapling' | 'growing'}
+					{accent}
+					{trunk_color}
+					{ground_color}
+				/>
+			{:else if group === 'mature-tree'}
+				<MatureTree
+					stage={visualization.stage as 'leafy' | 'fruiting' | 'autumn' | 'ready'}
+					{accent}
+					{trunk_color}
+					{ground_color}
+					fruit_types={visualization.fruitTypes}
+				/>
+			{:else if group === 'dead-tree'}
+				<DeadTree
+					stage={visualization.stage as 'bare' | 'dead' | 'stump'}
+					{accent}
+					{trunk_color}
+					{ground_color}
+				/>
+			{/if}
+		</g>
+	{/key}
+</svg>

--- a/src/lib/components/tree/TreeRenderer.svelte
+++ b/src/lib/components/tree/TreeRenderer.svelte
@@ -13,57 +13,59 @@
 	import { fade } from 'svelte/transition';
 
 	interface Props {
-		visualization: TreeVisualizationTree;
+		visualization?: TreeVisualizationTree;
 		accent_color: string;
 		is_dark?: boolean;
 	}
 
 	let { visualization, accent_color, is_dark = false }: Props = $props();
 
-	const group = $derived(STAGE_TO_GROUP[visualization.stage]);
+	const group = $derived(visualization ? STAGE_TO_GROUP[visualization.stage] : undefined);
 	const accent = $derived(compute_accent_colors(accent_color));
 	const trunk_color = $derived(compute_trunk_color(is_dark));
 	const ground_color = $derived(compute_ground_color(is_dark));
 </script>
 
-<svg
-	viewBox="0 0 {VIEWBOX_WIDTH} {VIEWBOX_HEIGHT}"
-	xmlns="http://www.w3.org/2000/svg"
-	role="img"
-	aria-label="Tree visualization: {visualization.stage} stage"
->
-	{#key group}
-		<g transition:fade={{ duration: 200 }}>
-			{#if group === 'seed-sprout'}
-				<SeedSprout
-					stage={visualization.stage as 'seed' | 'sprouting'}
-					{accent}
-					{trunk_color}
-					{ground_color}
-				/>
-			{:else if group === 'sapling'}
-				<Sapling
-					stage={visualization.stage as 'sapling' | 'growing'}
-					{accent}
-					{trunk_color}
-					{ground_color}
-				/>
-			{:else if group === 'mature-tree'}
-				<MatureTree
-					stage={visualization.stage as 'leafy' | 'fruiting' | 'autumn' | 'ready'}
-					{accent}
-					{trunk_color}
-					{ground_color}
-					fruit_types={visualization.fruitTypes}
-				/>
-			{:else if group === 'dead-tree'}
-				<DeadTree
-					stage={visualization.stage as 'bare' | 'dead' | 'stump'}
-					{accent}
-					{trunk_color}
-					{ground_color}
-				/>
-			{/if}
-		</g>
-	{/key}
-</svg>
+{#if visualization}
+	<svg
+		viewBox="0 0 {VIEWBOX_WIDTH} {VIEWBOX_HEIGHT}"
+		xmlns="http://www.w3.org/2000/svg"
+		role="img"
+		aria-label="Tree visualization: {visualization.stage} stage"
+	>
+		{#key group}
+			<g transition:fade={{ duration: 200 }}>
+				{#if group === 'seed-sprout'}
+					<SeedSprout
+						stage={visualization.stage as 'seed' | 'sprouting'}
+						{accent}
+						{trunk_color}
+						{ground_color}
+					/>
+				{:else if group === 'sapling'}
+					<Sapling
+						stage={visualization.stage as 'sapling' | 'growing'}
+						{accent}
+						{trunk_color}
+						{ground_color}
+					/>
+				{:else if group === 'mature-tree'}
+					<MatureTree
+						stage={visualization.stage as 'leafy' | 'fruiting' | 'autumn' | 'ready'}
+						{accent}
+						{trunk_color}
+						{ground_color}
+						fruit_types={visualization.fruitTypes}
+					/>
+				{:else if group === 'dead-tree'}
+					<DeadTree
+						stage={visualization.stage as 'bare' | 'dead' | 'stump'}
+						{accent}
+						{trunk_color}
+						{ground_color}
+					/>
+				{/if}
+			</g>
+		{/key}
+	</svg>
+{/if}

--- a/src/lib/components/tree/attachment_points.test.ts
+++ b/src/lib/components/tree/attachment_points.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { compute_attachment_points } from './attachment_points';
+import type { TreeStage } from '$lib/types/tree_visualization';
+import { CROWN_ZONE_END, GROUND_ZONE_START, VIEWBOX_WIDTH } from './types';
+
+const ALL_STAGES: TreeStage[] = [
+	'seed',
+	'sprouting',
+	'sapling',
+	'growing',
+	'leafy',
+	'fruiting',
+	'autumn',
+	'ready',
+	'bare',
+	'dead',
+	'stump',
+];
+
+describe('compute_attachment_points', () => {
+	it('returns valid points for all 11 stages', () => {
+		for (const stage of ALL_STAGES) {
+			const points = compute_attachment_points(stage);
+			expect(points.crown).toBeDefined();
+			expect(points.trunkBase).toBeDefined();
+			expect(points.roots).toBeDefined();
+		}
+	});
+
+	it('crown point x is within viewBox width', () => {
+		for (const stage of ALL_STAGES) {
+			const points = compute_attachment_points(stage);
+			expect(points.crown.x).toBeGreaterThanOrEqual(0);
+			expect(points.crown.x).toBeLessThanOrEqual(VIEWBOX_WIDTH);
+		}
+	});
+
+	it('crown point y is within crown zone (y <= 50) for full-sized trees', () => {
+		const full_tree_stages: TreeStage[] = [
+			'sapling',
+			'growing',
+			'leafy',
+			'fruiting',
+			'autumn',
+			'ready',
+			'bare',
+		];
+		for (const stage of full_tree_stages) {
+			const points = compute_attachment_points(stage);
+			expect(points.crown.y).toBeLessThanOrEqual(CROWN_ZONE_END);
+		}
+	});
+
+	it('trunkBase point y is near trunk-ground boundary (~110)', () => {
+		for (const stage of ALL_STAGES) {
+			const points = compute_attachment_points(stage);
+			expect(points.trunkBase.y).toBeGreaterThanOrEqual(GROUND_ZONE_START - 10);
+			expect(points.trunkBase.y).toBeLessThanOrEqual(GROUND_ZONE_START + 20);
+		}
+	});
+
+	it('roots point y is in ground zone (y >= 110)', () => {
+		for (const stage of ALL_STAGES) {
+			const points = compute_attachment_points(stage);
+			expect(points.roots.y).toBeGreaterThanOrEqual(GROUND_ZONE_START);
+		}
+	});
+
+	it('seed/stump crown y is higher than ground (not at top)', () => {
+		const low_stages: TreeStage[] = ['seed', 'stump'];
+		for (const stage of low_stages) {
+			const points = compute_attachment_points(stage);
+			// These are low trees, crown should be below the full crown zone
+			expect(points.crown.y).toBeGreaterThan(CROWN_ZONE_END);
+		}
+	});
+});

--- a/src/lib/components/tree/attachment_points.ts
+++ b/src/lib/components/tree/attachment_points.ts
@@ -1,0 +1,78 @@
+import type { TreeStage } from '$lib/types/tree_visualization';
+import type { AttachmentPoints } from './types';
+
+/**
+ * Computes overlay attachment points for each tree stage.
+ * Points are in SVG coordinate space (viewBox 0 0 100 150).
+ * Crown zone: y 0–50, Trunk zone: y 50–110, Ground zone: y 110–150.
+ */
+export function compute_attachment_points(stage: TreeStage): AttachmentPoints {
+	switch (stage) {
+		case 'seed':
+			return {
+				crown: { x: 50, y: 95 },
+				trunkBase: { x: 50, y: 110 },
+				roots: { x: 50, y: 120 },
+			};
+		case 'sprouting':
+			return {
+				crown: { x: 50, y: 80 },
+				trunkBase: { x: 50, y: 110 },
+				roots: { x: 50, y: 120 },
+			};
+		case 'sapling':
+			return {
+				crown: { x: 50, y: 35 },
+				trunkBase: { x: 50, y: 108 },
+				roots: { x: 50, y: 120 },
+			};
+		case 'growing':
+			return {
+				crown: { x: 50, y: 28 },
+				trunkBase: { x: 50, y: 108 },
+				roots: { x: 50, y: 120 },
+			};
+		case 'leafy':
+			return {
+				crown: { x: 50, y: 18 },
+				trunkBase: { x: 50, y: 105 },
+				roots: { x: 50, y: 118 },
+			};
+		case 'fruiting':
+			return {
+				crown: { x: 50, y: 15 },
+				trunkBase: { x: 50, y: 105 },
+				roots: { x: 50, y: 118 },
+			};
+		case 'autumn':
+			return {
+				crown: { x: 50, y: 18 },
+				trunkBase: { x: 50, y: 105 },
+				roots: { x: 50, y: 118 },
+			};
+		case 'ready':
+			return {
+				crown: { x: 50, y: 12 },
+				trunkBase: { x: 50, y: 105 },
+				roots: { x: 50, y: 118 },
+			};
+		case 'bare':
+			return {
+				crown: { x: 50, y: 20 },
+				trunkBase: { x: 50, y: 108 },
+				roots: { x: 50, y: 120 },
+			};
+		case 'dead':
+			return {
+				crown: { x: 50, y: 30 },
+				trunkBase: { x: 50, y: 108 },
+				roots: { x: 50, y: 120 },
+			};
+		case 'stump':
+			return {
+				crown: { x: 50, y: 90 },
+				trunkBase: { x: 50, y: 110 },
+				roots: { x: 50, y: 120 },
+			};
+	}
+}

--- a/src/lib/components/tree/color_utils.test.ts
+++ b/src/lib/components/tree/color_utils.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import {
+	hex_to_oklch,
+	compute_accent_colors,
+	compute_trunk_color,
+	oklch_to_css,
+} from './color_utils';
+
+// ─── hex_to_oklch ────────────────────────────────────────────────────────
+
+describe('hex_to_oklch', () => {
+	it('converts pure red (#ff0000) to approximate OKLCH values', () => {
+		const result = hex_to_oklch('#ff0000');
+		expect(result.lightness).toBeCloseTo(0.6279, 1);
+		expect(result.chroma).toBeGreaterThan(0.2);
+		expect(result.hue).toBeGreaterThan(20);
+		expect(result.hue).toBeLessThan(35);
+	});
+
+	it('converts pure white (#ffffff) to L≈1, C≈0', () => {
+		const result = hex_to_oklch('#ffffff');
+		expect(result.lightness).toBeCloseTo(1.0, 1);
+		expect(result.chroma).toBeCloseTo(0, 2);
+	});
+
+	it('converts pure black (#000000) to L≈0, C≈0', () => {
+		const result = hex_to_oklch('#000000');
+		expect(result.lightness).toBeCloseTo(0, 2);
+		expect(result.chroma).toBeCloseTo(0, 2);
+	});
+
+	it('handles 3-char hex shorthand (#f00)', () => {
+		const result = hex_to_oklch('#f00');
+		expect(result.lightness).toBeCloseTo(0.6279, 1);
+		expect(result.chroma).toBeGreaterThan(0.2);
+	});
+
+	it('handles hex without # prefix', () => {
+		const result = hex_to_oklch('ef4444');
+		expect(result.lightness).toBeGreaterThan(0.5);
+		expect(result.chroma).toBeGreaterThan(0.1);
+	});
+});
+
+// ─── compute_accent_colors ───────────────────────────────────────────────
+
+describe('compute_accent_colors', () => {
+	it('returns front at L=0.65, shadow at L=0.50, highlight at L=0.78', () => {
+		const result = compute_accent_colors('#3b82f6');
+		expect(result.front).toContain('oklch(');
+		expect(result.shadow).toContain('oklch(');
+		expect(result.highlight).toContain('oklch(');
+		// Parse L values from strings
+		const front_l = parse_lightness(result.front);
+		const shadow_l = parse_lightness(result.shadow);
+		const highlight_l = parse_lightness(result.highlight);
+		expect(front_l).toBeCloseTo(0.65, 2);
+		expect(shadow_l).toBeCloseTo(0.5, 2);
+		expect(highlight_l).toBeCloseTo(0.78, 2);
+	});
+
+	it('preserves original chroma and hue', () => {
+		const original = hex_to_oklch('#3b82f6');
+		const result = compute_accent_colors('#3b82f6');
+		const front_parts = parse_oklch_parts(result.front);
+		expect(front_parts.chroma).toBeCloseTo(original.chroma, 2);
+		expect(front_parts.hue).toBeCloseTo(original.hue, 0);
+	});
+
+	it('handles achromatic colors (black) without NaN hue', () => {
+		const result = compute_accent_colors('#000000');
+		expect(result.front).not.toContain('NaN');
+		expect(result.shadow).not.toContain('NaN');
+		expect(result.highlight).not.toContain('NaN');
+	});
+});
+
+// ─── compute_trunk_color ─────────────────────────────────────────────────
+
+describe('compute_trunk_color', () => {
+	it('returns light mode trunk color when isDark=false', () => {
+		const result = compute_trunk_color(false);
+		expect(result).toBe('oklch(0.45 0.02 60)');
+	});
+
+	it('returns dark mode trunk color when isDark=true', () => {
+		const result = compute_trunk_color(true);
+		expect(result).toBe('oklch(0.35 0.02 60)');
+	});
+});
+
+// ─── oklch_to_css ────────────────────────────────────────────────────────
+
+describe('oklch_to_css', () => {
+	it('formats OKLCH values to CSS string', () => {
+		const result = oklch_to_css({ lightness: 0.65, chroma: 0.15, hue: 250 });
+		expect(result).toBe('oklch(0.65 0.15 250)');
+	});
+
+	it('clamps lightness between 0 and 1', () => {
+		const result = oklch_to_css({ lightness: 1.5, chroma: 0.1, hue: 100 });
+		expect(result).toBe('oklch(1 0.1 100)');
+	});
+});
+
+// ─── Helpers ─────────────────────────────────────────────────────────────
+
+function parse_lightness(css: string): number {
+	const match = css.match(/oklch\(([\d.]+)/);
+	return match ? parseFloat(match[1]) : NaN;
+}
+
+function parse_oklch_parts(css: string): { lightness: number; chroma: number; hue: number } {
+	const match = css.match(/oklch\(([\d.]+)\s+([\d.]+)\s+([\d.]+)\)/);
+	if (!match) {
+		return { lightness: NaN, chroma: NaN, hue: NaN };
+	}
+	return {
+		lightness: parseFloat(match[1]),
+		chroma: parseFloat(match[2]),
+		hue: parseFloat(match[3]),
+	};
+}

--- a/src/lib/components/tree/color_utils.ts
+++ b/src/lib/components/tree/color_utils.ts
@@ -1,0 +1,106 @@
+import type { OklchColor } from './types';
+
+// ─── Hex → OKLCH Conversion ──────────────────────────────────────────────
+
+function parse_hex(hex: string): [number, number, number] {
+	let cleaned = hex.replace(/^#/, '');
+	if (cleaned.length === 3) {
+		cleaned = cleaned[0] + cleaned[0] + cleaned[1] + cleaned[1] + cleaned[2] + cleaned[2];
+	}
+	const r = parseInt(cleaned.slice(0, 2), 16) / 255;
+	const g = parseInt(cleaned.slice(2, 4), 16) / 255;
+	const b = parseInt(cleaned.slice(4, 6), 16) / 255;
+	return [r, g, b];
+}
+
+function srgb_to_linear(c: number): number {
+	return c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+}
+
+function linear_rgb_to_oklab(r: number, g: number, b: number): [number, number, number] {
+	const l = 0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b;
+	const m = 0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b;
+	const s = 0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b;
+
+	const l_root = Math.cbrt(l);
+	const m_root = Math.cbrt(m);
+	const s_root = Math.cbrt(s);
+
+	const L = 0.2104542553 * l_root + 0.793617785 * m_root - 0.0040720468 * s_root;
+	const a = 1.9779984951 * l_root - 2.428592205 * m_root + 0.4505937099 * s_root;
+	const b_val = 0.0259040371 * l_root + 0.7827717662 * m_root - 0.808675766 * s_root;
+
+	return [L, a, b_val];
+}
+
+function oklab_to_oklch(L: number, a: number, b: number): OklchColor {
+	const chroma = Math.sqrt(a * a + b * b);
+	let hue = (Math.atan2(b, a) * 180) / Math.PI;
+	if (hue < 0) {
+		hue += 360;
+	}
+	// For achromatic colors, set hue to 0 to avoid NaN
+	if (chroma < 0.001) {
+		return { lightness: L, chroma, hue: 0 };
+	}
+	return { lightness: L, chroma, hue };
+}
+
+export function hex_to_oklch(hex: string): OklchColor {
+	const [r, g, b] = parse_hex(hex);
+	const [lr, lg, lb] = [srgb_to_linear(r), srgb_to_linear(g), srgb_to_linear(b)];
+	const [L, a, b_val] = linear_rgb_to_oklab(lr, lg, lb);
+	return oklab_to_oklch(L, a, b_val);
+}
+
+// ─── OKLCH → CSS ─────────────────────────────────────────────────────────
+
+export function oklch_to_css(color: OklchColor): string {
+	const l = Math.round(Math.min(1, Math.max(0, color.lightness)) * 100) / 100;
+	const c = Math.round(color.chroma * 100) / 100;
+	const h = Math.round(color.hue * 100) / 100;
+	return `oklch(${l} ${c} ${h})`;
+}
+
+// ─── Accent Color Variants ───────────────────────────────────────────────
+
+const ACCENT_FRONT_LIGHTNESS = 0.65;
+const ACCENT_SHADOW_LIGHTNESS = 0.5;
+const ACCENT_HIGHLIGHT_LIGHTNESS = 0.78;
+
+export function compute_accent_colors(hex: string): {
+	front: string;
+	shadow: string;
+	highlight: string;
+} {
+	const base = hex_to_oklch(hex);
+	return {
+		front: oklch_to_css({
+			lightness: ACCENT_FRONT_LIGHTNESS,
+			chroma: base.chroma,
+			hue: base.hue,
+		}),
+		shadow: oklch_to_css({
+			lightness: ACCENT_SHADOW_LIGHTNESS,
+			chroma: base.chroma,
+			hue: base.hue,
+		}),
+		highlight: oklch_to_css({
+			lightness: ACCENT_HIGHLIGHT_LIGHTNESS,
+			chroma: base.chroma,
+			hue: base.hue,
+		}),
+	};
+}
+
+// ─── Trunk Color ─────────────────────────────────────────────────────────
+
+export function compute_trunk_color(is_dark: boolean): string {
+	return is_dark ? 'oklch(0.35 0.02 60)' : 'oklch(0.45 0.02 60)';
+}
+
+// ─── Ground Shadow ───────────────────────────────────────────────────────
+
+export function compute_ground_color(is_dark: boolean): string {
+	return is_dark ? 'oklch(0.25 0.01 60)' : 'oklch(0.75 0.01 60)';
+}

--- a/src/lib/components/tree/index.ts
+++ b/src/lib/components/tree/index.ts
@@ -1,0 +1,12 @@
+export { default as TreeRenderer } from './TreeRenderer.svelte';
+export { compute_accent_colors, compute_trunk_color, hex_to_oklch } from './color_utils';
+export { compute_attachment_points } from './attachment_points';
+export type {
+	TreeComponentProps,
+	AttachmentPoints,
+	Point2D,
+	AccentColors,
+	OklchColor,
+	TreeComponentGroup,
+} from './types';
+export { STAGE_TO_GROUP, VIEWBOX_WIDTH, VIEWBOX_HEIGHT } from './types';

--- a/src/lib/components/tree/types.ts
+++ b/src/lib/components/tree/types.ts
@@ -1,0 +1,62 @@
+import type { TreeStage, TreeVisualizationTree } from '$lib/types/tree_visualization';
+
+// ─── Geometry ────────────────────────────────────────────────────────────
+
+export interface Point2D {
+	readonly x: number;
+	readonly y: number;
+}
+
+export interface AttachmentPoints {
+	readonly crown: Point2D;
+	readonly trunkBase: Point2D;
+	readonly roots: Point2D;
+}
+
+// ─── Color ───────────────────────────────────────────────────────────────
+
+export interface OklchColor {
+	readonly lightness: number;
+	readonly chroma: number;
+	readonly hue: number;
+}
+
+export interface AccentColors {
+	readonly front: string;
+	readonly shadow: string;
+	readonly highlight: string;
+}
+
+// ─── Component Props ─────────────────────────────────────────────────────
+
+export interface TreeComponentProps {
+	readonly visualization: TreeVisualizationTree;
+	readonly accentColor: string;
+	readonly isDark: boolean;
+}
+
+// ─── Stage → Component Group Mapping ─────────────────────────────────────
+
+export type TreeComponentGroup = 'seed-sprout' | 'sapling' | 'mature-tree' | 'dead-tree';
+
+export const STAGE_TO_GROUP: Readonly<Record<TreeStage, TreeComponentGroup>> = {
+	seed: 'seed-sprout',
+	sprouting: 'seed-sprout',
+	sapling: 'sapling',
+	growing: 'sapling',
+	leafy: 'mature-tree',
+	fruiting: 'mature-tree',
+	autumn: 'mature-tree',
+	ready: 'mature-tree',
+	bare: 'dead-tree',
+	dead: 'dead-tree',
+	stump: 'dead-tree',
+};
+
+// ─── ViewBox Constants ───────────────────────────────────────────────────
+
+export const VIEWBOX_WIDTH = 100;
+export const VIEWBOX_HEIGHT = 150;
+export const CROWN_ZONE_END = 50;
+export const TRUNK_ZONE_END = 110;
+export const GROUND_ZONE_START = 110;


### PR DESCRIPTION
## Description
- 4 SVG component groups rendering low-poly geometric trees: `SeedSprout` (seed, sprouting), `Sapling` (sapling, growing), `MatureTree` (leafy, fruiting, autumn, ready), `DeadTree` (bare, dead, stump)
- `TreeRenderer` dispatcher routes `TreeVisualizationTree` to correct group with Svelte transitions
- OKLCH color system: accent variants at L=65%/50%/78%, dark-mode trunk colors
- Attachment points (crown, trunkBase, roots) computed per stage for overlay positioning
- Ready-stage glow via SVG `feGaussianBlur` + `feMerge` filter
- Storybook stories for all 11 stages + gallery view with color picker

## Resolves
Closes #21

## Testing
- [x] 12 unit tests for `color_utils` (hex→OKLCH, accent variants, trunk color)
- [x] 6 unit tests for `attachment_points` (zone bounds for all 11 stages)
- [x] All checks pass (`check:all`: prettier, oxlint, eslint, stylelint, knip, svelte-check)
- [x] Build passes clean
- [ ] Visual verification in Storybook (HITL)