### PR TITLE
fix(rust): remove dead code, fix tokio::spawn panics, add compile-time guards

### DIFF
--- a/src-tauri/clippy.toml
+++ b/src-tauri/clippy.toml
@@ -1,0 +1,3 @@
+disallowed-methods = [
+    { path = "tokio::spawn", reason = "Use tauri::async_runtime::spawn instead — tokio::spawn panics outside Tokio runtime context (e.g. in Tauri setup)" },
+]

--- a/src-tauri/src/commands/worktree_commands.rs
+++ b/src-tauri/src/commands/worktree_commands.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, State};
 use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader};
 use tokio::process::Command;
-use tokio::task::JoinHandle;
+use tauri::async_runtime::JoinHandle;
 
 use crate::database::connection::DatabaseState;
 
@@ -213,7 +213,7 @@ fn stream_output(
     issue_id: String,
     source: &'static str,
 ) -> JoinHandle<()> {
-    tokio::spawn(async move {
+    tauri::async_runtime::spawn(async move {
         let mut lines = BufReader::new(reader).lines();
         while let Ok(Some(line)) = lines.next_line().await {
             emit_progress(&app_handle, &issue_id, source, &line);

--- a/src-tauri/src/git/branch_detection.rs
+++ b/src-tauri/src/git/branch_detection.rs
@@ -84,14 +84,16 @@ mod tests {
     #[test]
     fn detects_existing_branch() {
         let repo_root = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
-        // The current branch must exist locally
-        let result = resolve_branch_status(repo_root, "4-git-cli-integration");
+        let repository = git2::Repository::discover(repo_root).unwrap();
+        let head = repository.head().unwrap();
+        let branch_name = head.shorthand().unwrap();
+
+        let result = resolve_branch_status(repo_root, branch_name);
         assert!(result.is_ok());
         let status = result.unwrap();
-        // Either Active (if pushed) or Local (if not yet pushed)
         assert!(
             status == BranchStatus::Active || status == BranchStatus::Local,
-            "Expected Active or Local, got {:?}",
+            "Expected Active or Local for current branch '{branch_name}', got {:?}",
             status
         );
     }

--- a/src-tauri/src/git/cli_operations.rs
+++ b/src-tauri/src/git/cli_operations.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 use std::process::Command;
 
 use super::error::GitError;
-use super::types::{is_unsafe_branch_ref, WorktreeInfo};
+use super::types::is_unsafe_branch_ref;
 
 fn run_git_command(working_directory: &Path, args: &[&str]) -> Result<String, GitError> {
     let output = Command::new("git")
@@ -97,70 +97,6 @@ pub fn detect_merge_conflicts(
     }
 }
 
-pub fn verify_branch_ref(working_directory: &Path, branch_name: &str) -> Result<bool, GitError> {
-    if is_unsafe_branch_ref(branch_name) {
-        return Err(GitError::UnsafeBranchRef(branch_name.to_string()));
-    }
-
-    let ref_path = format!("refs/heads/{branch_name}");
-    let (exit_code, _stdout) =
-        run_git_command_with_exit_code(working_directory, &["rev-parse", "--verify", &ref_path])?;
-
-    Ok(exit_code == 0)
-}
-
-pub fn list_worktrees(working_directory: &Path) -> Result<Vec<WorktreeInfo>, GitError> {
-    let output = run_git_command(working_directory, &["worktree", "list", "--porcelain"])?;
-    Ok(parse_worktree_porcelain(&output))
-}
-
-pub fn resolve_repo_root(working_directory: &Path) -> Result<String, GitError> {
-    let output = run_git_command(working_directory, &["rev-parse", "--show-toplevel"])?;
-    Ok(output.trim().to_string())
-}
-
-fn parse_worktree_porcelain(output: &str) -> Vec<WorktreeInfo> {
-    let mut worktrees = Vec::new();
-    let mut current_path: Option<String> = None;
-    let mut current_head: Option<String> = None;
-    let mut current_branch: Option<String> = None;
-    let mut is_bare = false;
-
-    for line in output.lines() {
-        if let Some(path) = line.strip_prefix("worktree ") {
-            // Flush previous entry
-            if let Some(path_value) = current_path.take() {
-                worktrees.push(WorktreeInfo {
-                    path: path_value,
-                    head_commit: current_head.take(),
-                    branch: current_branch.take(),
-                    is_bare,
-                });
-                is_bare = false;
-            }
-            current_path = Some(path.to_string());
-        } else if let Some(head) = line.strip_prefix("HEAD ") {
-            current_head = Some(head.to_string());
-        } else if let Some(branch) = line.strip_prefix("branch ") {
-            current_branch = Some(branch.to_string());
-        } else if line == "bare" {
-            is_bare = true;
-        }
-    }
-
-    // Flush last entry
-    if let Some(path_value) = current_path {
-        worktrees.push(WorktreeInfo {
-            path: path_value,
-            head_commit: current_head,
-            branch: current_branch,
-            is_bare,
-        });
-    }
-
-    worktrees
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -193,85 +129,4 @@ mod tests {
         assert!(matches!(result.unwrap_err(), GitError::UnsafeBranchRef(_)));
     }
 
-    #[test]
-    fn rejects_branch_name_starting_with_dash_for_verify() {
-        let result = verify_branch_ref(Path::new("."), "--malicious");
-        assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), GitError::UnsafeBranchRef(_)));
-    }
-
-    #[test]
-    fn parses_empty_worktree_output() {
-        let result = parse_worktree_porcelain("");
-        assert!(result.is_empty());
-    }
-
-    #[test]
-    fn parses_single_worktree() {
-        let output = "worktree /home/user/repo\nHEAD abc123def\nbranch refs/heads/main\n\n";
-        let result = parse_worktree_porcelain(output);
-
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].path, "/home/user/repo");
-        assert_eq!(result[0].head_commit.as_deref(), Some("abc123def"));
-        assert_eq!(result[0].branch.as_deref(), Some("refs/heads/main"));
-        assert!(!result[0].is_bare);
-    }
-
-    #[test]
-    fn parses_multiple_worktrees() {
-        let output = "\
-worktree /home/user/repo
-HEAD abc123
-branch refs/heads/main
-
-worktree /home/user/repo-wt
-HEAD def456
-branch refs/heads/feature
-
-";
-        let result = parse_worktree_porcelain(output);
-
-        assert_eq!(result.len(), 2);
-        assert_eq!(result[0].path, "/home/user/repo");
-        assert_eq!(result[0].branch.as_deref(), Some("refs/heads/main"));
-        assert_eq!(result[1].path, "/home/user/repo-wt");
-        assert_eq!(result[1].branch.as_deref(), Some("refs/heads/feature"));
-    }
-
-    #[test]
-    fn parses_bare_worktree() {
-        let output = "worktree /home/user/repo.git\nbare\n\n";
-        let result = parse_worktree_porcelain(output);
-
-        assert_eq!(result.len(), 1);
-        assert!(result[0].is_bare);
-        assert!(result[0].head_commit.is_none());
-        assert!(result[0].branch.is_none());
-    }
-
-    // Integration tests that run against the actual repo
-    #[test]
-    fn verify_branch_ref_finds_existing_branch_in_this_repo() {
-        let repo_root = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
-        let result = verify_branch_ref(repo_root, "4-git-cli-integration");
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn list_worktrees_succeeds_in_this_repo() {
-        let repo_root = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
-        let result = list_worktrees(repo_root);
-        assert!(result.is_ok());
-        let worktrees = result.unwrap();
-        assert!(!worktrees.is_empty(), "Should find at least one worktree");
-    }
-
-    #[test]
-    fn resolve_repo_root_succeeds_in_this_repo() {
-        let repo_root = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
-        let result = resolve_repo_root(repo_root);
-        assert!(result.is_ok());
-        assert!(!result.unwrap().is_empty());
-    }
 }

--- a/src-tauri/src/git/fetch_coordinator.rs
+++ b/src-tauri/src/git/fetch_coordinator.rs
@@ -72,12 +72,6 @@ impl FetchCoordinator {
 
         result
     }
-
-    pub fn reset(&self) {
-        if let Ok(mut map) = self.in_flight.lock() {
-            map.clear();
-        }
-    }
 }
 
 fn run_git_fetch(repo_root: &Path) -> Result<(), GitError> {
@@ -107,21 +101,6 @@ mod tests {
     #[test]
     fn new_coordinator_has_no_in_flight_fetches() {
         let coordinator = FetchCoordinator::new();
-        let map = coordinator.in_flight.lock().unwrap();
-        assert!(map.is_empty());
-    }
-
-    #[test]
-    fn reset_clears_all_entries() {
-        let coordinator = FetchCoordinator::new();
-        {
-            let mut map = coordinator.in_flight.lock().unwrap();
-            map.insert(
-                PathBuf::from("/some/repo"),
-                Arc::new(Mutex::new(Some(Ok(())))),
-            );
-        }
-        coordinator.reset();
         let map = coordinator.in_flight.lock().unwrap();
         assert!(map.is_empty());
     }

--- a/src-tauri/src/git/types.rs
+++ b/src-tauri/src/git/types.rs
@@ -22,14 +22,6 @@ impl BranchStatus {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct WorktreeInfo {
-    pub path: String,
-    pub head_commit: Option<String>,
-    pub branch: Option<String>,
-    pub is_bare: bool,
-}
-
 /// Rejects branch refs starting with `-` to prevent argument injection.
 pub fn is_unsafe_branch_ref(ref_name: &str) -> bool {
     ref_name.starts_with('-')

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(unused_imports, dead_code, clippy::disallowed_methods)]
+
 mod commands;
 mod database;
 mod git;

--- a/src-tauri/src/models/notification.rs
+++ b/src-tauri/src/models/notification.rs
@@ -12,14 +12,6 @@ pub enum NotificationEventType {
 }
 
 impl NotificationEventType {
-    pub const ALL: &[NotificationEventType] = &[
-        NotificationEventType::NeedsInput,
-        NotificationEventType::NeedsReview,
-        NotificationEventType::Finished,
-        NotificationEventType::Errored,
-        NotificationEventType::PrReady,
-    ];
-
     pub fn as_str(&self) -> &'static str {
         match self {
             NotificationEventType::NeedsInput => "needs-input",
@@ -27,28 +19,6 @@ impl NotificationEventType {
             NotificationEventType::Finished => "finished",
             NotificationEventType::Errored => "errored",
             NotificationEventType::PrReady => "pr-ready",
-        }
-    }
-
-    pub fn from_str(value: &str) -> Option<NotificationEventType> {
-        match value {
-            "needs-input" => Some(NotificationEventType::NeedsInput),
-            "needs-review" => Some(NotificationEventType::NeedsReview),
-            "finished" => Some(NotificationEventType::Finished),
-            "errored" => Some(NotificationEventType::Errored),
-            "pr-ready" => Some(NotificationEventType::PrReady),
-            _ => None,
-        }
-    }
-
-    /// Default sound file name shipped in resources/sounds/.
-    pub fn default_sound_file(&self) -> Option<&'static str> {
-        match self {
-            NotificationEventType::NeedsInput | NotificationEventType::Errored => {
-                Some("urgent.wav")
-            }
-            NotificationEventType::NeedsReview => Some("gentle.wav"),
-            _ => None,
         }
     }
 }
@@ -134,32 +104,6 @@ impl NotificationConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn event_type_round_trip() {
-        for event_type in NotificationEventType::ALL {
-            let as_str = event_type.as_str();
-            let parsed = NotificationEventType::from_str(as_str);
-            assert_eq!(parsed, Some(*event_type), "round-trip failed for {as_str}");
-        }
-    }
-
-    #[test]
-    fn event_type_from_str_unknown_returns_none() {
-        assert_eq!(NotificationEventType::from_str("unknown"), None);
-    }
-
-    #[test]
-    fn defaults_cover_all_event_types() {
-        let defaults = NotificationConfig::defaults();
-        for event_type in NotificationEventType::ALL {
-            assert!(
-                defaults.iter().any(|c| c.event_type == event_type.as_str()),
-                "missing default for {}",
-                event_type.as_str()
-            );
-        }
-    }
 
     #[test]
     fn needs_input_defaults_all_channels_on() {

--- a/src-tauri/src/session/claude_code_provider.rs
+++ b/src-tauri/src/session/claude_code_provider.rs
@@ -77,7 +77,6 @@ impl SessionProvider for ClaudeCodeProvider {
             stdout,
             stderr,
             pid,
-            session_id: None,
         })
     }
 

--- a/src-tauri/src/session/discovery.rs
+++ b/src-tauri/src/session/discovery.rs
@@ -97,19 +97,6 @@ impl SessionDiscoverer {
         }
     }
 
-    /// For testing: create with custom directories.
-    #[cfg(test)]
-    pub fn with_directories(
-        projects_directory: PathBuf,
-        sessions_directory: PathBuf,
-    ) -> Self {
-        Self {
-            system: System::new(),
-            claude_projects_directory: projects_directory,
-            claude_sessions_directory: sessions_directory,
-        }
-    }
-
     /// Discover all running Claude Code sessions not managed by BamGit.
     /// `excluded_pids` are PIDs of sessions already managed by BamGit.
     pub fn discover_sessions(&mut self, excluded_pids: &[u32]) -> Vec<DiscoveredSession> {

--- a/src-tauri/src/session/discovery_polling.rs
+++ b/src-tauri/src/session/discovery_polling.rs
@@ -1,4 +1,3 @@
-use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -37,7 +36,7 @@ impl DiscoveryPoller {
 
         let running = Arc::clone(&self.running);
 
-        tokio::spawn(async move {
+        tauri::async_runtime::spawn(async move {
             let db_path = match app_handle.path().app_data_dir() {
                 Ok(dir) => dir.join("bamgit.db"),
                 Err(_) => {

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -55,7 +55,7 @@ impl SessionManager {
 
         let actor_session_id = session_id.clone();
         let actors_ref = Arc::clone(&self.actors);
-        tokio::spawn(async move {
+        tauri::async_runtime::spawn(async move {
             session_actor::run_actor(
                 actor_session_id.clone(),
                 handle,

--- a/src-tauri/src/session/provider.rs
+++ b/src-tauri/src/session/provider.rs
@@ -27,8 +27,6 @@ pub struct SessionHandle {
     pub stdout: Option<ChildStdout>,
     pub stderr: Option<ChildStderr>,
     pub pid: u32,
-    /// Captured from the first SessionInit event.
-    pub session_id: Option<String>,
 }
 
 /// Unified event type that all providers map their protocol to.


### PR DESCRIPTION
## Description
- Fix app crash on startup: replace `tokio::spawn` with `tauri::async_runtime::spawn` in discovery poller (runtime panic outside Tokio context)
- Fix 2 latent `tokio::spawn` panics in worktree commands and session manager
- Remove all dead code: unused git worktree ops, `WorktreeInfo`, `FetchCoordinator::reset`, `NotificationEventType` helpers, `SessionHandle::session_id`, `SessionDiscoverer::with_directories`
- Add `#![deny(unused_imports, dead_code, clippy::disallowed_methods)]` to `lib.rs` — dead code and unused imports are now compile errors
- Add `clippy.toml` banning `tokio::spawn` with guidance to use `tauri::async_runtime::spawn`
- Fix flaky integration test: use dynamic HEAD branch instead of hardcoded `4-git-cli-integration`

## Testing
- [x] All checks pass (`check:all`: prettier, oxlint, eslint, stylelint, knip, svelte-check)
- [x] Build passes clean
- [x] Clippy clean with new `deny` attributes