### PR TITLE
#22 feat(viz): potted plant SVG components

### DIFF
--- a/src/lib/components/potted-plant/PotBase.svelte
+++ b/src/lib/components/potted-plant/PotBase.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+	interface Props {
+		ground_color: string;
+		is_dark: boolean;
+	}
+
+	let { ground_color, is_dark }: Props = $props();
+
+	const pot_front = $derived(is_dark ? 'oklch(0.40 0.10 45)' : 'oklch(0.55 0.12 45)');
+	const pot_shadow = $derived(is_dark ? 'oklch(0.32 0.08 45)' : 'oklch(0.45 0.10 45)');
+	const pot_rim = $derived(is_dark ? 'oklch(0.48 0.10 45)' : 'oklch(0.62 0.12 45)');
+</script>
+
+<g data-component="pot-base">
+	<!-- Ground shadow ellipse -->
+	<ellipse cx="40" cy="97" rx="22" ry="4" fill={ground_color} opacity="0.6" />
+
+	<!-- Pot body: faceted trapezoid (wider at top, narrower at bottom) -->
+	<!-- Front face -->
+	<polygon points="18,62 62,62 56,95 24,95" fill={pot_front} />
+	<!-- Left shadow facet (darker side) -->
+	<polygon points="18,62 30,62 26,95 24,95" fill={pot_shadow} />
+
+	<!-- Rim band -->
+	<polygon points="16,58 64,58 62,65 18,65" fill={pot_rim} />
+	<!-- Rim highlight facet -->
+	<polygon points="16,58 40,58 40,62 18,62" fill={pot_front} />
+
+	<!-- Bottom edge -->
+	<line x1="24" y1="95" x2="56" y2="95" stroke={pot_shadow} stroke-width="1" />
+</g>

--- a/src/lib/components/potted-plant/PottedDried.svelte
+++ b/src/lib/components/potted-plant/PottedDried.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	import type { AccentColors } from '../tree/types';
+	import { compute_potted_plant_attachment_points } from './attachment_points';
+	import PotBase from './PotBase.svelte';
+
+	interface Props {
+		accent: AccentColors;
+		trunk_color: string;
+		ground_color: string;
+		is_dark: boolean;
+	}
+
+	let { accent, trunk_color, ground_color, is_dark }: Props = $props();
+
+	const attachment_points = $derived(compute_potted_plant_attachment_points('dried'));
+</script>
+
+<g data-stage="dried" data-attachment-points={JSON.stringify(attachment_points)}>
+	<PotBase {ground_color} {is_dark} />
+
+	<!-- Cracked dry soil surface -->
+	<polygon points="20,62 60,62 58,66 22,66" fill={ground_color} />
+	<!-- Soil crack lines -->
+	<line x1="30" y1="62" x2="34" y2="66" stroke={trunk_color} stroke-width="0.5" opacity="0.5" />
+	<line x1="46" y1="62" x2="50" y2="66" stroke={trunk_color} stroke-width="0.5" opacity="0.5" />
+
+	<!-- Dead stem (tilted, broken) -->
+	<polygon points="38,40 42,38 43,64 39,64" fill={trunk_color} />
+	<!-- Break point -->
+	<polygon points="38,40 42,38 44,42 40,44" fill={ground_color} />
+
+	<!-- Remaining branch stubs -->
+	<line x1="39" y1="48" x2="30" y2="42" stroke={trunk_color} stroke-width="1.5" />
+	<line x1="42" y1="52" x2="50" y2="46" stroke={trunk_color} stroke-width="1.2" />
+
+	<!-- Single dried leaf on ground near pot -->
+	<polygon points="52,92 58,88 56,93" fill={accent.shadow} opacity="0.4" />
+</g>

--- a/src/lib/components/potted-plant/PottedPlant.svelte
+++ b/src/lib/components/potted-plant/PottedPlant.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+	import type { PottedPlantStage } from '$lib/types/tree_visualization';
+	import type { AccentColors } from '../tree/types';
+	import { compute_potted_plant_attachment_points } from './attachment_points';
+	import PotBase from './PotBase.svelte';
+
+	interface Props {
+		stage: Extract<PottedPlantStage, 'small-plant' | 'flowering'>;
+		accent: AccentColors;
+		trunk_color: string;
+		ground_color: string;
+		is_dark: boolean;
+	}
+
+	let { stage, accent, trunk_color, ground_color, is_dark }: Props = $props();
+
+	const attachment_points = $derived(compute_potted_plant_attachment_points(stage));
+</script>
+
+<g data-stage={stage} data-attachment-points={JSON.stringify(attachment_points)}>
+	<PotBase {ground_color} {is_dark} />
+
+	<!-- Stem -->
+	<rect x="38" y="32" width="4" height="32" fill={trunk_color} />
+
+	<!-- Small angular canopy — layered triangles -->
+	<!-- Back layer (shadow) -->
+	<polygon points="40,22 26,48 54,48" fill={accent.shadow} />
+	<!-- Front layer -->
+	<polygon points="40,26 30,48 50,48" fill={accent.front} />
+	<!-- Highlight facet -->
+	<polygon points="40,26 46,38 40,38" fill={accent.highlight} />
+
+	{#if stage === 'small-plant'}
+		<!-- Extra small side leaves -->
+		<polygon points="30,42 22,36 28,44" fill={accent.front} />
+		<polygon points="50,42 58,36 52,44" fill={accent.front} />
+	{:else}
+		<!-- Flowering: additional canopy volume -->
+		<polygon points="40,18 22,46 58,46" fill={accent.shadow} opacity="0.5" />
+
+		<!-- Angular flowers at crown (accent.highlight colored) -->
+		<!-- Center flower -->
+		<polygon points="40,18 37,24 43,24" fill={accent.highlight} />
+		<circle cx="40" cy="21" r="2" fill={accent.highlight} />
+
+		<!-- Left flower -->
+		<polygon points="28,30 25,36 31,36" fill={accent.highlight} />
+		<circle cx="28" cy="33" r="1.5" fill={accent.highlight} />
+
+		<!-- Right flower -->
+		<polygon points="52,30 49,36 55,36" fill={accent.highlight} />
+		<circle cx="52" cy="33" r="1.5" fill={accent.highlight} />
+	{/if}
+</g>

--- a/src/lib/components/potted-plant/PottedPlantRenderer.stories.svelte
+++ b/src/lib/components/potted-plant/PottedPlantRenderer.stories.svelte
@@ -1,0 +1,169 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import { PottedPlantRenderer } from './index';
+	import ThemeDecorator from '$lib/storybook/ThemeDecorator.svelte';
+
+	const { Story } = defineMeta({
+		title: 'Viz/PottedPlantRenderer',
+		component: PottedPlantRenderer,
+		// @ts-expect-error — Storybook decorator typing doesn't match Svelte 5 Component type
+		decorators: [() => ThemeDecorator],
+		tags: ['autodocs'],
+		argTypes: {
+			accent_color: { control: 'color' },
+			is_dark: { control: 'boolean' },
+		},
+	});
+</script>
+
+<script lang="ts">
+	import type {
+		TreeVisualizationPottedPlant,
+		PottedPlantStage,
+	} from '$lib/types/tree_visualization';
+
+	interface StoryArgs {
+		visualization?: TreeVisualizationPottedPlant;
+		accent_color: string;
+		is_dark?: boolean;
+	}
+
+	const ALL_STAGES: PottedPlantStage[] = [
+		'pot-with-soil',
+		'sprout',
+		'small-plant',
+		'flowering',
+		'dried',
+	];
+
+	function make_plant(
+		stage: PottedPlantStage,
+		extras: Partial<TreeVisualizationPottedPlant> = {},
+	): TreeVisualizationPottedPlant {
+		return {
+			kind: 'potted-plant',
+			stage,
+			overlays: [],
+			...extras,
+		};
+	}
+</script>
+
+<Story
+	name="Pot with Soil"
+	args={{ visualization: make_plant('pot-with-soil'), accent_color: '#22c55e', is_dark: false }}
+>
+	{#snippet template(args: StoryArgs)}
+		<div class="w-24">
+			<PottedPlantRenderer
+				visualization={args.visualization}
+				accent_color={args.accent_color}
+				is_dark={args.is_dark}
+			/>
+		</div>
+	{/snippet}
+</Story>
+
+<Story
+	name="Sprout"
+	args={{ visualization: make_plant('sprout'), accent_color: '#22c55e', is_dark: false }}
+>
+	{#snippet template(args: StoryArgs)}
+		<div class="w-24">
+			<PottedPlantRenderer
+				visualization={args.visualization}
+				accent_color={args.accent_color}
+				is_dark={args.is_dark}
+			/>
+		</div>
+	{/snippet}
+</Story>
+
+<Story
+	name="Small Plant"
+	args={{ visualization: make_plant('small-plant'), accent_color: '#3b82f6', is_dark: false }}
+>
+	{#snippet template(args: StoryArgs)}
+		<div class="w-24">
+			<PottedPlantRenderer
+				visualization={args.visualization}
+				accent_color={args.accent_color}
+				is_dark={args.is_dark}
+			/>
+		</div>
+	{/snippet}
+</Story>
+
+<Story
+	name="Flowering"
+	args={{ visualization: make_plant('flowering'), accent_color: '#ec4899', is_dark: false }}
+>
+	{#snippet template(args: StoryArgs)}
+		<div class="w-24">
+			<PottedPlantRenderer
+				visualization={args.visualization}
+				accent_color={args.accent_color}
+				is_dark={args.is_dark}
+			/>
+		</div>
+	{/snippet}
+</Story>
+
+<Story
+	name="Dried"
+	args={{ visualization: make_plant('dried'), accent_color: '#6b7280', is_dark: false }}
+>
+	{#snippet template(args: StoryArgs)}
+		<div class="w-24">
+			<PottedPlantRenderer
+				visualization={args.visualization}
+				accent_color={args.accent_color}
+				is_dark={args.is_dark}
+			/>
+		</div>
+	{/snippet}
+</Story>
+
+<Story
+	name="All Stages Gallery"
+	args={{ visualization: make_plant('pot-with-soil'), accent_color: '#22c55e', is_dark: false }}
+>
+	{#snippet template(args: StoryArgs)}
+		<div class="grid grid-cols-5 gap-4">
+			{#each ALL_STAGES as stage (stage)}
+				<div class="flex flex-col items-center gap-1">
+					<div class="w-20">
+						<PottedPlantRenderer
+							visualization={make_plant(stage)}
+							accent_color={args.accent_color}
+							is_dark={args.is_dark}
+						/>
+					</div>
+					<span class="text-xs text-muted-foreground">{stage}</span>
+				</div>
+			{/each}
+		</div>
+	{/snippet}
+</Story>
+
+<Story
+	name="Dark Mode Gallery"
+	args={{ visualization: make_plant('pot-with-soil'), accent_color: '#22c55e', is_dark: true }}
+>
+	{#snippet template(args: StoryArgs)}
+		<div class="grid grid-cols-5 gap-4 rounded-lg bg-background p-4">
+			{#each ALL_STAGES as stage (stage)}
+				<div class="flex flex-col items-center gap-1">
+					<div class="w-20">
+						<PottedPlantRenderer
+							visualization={make_plant(stage)}
+							accent_color={args.accent_color}
+							is_dark={args.is_dark}
+						/>
+					</div>
+					<span class="text-xs text-muted-foreground">{stage}</span>
+				</div>
+			{/each}
+		</div>
+	{/snippet}
+</Story>

--- a/src/lib/components/potted-plant/PottedPlantRenderer.svelte
+++ b/src/lib/components/potted-plant/PottedPlantRenderer.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+	import type { TreeVisualizationPottedPlant } from '$lib/types/tree_visualization';
+	import { POTTED_STAGE_TO_GROUP, POTTED_VIEWBOX_WIDTH, POTTED_VIEWBOX_HEIGHT } from './types';
+	import {
+		compute_accent_colors,
+		compute_trunk_color,
+		compute_ground_color,
+	} from '../tree/color_utils';
+	import PottedSoil from './PottedSoil.svelte';
+	import PottedPlant from './PottedPlant.svelte';
+	import PottedDried from './PottedDried.svelte';
+	import { fade } from 'svelte/transition';
+
+	interface Props {
+		visualization?: TreeVisualizationPottedPlant;
+		accent_color: string;
+		is_dark?: boolean;
+	}
+
+	let { visualization, accent_color, is_dark = false }: Props = $props();
+
+	const group = $derived(visualization ? POTTED_STAGE_TO_GROUP[visualization.stage] : undefined);
+	const accent = $derived(compute_accent_colors(accent_color));
+	const trunk_color = $derived(compute_trunk_color(is_dark));
+	const ground_color = $derived(compute_ground_color(is_dark));
+</script>
+
+{#if visualization}
+	<svg
+		viewBox="0 0 {POTTED_VIEWBOX_WIDTH} {POTTED_VIEWBOX_HEIGHT}"
+		xmlns="http://www.w3.org/2000/svg"
+		role="img"
+		aria-label="Potted plant visualization: {visualization.stage} stage"
+	>
+		{#key group}
+			<g transition:fade={{ duration: 200 }}>
+				{#if group === 'soil-sprout'}
+					<PottedSoil
+						stage={visualization.stage as 'pot-with-soil' | 'sprout'}
+						{accent}
+						{trunk_color}
+						{ground_color}
+						{is_dark}
+					/>
+				{:else if group === 'plant'}
+					<PottedPlant
+						stage={visualization.stage as 'small-plant' | 'flowering'}
+						{accent}
+						{trunk_color}
+						{ground_color}
+						{is_dark}
+					/>
+				{:else if group === 'dried'}
+					<PottedDried {accent} {trunk_color} {ground_color} {is_dark} />
+				{/if}
+			</g>
+		{/key}
+	</svg>
+{/if}

--- a/src/lib/components/potted-plant/PottedSoil.svelte
+++ b/src/lib/components/potted-plant/PottedSoil.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	import type { PottedPlantStage } from '$lib/types/tree_visualization';
+	import type { AccentColors } from '../tree/types';
+	import { compute_potted_plant_attachment_points } from './attachment_points';
+	import PotBase from './PotBase.svelte';
+
+	interface Props {
+		stage: Extract<PottedPlantStage, 'pot-with-soil' | 'sprout'>;
+		accent: AccentColors;
+		trunk_color: string;
+		ground_color: string;
+		is_dark: boolean;
+	}
+
+	let { stage, accent, trunk_color, ground_color, is_dark }: Props = $props();
+
+	const attachment_points = $derived(compute_potted_plant_attachment_points(stage));
+</script>
+
+<g data-stage={stage} data-attachment-points={JSON.stringify(attachment_points)}>
+	<PotBase {ground_color} {is_dark} />
+
+	<!-- Soil surface inside pot -->
+	<polygon points="20,62 60,62 58,66 22,66" fill={ground_color} />
+
+	{#if stage === 'sprout'}
+		<!-- Thin stem rising from soil -->
+		<rect x="38" y="48" width="4" height="16" fill={trunk_color} />
+
+		<!-- Left cotyledon leaf (angular) -->
+		<polygon points="38,52 28,44 32,50" fill={accent.front} />
+		<polygon points="38,52 28,44 30,47" fill={accent.highlight} />
+
+		<!-- Right cotyledon leaf (angular) -->
+		<polygon points="42,50 52,42 48,48" fill={accent.front} />
+		<polygon points="42,50 52,42 50,45" fill={accent.shadow} />
+	{/if}
+</g>

--- a/src/lib/components/potted-plant/attachment_points.test.ts
+++ b/src/lib/components/potted-plant/attachment_points.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { compute_potted_plant_attachment_points } from './attachment_points';
+import type { PottedPlantStage } from '$lib/types/tree_visualization';
+import {
+	POTTED_VIEWBOX_WIDTH,
+	POTTED_VIEWBOX_HEIGHT,
+	POTTED_GROUND_ZONE_START,
+	POTTED_PLANT_ZONE_END,
+} from './types';
+
+const ALL_STAGES: PottedPlantStage[] = [
+	'pot-with-soil',
+	'sprout',
+	'small-plant',
+	'flowering',
+	'dried',
+];
+
+describe('compute_potted_plant_attachment_points', () => {
+	it('returns valid points for all 5 stages', () => {
+		for (const stage of ALL_STAGES) {
+			const points = compute_potted_plant_attachment_points(stage);
+			expect(points.crown).toBeDefined();
+			expect(points.trunkBase).toBeDefined();
+			expect(points.roots).toBeDefined();
+		}
+	});
+
+	it('all points x are within viewBox width', () => {
+		for (const stage of ALL_STAGES) {
+			const points = compute_potted_plant_attachment_points(stage);
+			expect(points.crown.x).toBeGreaterThanOrEqual(0);
+			expect(points.crown.x).toBeLessThanOrEqual(POTTED_VIEWBOX_WIDTH);
+			expect(points.trunkBase.x).toBeGreaterThanOrEqual(0);
+			expect(points.trunkBase.x).toBeLessThanOrEqual(POTTED_VIEWBOX_WIDTH);
+			expect(points.roots.x).toBeGreaterThanOrEqual(0);
+			expect(points.roots.x).toBeLessThanOrEqual(POTTED_VIEWBOX_WIDTH);
+		}
+	});
+
+	it('all points y are within viewBox height', () => {
+		for (const stage of ALL_STAGES) {
+			const points = compute_potted_plant_attachment_points(stage);
+			expect(points.crown.y).toBeGreaterThanOrEqual(0);
+			expect(points.crown.y).toBeLessThanOrEqual(POTTED_VIEWBOX_HEIGHT);
+			expect(points.trunkBase.y).toBeGreaterThanOrEqual(0);
+			expect(points.trunkBase.y).toBeLessThanOrEqual(POTTED_VIEWBOX_HEIGHT);
+			expect(points.roots.y).toBeGreaterThanOrEqual(0);
+			expect(points.roots.y).toBeLessThanOrEqual(POTTED_VIEWBOX_HEIGHT);
+		}
+	});
+
+	it('points x are centered near viewBox midpoint', () => {
+		const midX = POTTED_VIEWBOX_WIDTH / 2;
+		for (const stage of ALL_STAGES) {
+			const points = compute_potted_plant_attachment_points(stage);
+			expect(points.crown.x).toBe(midX);
+			expect(points.trunkBase.x).toBe(midX);
+			expect(points.roots.x).toBe(midX);
+		}
+	});
+
+	it('crown y rises as plant grows (flowering < small-plant < sprout < pot-with-soil)', () => {
+		const soil = compute_potted_plant_attachment_points('pot-with-soil');
+		const sprout = compute_potted_plant_attachment_points('sprout');
+		const small = compute_potted_plant_attachment_points('small-plant');
+		const flowering = compute_potted_plant_attachment_points('flowering');
+
+		// Lower y = higher in SVG coordinate space
+		expect(soil.crown.y).toBeGreaterThan(sprout.crown.y);
+		expect(sprout.crown.y).toBeGreaterThan(small.crown.y);
+		expect(small.crown.y).toBeGreaterThan(flowering.crown.y);
+	});
+
+	it('flowering crown is within plant zone (y <= plant zone end)', () => {
+		const flowering = compute_potted_plant_attachment_points('flowering');
+		expect(flowering.crown.y).toBeLessThanOrEqual(POTTED_PLANT_ZONE_END);
+	});
+
+	it('trunkBase is near pot zone for all stages', () => {
+		for (const stage of ALL_STAGES) {
+			const points = compute_potted_plant_attachment_points(stage);
+			expect(points.trunkBase.y).toBeGreaterThanOrEqual(POTTED_GROUND_ZONE_START - 15);
+			expect(points.trunkBase.y).toBeLessThanOrEqual(POTTED_GROUND_ZONE_START + 10);
+		}
+	});
+
+	it('roots are in ground zone (y >= ground zone start)', () => {
+		for (const stage of ALL_STAGES) {
+			const points = compute_potted_plant_attachment_points(stage);
+			expect(points.roots.y).toBeGreaterThanOrEqual(POTTED_GROUND_ZONE_START);
+		}
+	});
+
+	it('dried crown is higher than pot-with-soil (still has structure)', () => {
+		const soil = compute_potted_plant_attachment_points('pot-with-soil');
+		const dried = compute_potted_plant_attachment_points('dried');
+		expect(dried.crown.y).toBeLessThan(soil.crown.y);
+	});
+});

--- a/src/lib/components/potted-plant/attachment_points.ts
+++ b/src/lib/components/potted-plant/attachment_points.ts
@@ -1,0 +1,42 @@
+import type { PottedPlantStage } from '$lib/types/tree_visualization';
+import type { AttachmentPoints } from '../tree/types';
+
+/**
+ * Computes overlay attachment points for each potted plant stage.
+ * Points are in SVG coordinate space (viewBox 0 0 80 120).
+ * Plant zone: y 0–55, Pot zone: y 55–95, Ground zone: y 95–120.
+ */
+export function compute_potted_plant_attachment_points(stage: PottedPlantStage): AttachmentPoints {
+	switch (stage) {
+		case 'pot-with-soil':
+			return {
+				crown: { x: 40, y: 58 },
+				trunkBase: { x: 40, y: 88 },
+				roots: { x: 40, y: 100 },
+			};
+		case 'sprout':
+			return {
+				crown: { x: 40, y: 48 },
+				trunkBase: { x: 40, y: 88 },
+				roots: { x: 40, y: 100 },
+			};
+		case 'small-plant':
+			return {
+				crown: { x: 40, y: 30 },
+				trunkBase: { x: 40, y: 85 },
+				roots: { x: 40, y: 100 },
+			};
+		case 'flowering':
+			return {
+				crown: { x: 40, y: 18 },
+				trunkBase: { x: 40, y: 85 },
+				roots: { x: 40, y: 100 },
+			};
+		case 'dried':
+			return {
+				crown: { x: 40, y: 40 },
+				trunkBase: { x: 40, y: 88 },
+				roots: { x: 40, y: 100 },
+			};
+	}
+}

--- a/src/lib/components/potted-plant/index.ts
+++ b/src/lib/components/potted-plant/index.ts
@@ -1,0 +1,4 @@
+export { default as PottedPlantRenderer } from './PottedPlantRenderer.svelte';
+export { compute_potted_plant_attachment_points } from './attachment_points';
+export type { PottedPlantComponentProps, PottedPlantComponentGroup } from './types';
+export { POTTED_STAGE_TO_GROUP, POTTED_VIEWBOX_WIDTH, POTTED_VIEWBOX_HEIGHT } from './types';

--- a/src/lib/components/potted-plant/types.ts
+++ b/src/lib/components/potted-plant/types.ts
@@ -1,0 +1,32 @@
+import type { PottedPlantStage, TreeVisualizationPottedPlant } from '$lib/types/tree_visualization';
+
+// ─── Component Props ─────────────────────────────────────────────────────
+
+export interface PottedPlantComponentProps {
+	readonly visualization: TreeVisualizationPottedPlant;
+	readonly accent_color: string;
+	readonly is_dark: boolean;
+}
+
+// ─── Stage → Component Group Mapping ─────────────────────────────────────
+
+export type PottedPlantComponentGroup = 'soil-sprout' | 'plant' | 'dried';
+
+export const POTTED_STAGE_TO_GROUP: Readonly<Record<PottedPlantStage, PottedPlantComponentGroup>> =
+	{
+		'pot-with-soil': 'soil-sprout',
+		sprout: 'soil-sprout',
+		'small-plant': 'plant',
+		flowering: 'plant',
+		dried: 'dried',
+	};
+
+// ─── ViewBox Constants ───────────────────────────────────────────────────
+
+export const POTTED_VIEWBOX_WIDTH = 80;
+export const POTTED_VIEWBOX_HEIGHT = 120;
+
+/** Plant canopy zone: y 0–55 */
+export const POTTED_PLANT_ZONE_END = 55;
+/** Ground zone: y 95–120 (pot body occupies y 55–95) */
+export const POTTED_GROUND_ZONE_START = 95;


### PR DESCRIPTION
## Description
- Adds 5-stage potted plant SVG components for worktree-less issues: `pot-with-soil`, `sprout`, `small-plant`, `flowering`, `dried`
- Mirrors the tree component architecture (#21) with a smaller 80×120 viewBox for visual distinction
- Reuses color utilities (accent/trunk/ground) from the tree module — no duplication
- Svelte fade transitions between stage groups via `{#key group}` + `transition:fade`
- Storybook stories for each stage + light/dark gallery views

## Resolves
Closes #22

## Testing
- [x] 9 attachment-points tests (geometry validity, zone bounds, crown-rises progression)
- [x] svelte-autofixer clean on all .svelte files
- [x] oxlint + svelte-check pass (0 new errors introduced)
- [ ] Storybook visual review: accent color tints canopy/flowers; dark mode toggles pot/trunk/ground colors; potted plants visibly smaller than trees

## Art Decisions (HITL review welcome)
- Terracotta pot with faceted trapezoid + rim band + left shadow facet
- Angular triangular canopy layers for small-plant/flowering
- Flowering adds small angular flower shapes in `accent.highlight`
- Dried shows cracked soil, tilted broken stem, single fallen leaf