### PR TITLE
chore(storybook): silence Vite root warning on Windows, sync before dev

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,7 +1,7 @@
 import type { StorybookConfig } from '@storybook/sveltekit';
 
 const config: StorybookConfig = {
-	stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|ts|svelte)'],
+	stories: ['../src/**/*.stories.@(js|ts|svelte)'],
 	addons: [
 		'@storybook/addon-svelte-csf',
 		'@chromatic-com/storybook',
@@ -10,6 +10,14 @@ const config: StorybookConfig = {
 		'@storybook/addon-docs',
 	],
 	framework: '@storybook/sveltekit',
+	// SvelteKit's vite plugin posixifies the project root and warns on Windows
+	// when Storybook's builder provides a backslash-separated root. Normalize
+	// separators here so the initial and resolved roots match, silencing the
+	// cosmetic "Vite config options will be overridden by SvelteKit: - root" warning.
+	viteFinal: async (config) => ({
+		...config,
+		root: config.root?.replace(/\\/g, '/') ?? process.cwd().replace(/\\/g, '/'),
+	}),
 };
 
 export default config;

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
 		"test:e2e": "playwright test --pass-with-no-tests",
 		"prepare": "husky",
 		"tauri": "tauri",
-		"storybook": "storybook dev -p 6006",
-		"build:storybook": "storybook build"
+		"storybook": "svelte-kit sync && storybook dev -p 6006",
+		"build:storybook": "svelte-kit sync && storybook build"
 	},
 	"dependencies": {
 		"@tauri-apps/api": "^2",


### PR DESCRIPTION
## Summary
- Normalize `root` in `viteFinal` to forward slashes so SvelteKit's posixified root matches Storybook's, eliminating the cosmetic `Vite config options will be overridden by SvelteKit: - root` warning on Windows
- Run `svelte-kit sync` before `storybook dev`/`build` so generated types are present on fresh clones
- Drop `*.mdx` from the stories glob (no MDX stories in repo)

## Test plan
- [ ] `pnpm storybook` runs without the Vite `root` override warning on Windows
- [ ] `pnpm build:storybook` succeeds from a clean checkout
- [ ] Existing stories still load