### PR TITLE
#24 feat(viz): Forest Layout Manager

### DIFF
--- a/src/lib/engine/forest_layout.test.ts
+++ b/src/lib/engine/forest_layout.test.ts
@@ -1,0 +1,370 @@
+import { describe, it, expect } from 'vitest';
+import {
+	compute_forest_layout,
+	type ForestLayoutItem,
+	type ForestLayoutItemOak,
+	type ForestLayoutItemTree,
+	type ForestLayoutItemPottedPlant,
+	type Viewport,
+	type PositionedForestItem,
+	MIN_SPACING_PX,
+} from './forest_layout';
+
+// ─── Factories ──────────────────────────────────────────────────────────
+
+function create_viewport(overrides: Partial<Viewport> = {}): Viewport {
+	return { width: 1200, height: 800, ...overrides };
+}
+
+function create_oak(
+	overrides: Partial<Omit<ForestLayoutItemOak, 'kind'>> = {},
+): ForestLayoutItemOak {
+	return {
+		id: 'oak-1',
+		priority: null,
+		sortOrder: 0,
+		...overrides,
+		kind: 'oak',
+	};
+}
+
+function create_tree(
+	id: string,
+	overrides: Partial<Omit<ForestLayoutItemTree, 'kind' | 'id'>> = {},
+): ForestLayoutItemTree {
+	return {
+		id,
+		stage: 'leafy',
+		priority: 'medium',
+		sortOrder: 0,
+		...overrides,
+		kind: 'tree',
+	};
+}
+
+function create_stump(
+	id: string,
+	overrides: Partial<Omit<ForestLayoutItemTree, 'kind' | 'id' | 'stage'>> = {},
+): ForestLayoutItemTree {
+	return {
+		id,
+		priority: null,
+		sortOrder: 0,
+		...overrides,
+		kind: 'tree',
+		stage: 'stump',
+	};
+}
+
+function create_potted_plant(
+	id: string,
+	overrides: Partial<Omit<ForestLayoutItemPottedPlant, 'kind' | 'id'>> = {},
+): ForestLayoutItemPottedPlant {
+	return {
+		id,
+		stage: 'small-plant',
+		priority: null,
+		sortOrder: 0,
+		...overrides,
+		kind: 'potted-plant',
+	};
+}
+
+function find_item(items: readonly PositionedForestItem[], id: string): PositionedForestItem {
+	const found = items.find((item) => item.id === id);
+	if (!found) {
+		throw new Error(`Item ${id} not found in layout result`);
+	}
+	return found;
+}
+
+function euclidean_distance(a: PositionedForestItem, b: PositionedForestItem): number {
+	return Math.sqrt((a.x - b.x) ** 2 + (a.y - b.y) ** 2);
+}
+
+// ─── Empty Input ────────────────────────────────────────────────────────
+
+describe('compute_forest_layout — empty input', () => {
+	it('returns empty result for no items', () => {
+		const result = compute_forest_layout([], create_viewport());
+		expect(result.items).toEqual([]);
+		expect(result.oakPosition).toBeNull();
+	});
+});
+
+// ─── Oak Placement ──────────────────────────────────────────────────────
+
+describe('compute_forest_layout — oak placement', () => {
+	it('positions oak at center-top of viewport', () => {
+		const viewport = create_viewport({ width: 1200, height: 800 });
+		const result = compute_forest_layout([create_oak()], viewport);
+
+		expect(result.oakPosition).not.toBeNull();
+		const oak = result.oakPosition!;
+		expect(oak.x).toBeCloseTo(600, 0); // center x
+		expect(oak.y).toBeLessThan(800 * 0.25); // top 25%
+		expect(oak.scale).toBe(1.0);
+		expect(oak.opacity).toBe(1.0);
+	});
+
+	it('returns null oakPosition when no oak provided', () => {
+		const result = compute_forest_layout(
+			[create_tree('t1'), create_tree('t2')],
+			create_viewport(),
+		);
+		expect(result.oakPosition).toBeNull();
+	});
+
+	it('includes oak in items array', () => {
+		const result = compute_forest_layout([create_oak()], create_viewport());
+		expect(result.items).toHaveLength(1);
+		expect(result.items[0].id).toBe('oak-1');
+	});
+});
+
+// ─── Tree Semicircle Arrangement ────────────────────────────────────────
+
+describe('compute_forest_layout — tree semicircle', () => {
+	it('distributes trees with y below oak position', () => {
+		const oak = create_oak();
+		const trees = Array.from({ length: 5 }, (_, i) => create_tree(`t${i}`));
+		const viewport = create_viewport();
+		const result = compute_forest_layout([oak, ...trees], viewport);
+
+		const oak_pos = result.oakPosition!;
+		for (const tree of trees) {
+			const pos = find_item(result.items, tree.id);
+			expect(pos.y).toBeGreaterThan(oak_pos.y);
+		}
+	});
+
+	it('distributes trees symmetrically around center x', () => {
+		const trees = Array.from({ length: 4 }, (_, i) => create_tree(`t${i}`));
+		const viewport = create_viewport({ width: 1000, height: 800 });
+		const result = compute_forest_layout(trees, viewport);
+
+		const center_x = 500;
+		const positions = trees.map((t) => find_item(result.items, t.id));
+		const left_count = positions.filter((p) => p.x < center_x).length;
+		const right_count = positions.filter((p) => p.x > center_x).length;
+		// Even count should split evenly
+		expect(left_count).toBe(right_count);
+	});
+
+	it('places single tree centered in tree zone', () => {
+		const viewport = create_viewport({ width: 1000, height: 800 });
+		const result = compute_forest_layout([create_tree('solo')], viewport);
+
+		const pos = find_item(result.items, 'solo');
+		expect(pos.x).toBeCloseTo(500, 0);
+	});
+
+	it('orders trees by priority then sort_order — higher priority closer to center', () => {
+		const items: ForestLayoutItem[] = [
+			create_oak(),
+			create_tree('low', { priority: 'low', sortOrder: 0 }),
+			create_tree('top', { priority: 'top', sortOrder: 0 }),
+			create_tree('med', { priority: 'medium', sortOrder: 0 }),
+			create_tree('high', { priority: 'high', sortOrder: 0 }),
+		];
+		const viewport = create_viewport();
+		const result = compute_forest_layout(items, viewport);
+
+		const oak_pos = result.oakPosition!;
+		const top_pos = find_item(result.items, 'top');
+		const low_pos = find_item(result.items, 'low');
+
+		// Higher-priority tree should be in inner ring (closer to oak center)
+		const top_distance = euclidean_distance(top_pos, oak_pos);
+		const low_distance = euclidean_distance(low_pos, oak_pos);
+		expect(top_distance).toBeLessThan(low_distance);
+	});
+});
+
+// ─── Stump Placement ───────────────────────────────────────────────────
+
+describe('compute_forest_layout — stumps', () => {
+	it('places stumps with reduced opacity', () => {
+		const items = [create_oak(), create_stump('s1'), create_tree('t1')];
+		const result = compute_forest_layout(items, create_viewport());
+
+		const stump = find_item(result.items, 's1');
+		expect(stump.opacity).toBeLessThanOrEqual(0.5);
+	});
+
+	it('places stumps at periphery — further from center than trees', () => {
+		const items = [create_oak(), create_tree('t1'), create_tree('t2'), create_stump('s1')];
+		const viewport = create_viewport();
+		const result = compute_forest_layout(items, viewport);
+
+		const oak_pos = result.oakPosition!;
+		const tree_distances = ['t1', 't2'].map((id) =>
+			euclidean_distance(find_item(result.items, id), oak_pos),
+		);
+		const stump_distance = euclidean_distance(find_item(result.items, 's1'), oak_pos);
+		const max_tree_distance = Math.max(...tree_distances);
+		expect(stump_distance).toBeGreaterThanOrEqual(max_tree_distance);
+	});
+
+	it('gives stumps reduced scale', () => {
+		const result = compute_forest_layout([create_stump('s1')], create_viewport());
+		const stump = find_item(result.items, 's1');
+		expect(stump.scale).toBeLessThanOrEqual(0.6);
+	});
+});
+
+// ─── Potted Plants Shelf ────────────────────────────────────────────────
+
+describe('compute_forest_layout — potted plants', () => {
+	it('positions potted plants on bottom shelf strip', () => {
+		const viewport = create_viewport({ height: 800 });
+		const plants = [create_potted_plant('p1'), create_potted_plant('p2')];
+		const result = compute_forest_layout(plants, viewport);
+
+		for (const plant of plants) {
+			const pos = find_item(result.items, plant.id);
+			expect(pos.y).toBeGreaterThanOrEqual(viewport.height * 0.8);
+		}
+	});
+
+	it('distributes potted plants horizontally across shelf', () => {
+		const viewport = create_viewport({ width: 1000 });
+		const plants = Array.from({ length: 3 }, (_, i) => create_potted_plant(`p${i}`));
+		const result = compute_forest_layout(plants, viewport);
+
+		const positions = plants.map((p) => find_item(result.items, p.id));
+		const x_values = positions.map((p) => p.x).sort((a, b) => a - b);
+
+		// Should be spread out, not stacked
+		for (let i = 1; i < x_values.length; i++) {
+			expect(x_values[i] - x_values[i - 1]).toBeGreaterThan(0);
+		}
+	});
+
+	it('exposes shelfY coordinate', () => {
+		const viewport = create_viewport({ height: 800 });
+		const result = compute_forest_layout([create_potted_plant('p1')], viewport);
+		expect(result.shelfY).toBeGreaterThanOrEqual(viewport.height * 0.8);
+	});
+});
+
+// ─── Minimum Spacing ────────────────────────────────────────────────────
+
+describe('compute_forest_layout — minimum spacing', () => {
+	it('enforces minimum spacing between all items', () => {
+		const items: ForestLayoutItem[] = [
+			create_oak(),
+			...Array.from({ length: 15 }, (_, i) => create_tree(`t${i}`)),
+		];
+		const viewport = create_viewport({ width: 800, height: 600 });
+		const result = compute_forest_layout(items, viewport);
+
+		for (let i = 0; i < result.items.length; i++) {
+			for (let j = i + 1; j < result.items.length; j++) {
+				const distance = euclidean_distance(result.items[i], result.items[j]);
+				expect(distance).toBeGreaterThanOrEqual(MIN_SPACING_PX * 0.9); // 10% tolerance
+			}
+		}
+	});
+});
+
+// ─── Viewport Responsiveness ────────────────────────────────────────────
+
+describe('compute_forest_layout — viewport responsiveness', () => {
+	it('produces different positions for different viewport sizes', () => {
+		const items = [create_oak(), create_tree('t1'), create_tree('t2')];
+		const small = compute_forest_layout(items, create_viewport({ width: 600, height: 400 }));
+		const large = compute_forest_layout(items, create_viewport({ width: 1600, height: 1000 }));
+
+		const small_oak = small.oakPosition!;
+		const large_oak = large.oakPosition!;
+		expect(small_oak.x).not.toBeCloseTo(large_oak.x, 0);
+	});
+
+	it('scales positions proportionally to viewport', () => {
+		const items = [create_oak(), create_tree('t1')];
+		const v1 = create_viewport({ width: 1000, height: 800 });
+		const v2 = create_viewport({ width: 2000, height: 1600 });
+
+		const r1 = compute_forest_layout(items, v1);
+		const r2 = compute_forest_layout(items, v2);
+
+		// Positions should roughly double
+		const oak1 = r1.oakPosition!;
+		const oak2 = r2.oakPosition!;
+		expect(oak2.x / oak1.x).toBeCloseTo(2.0, 0);
+		expect(oak2.y / oak1.y).toBeCloseTo(2.0, 0);
+	});
+});
+
+// ─── Many Trees Overflow ────────────────────────────────────────────────
+
+describe('compute_forest_layout — large item counts', () => {
+	it('handles 30+ trees without crashing', () => {
+		const items: ForestLayoutItem[] = [
+			create_oak(),
+			...Array.from({ length: 35 }, (_, i) => create_tree(`t${i}`)),
+		];
+		const result = compute_forest_layout(items, create_viewport());
+		expect(result.items).toHaveLength(36);
+	});
+});
+
+// ─── Mixed Kinds ────────────────────────────────────────────────────────
+
+describe('compute_forest_layout — mixed kinds', () => {
+	it('correctly zones all kinds simultaneously', () => {
+		const viewport = create_viewport({ width: 1200, height: 800 });
+		const items: ForestLayoutItem[] = [
+			create_oak(),
+			create_tree('t1'),
+			create_tree('t2'),
+			create_stump('s1'),
+			create_potted_plant('p1'),
+			create_potted_plant('p2'),
+		];
+		const result = compute_forest_layout(items, viewport);
+
+		expect(result.items).toHaveLength(6);
+		expect(result.oakPosition).not.toBeNull();
+
+		const oak = result.oakPosition!;
+		const t1 = find_item(result.items, 't1');
+		const s1 = find_item(result.items, 's1');
+		const p1 = find_item(result.items, 'p1');
+
+		// Oak at top
+		expect(oak.y).toBeLessThan(t1.y);
+		// Trees above shelf
+		expect(t1.y).toBeLessThan(result.shelfY);
+		// Potted plants at/below shelf
+		expect(p1.y).toBeGreaterThanOrEqual(result.shelfY - 10); // small tolerance
+		// Stump reduced opacity
+		expect(s1.opacity).toBeLessThanOrEqual(0.5);
+	});
+});
+
+// ─── zIndex Ordering ────────────────────────────────────────────────────
+
+describe('compute_forest_layout — zIndex', () => {
+	it('gives oak the highest zIndex', () => {
+		const items = [create_oak(), create_tree('t1'), create_potted_plant('p1')];
+		const result = compute_forest_layout(items, create_viewport());
+
+		const oak = result.oakPosition!;
+		for (const item of result.items) {
+			if (item.id !== oak.id) {
+				expect(oak.zIndex).toBeGreaterThanOrEqual(item.zIndex);
+			}
+		}
+	});
+
+	it('gives stumps the lowest zIndex', () => {
+		const items = [create_tree('t1'), create_stump('s1'), create_potted_plant('p1')];
+		const result = compute_forest_layout(items, create_viewport());
+
+		const stump = find_item(result.items, 's1');
+		const tree = find_item(result.items, 't1');
+		expect(stump.zIndex).toBeLessThan(tree.zIndex);
+	});
+});

--- a/src/lib/engine/forest_layout.ts
+++ b/src/lib/engine/forest_layout.ts
@@ -1,0 +1,392 @@
+import type { TreeStage, PottedPlantStage } from '$lib/types/tree_visualization';
+
+type IssuePriority = 'low' | 'medium' | 'high' | 'top' | null;
+
+// ─── Input Types ────────────────────────────────────────────────────────
+
+export interface Viewport {
+	readonly width: number;
+	readonly height: number;
+}
+
+export interface ForestLayoutItemOak {
+	readonly id: string;
+	readonly kind: 'oak';
+	readonly priority: IssuePriority;
+	readonly sortOrder: number;
+}
+
+export interface ForestLayoutItemTree {
+	readonly id: string;
+	readonly kind: 'tree';
+	readonly stage: TreeStage;
+	readonly priority: IssuePriority;
+	readonly sortOrder: number;
+}
+
+export interface ForestLayoutItemPottedPlant {
+	readonly id: string;
+	readonly kind: 'potted-plant';
+	readonly stage: PottedPlantStage;
+	readonly priority: IssuePriority;
+	readonly sortOrder: number;
+}
+
+export type ForestLayoutItem =
+	| ForestLayoutItemOak
+	| ForestLayoutItemTree
+	| ForestLayoutItemPottedPlant;
+
+// ─── Output Types ───────────────────────────────────────────────────────
+
+export interface PositionedForestItem {
+	readonly id: string;
+	readonly x: number;
+	readonly y: number;
+	readonly scale: number;
+	readonly opacity: number;
+	readonly zIndex: number;
+}
+
+export interface ForestLayoutResult {
+	readonly items: readonly PositionedForestItem[];
+	readonly oakPosition: PositionedForestItem | null;
+	readonly shelfY: number;
+}
+
+// ─── Constants ──────────────────────────────────────────────────────────
+
+/** Minimum pixel distance between any two positioned items. */
+export const MIN_SPACING_PX = 60;
+
+/** Fraction of viewport height where the oak sits. */
+const OAK_Y_FRACTION = 0.12;
+
+/** Fraction of viewport height where the shelf strip begins. */
+const SHELF_Y_FRACTION = 0.88;
+
+/** Ring radius step as fraction of viewport width. */
+const RING_RADIUS_STEP_FRACTION = 0.12;
+
+/** Base ring radius as fraction of viewport width. */
+const BASE_RING_RADIUS_FRACTION = 0.15;
+
+/** Scale decay per ring for trees. */
+const TREE_SCALE_PER_RING = [0.85, 0.75, 0.65, 0.55, 0.5];
+
+/** Vertical flatten factor for the semicircle arc (1.0 = full circle, <1 = compressed). */
+const SEMICIRCLE_VERTICAL_FLATTEN = 0.6;
+
+/** Max iterative passes for collision relaxation. */
+const MAX_RELAXATION_PASSES = 10;
+
+/** Vertical offset of tree semicircle center below the oak, as fraction of viewport height. */
+const TREE_CENTER_OFFSET_FRACTION = 0.18;
+
+/** Fallback tree center position when oak absent, as fraction of viewport height. */
+const TREE_CENTER_NO_OAK_FRACTION = 0.3;
+
+/** Horizontal margin for the shelf strip, as fraction of viewport width. */
+const SHELF_MARGIN_FRACTION = 0.1;
+
+const STUMP_OPACITY = 0.4;
+const STUMP_SCALE = 0.5;
+const POTTED_PLANT_SCALE = 0.6;
+
+// ─── zIndex Layers ──────────────────────────────────────────────────────
+
+const Z_OAK = 100;
+const Z_TREE_BASE = 50;
+const Z_POTTED_PLANT = 30;
+const Z_STUMP = 10;
+
+// ─── Internal Helpers ───────────────────────────────────────────────────
+
+function priority_rank(priority: IssuePriority): number {
+	switch (priority) {
+		case 'top':
+			return 0;
+		case 'high':
+			return 1;
+		case 'medium':
+			return 2;
+		case 'low':
+			return 3;
+		case null:
+			return 4;
+	}
+}
+
+function sort_by_priority_then_order(items: readonly ForestLayoutItem[]): ForestLayoutItem[] {
+	return [...items].sort((a, b) => {
+		const priority_diff = priority_rank(a.priority) - priority_rank(b.priority);
+		if (priority_diff !== 0) {
+			return priority_diff;
+		}
+		return a.sortOrder - b.sortOrder;
+	});
+}
+
+function is_stump(item: ForestLayoutItem): boolean {
+	return item.kind === 'tree' && item.stage === 'stump';
+}
+
+/** Capacity of ring at given index. Progressive: 3, 5, 7, 9, ... */
+function ring_capacity_at(ring_index: number): number {
+	return 3 + ring_index * 2;
+}
+
+/** Count rings required to hold `tree_count` items using the progressive capacity formula. */
+function count_tree_rings(tree_count: number): number {
+	if (tree_count === 0) {
+		return 0;
+	}
+	let ring_index = 0;
+	let remaining = tree_count;
+	while (remaining > 0) {
+		remaining -= ring_capacity_at(ring_index);
+		ring_index++;
+	}
+	return ring_index;
+}
+
+interface ClassifiedItems {
+	readonly oak: ForestLayoutItem | null;
+	readonly trees: readonly ForestLayoutItem[];
+	readonly stumps: readonly ForestLayoutItem[];
+	readonly potted_plants: readonly ForestLayoutItem[];
+}
+
+function classify_items(items: readonly ForestLayoutItem[]): ClassifiedItems {
+	let oak: ForestLayoutItem | null = null;
+	const trees: ForestLayoutItem[] = [];
+	const stumps: ForestLayoutItem[] = [];
+	const potted_plants: ForestLayoutItem[] = [];
+
+	for (const item of items) {
+		if (item.kind === 'oak') {
+			oak = item;
+		} else if (item.kind === 'potted-plant') {
+			potted_plants.push(item);
+		} else if (is_stump(item)) {
+			stumps.push(item);
+		} else {
+			trees.push(item);
+		}
+	}
+
+	return { oak, trees: sort_by_priority_then_order(trees), stumps, potted_plants };
+}
+
+/**
+ * Distribute `count` items evenly along a semicircle arc (PI radians, left to right).
+ * Returns angles in radians from PI (left) to 0 (right).
+ */
+function semicircle_angles(count: number): number[] {
+	if (count === 1) {
+		return [Math.PI / 2]; // center
+	}
+	const angles: number[] = [];
+	for (let i = 0; i < count; i++) {
+		angles.push(Math.PI - (i * Math.PI) / (count - 1));
+	}
+	return angles;
+}
+
+/**
+ * Place items on concentric semicircle rings below a center point.
+ * Returns positioned items with scale/opacity/zIndex.
+ */
+function place_on_semicircles(
+	items: readonly ForestLayoutItem[],
+	center_x: number,
+	center_y: number,
+	viewport_width: number,
+): PositionedForestItem[] {
+	if (items.length === 0) {
+		return [];
+	}
+
+	const base_radius = viewport_width * BASE_RING_RADIUS_FRACTION;
+	const radius_step = viewport_width * RING_RADIUS_STEP_FRACTION;
+	const result: PositionedForestItem[] = [];
+
+	let item_index = 0;
+	let ring_index = 0;
+
+	while (item_index < items.length) {
+		const capacity = Math.min(ring_capacity_at(ring_index), items.length - item_index);
+		const ring_items = items.slice(item_index, item_index + capacity);
+		const radius = base_radius + ring_index * radius_step;
+		const angles = semicircle_angles(ring_items.length);
+		const scale = TREE_SCALE_PER_RING[Math.min(ring_index, TREE_SCALE_PER_RING.length - 1)];
+
+		for (let i = 0; i < ring_items.length; i++) {
+			const angle = angles[i];
+			result.push({
+				id: ring_items[i].id,
+				x: center_x + radius * Math.cos(angle),
+				y: center_y + radius * Math.sin(angle) * SEMICIRCLE_VERTICAL_FLATTEN,
+				scale,
+				opacity: 1.0,
+				zIndex: Z_TREE_BASE + (TREE_SCALE_PER_RING.length - ring_index),
+			});
+		}
+
+		item_index += capacity;
+		ring_index++;
+	}
+
+	return result;
+}
+
+/**
+ * Ensure no two items are closer than MIN_SPACING_PX by nudging outward.
+ * Iterative relaxation — bounded by MAX_RELAXATION_PASSES.
+ */
+function enforce_minimum_spacing(
+	items: PositionedForestItem[],
+	center_x: number,
+	center_y: number,
+): PositionedForestItem[] {
+	const positions = items.map((item) => ({ ...item }));
+
+	for (let pass = 0; pass < MAX_RELAXATION_PASSES; pass++) {
+		let adjusted = false;
+		for (let i = 0; i < positions.length; i++) {
+			for (let j = i + 1; j < positions.length; j++) {
+				const dx = positions[j].x - positions[i].x;
+				const dy = positions[j].y - positions[i].y;
+				const dist = Math.sqrt(dx * dx + dy * dy);
+
+				if (dist < MIN_SPACING_PX && dist > 0) {
+					const overlap = (MIN_SPACING_PX - dist) / 2;
+					const nx = dx / dist;
+					const ny = dy / dist;
+
+					positions[i] = {
+						...positions[i],
+						x: positions[i].x - nx * overlap,
+						y: positions[i].y - ny * overlap,
+					};
+					positions[j] = {
+						...positions[j],
+						x: positions[j].x + nx * overlap,
+						y: positions[j].y + ny * overlap,
+					};
+					adjusted = true;
+				} else if (dist === 0) {
+					// Coincident points — nudge apart along direction from center
+					const angle_from_center = Math.atan2(
+						positions[i].y - center_y,
+						positions[i].x - center_x,
+					);
+					const nudge = MIN_SPACING_PX / 2;
+					positions[i] = {
+						...positions[i],
+						x: positions[i].x - Math.cos(angle_from_center) * nudge,
+						y: positions[i].y - Math.sin(angle_from_center) * nudge,
+					};
+					positions[j] = {
+						...positions[j],
+						x: positions[j].x + Math.cos(angle_from_center) * nudge,
+						y: positions[j].y + Math.sin(angle_from_center) * nudge,
+					};
+					adjusted = true;
+				}
+			}
+		}
+		if (!adjusted) {
+			break;
+		}
+	}
+
+	return positions;
+}
+
+// ─── Layout Engine ──────────────────────────────────────────────────────
+
+export function compute_forest_layout(
+	items: readonly ForestLayoutItem[],
+	viewport: Viewport,
+): ForestLayoutResult {
+	if (items.length === 0) {
+		return { items: [], oakPosition: null, shelfY: viewport.height * SHELF_Y_FRACTION };
+	}
+
+	const { oak, trees, stumps, potted_plants } = classify_items(items);
+	const center_x = viewport.width / 2;
+	const shelf_y = viewport.height * SHELF_Y_FRACTION;
+	const all_positioned: PositionedForestItem[] = [];
+
+	// ── Oak ──────────────────────────────────────────────────────────────
+	const oak_y = viewport.height * OAK_Y_FRACTION;
+	if (oak) {
+		all_positioned.push({
+			id: oak.id,
+			x: center_x,
+			y: oak_y,
+			scale: 1.0,
+			opacity: 1.0,
+			zIndex: Z_OAK,
+		});
+	}
+
+	// ── Trees (semicircle rings) ────────────────────────────────────────
+	const tree_center_y = oak
+		? oak_y + viewport.height * TREE_CENTER_OFFSET_FRACTION
+		: viewport.height * TREE_CENTER_NO_OAK_FRACTION;
+	const tree_positions = place_on_semicircles(trees, center_x, tree_center_y, viewport.width);
+	all_positioned.push(...tree_positions);
+
+	// ── Stumps (periphery beyond last tree ring) ────────────────────────
+	if (stumps.length > 0) {
+		const tree_ring_count = count_tree_rings(trees.length) || 1;
+		const base_radius = viewport.width * BASE_RING_RADIUS_FRACTION;
+		const radius_step = viewport.width * RING_RADIUS_STEP_FRACTION;
+		const stump_radius = base_radius + (tree_ring_count + 0.5) * radius_step;
+		const stump_angles = semicircle_angles(stumps.length);
+
+		for (let i = 0; i < stumps.length; i++) {
+			all_positioned.push({
+				id: stumps[i].id,
+				x: center_x + stump_radius * Math.cos(stump_angles[i]),
+				y:
+					tree_center_y +
+					stump_radius * Math.sin(stump_angles[i]) * SEMICIRCLE_VERTICAL_FLATTEN,
+				scale: STUMP_SCALE,
+				opacity: STUMP_OPACITY,
+				zIndex: Z_STUMP,
+			});
+		}
+	}
+
+	// ── Potted Plants (shelf strip) ─────────────────────────────────────
+	if (potted_plants.length > 0) {
+		const margin = viewport.width * SHELF_MARGIN_FRACTION;
+		const available_width = viewport.width - 2 * margin;
+		const spacing = potted_plants.length > 1 ? available_width / (potted_plants.length - 1) : 0;
+		const start_x = potted_plants.length > 1 ? margin : center_x;
+
+		for (let i = 0; i < potted_plants.length; i++) {
+			all_positioned.push({
+				id: potted_plants[i].id,
+				x: start_x + i * spacing,
+				y: shelf_y,
+				scale: POTTED_PLANT_SCALE,
+				opacity: 1.0,
+				zIndex: Z_POTTED_PLANT,
+			});
+		}
+	}
+
+	// ── Collision resolution ────────────────────────────────────────────
+	const resolved = enforce_minimum_spacing(all_positioned, center_x, tree_center_y);
+	const resolved_oak = oak ? (resolved.find((item) => item.id === oak.id) ?? null) : null;
+
+	return {
+		items: resolved,
+		oakPosition: resolved_oak,
+		shelfY: shelf_y,
+	};
+}


### PR DESCRIPTION
## Description

Pure layout calculation module that positions all items in the forest view. Returns x, y, scale, opacity, and zIndex for each tree/oak/potted-plant/stump based on viewport dimensions and issue metadata.

**Zones:**
- **Oak** at center-top (12% viewport height)
- **Trees** in concentric semicircles below oak, progressive ring capacity (3, 5, 7, 9...) — inner rings reserved for higher-priority items
- **Stumps** on outer ring with reduced opacity (0.4) and scale (0.5)
- **Potted plants** distributed across bottom shelf strip (88% viewport height)

Iterative collision relaxation (max 10 passes) enforces `MIN_SPACING_PX` between all items. Pure function — callers re-invoke on viewport resize via `$derived`.

## Acceptance Criteria

- [x] Oak at center-top of viewport
- [x] Sub-issue trees in concentric semicircles ordered by priority/sort_order
- [x] Potted plants on shelf strip at bottom
- [x] Stumps fade to outer edges with reduced opacity
- [x] Layout recalculates on viewport resize (pure fn — caller re-invokes)
- [x] Minimum spacing enforced between items
- [x] 21 unit tests covering various viewport sizes and issue counts

## Resolves

Closes #24

## Testing

- [x] 21 unit tests pass in \`src/lib/engine/forest_layout.test.ts\`
- [x] Typecheck + lint clean (\`pnpm run check:all\`)