### PR TITLE
#23 feat(viz): Oak tree + stone nameplate component

### DIFF
--- a/src/lib/components/tree/OakTree.stories.svelte
+++ b/src/lib/components/tree/OakTree.stories.svelte
@@ -1,0 +1,173 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import { TreeRenderer } from './index';
+	import ThemeDecorator from '$lib/storybook/ThemeDecorator.svelte';
+
+	const { Story } = defineMeta({
+		title: 'Viz/OakTree',
+		component: TreeRenderer,
+		// @ts-expect-error — Storybook decorator typing doesn't match Svelte 5 Component type
+		decorators: [() => ThemeDecorator],
+		tags: ['autodocs'],
+		argTypes: {
+			accent_color: { control: 'color' },
+			is_dark: { control: 'boolean' },
+		},
+	});
+</script>
+
+<script lang="ts">
+	import type { TreeVisualization, TreeVisualizationOak } from '$lib/types/tree_visualization';
+
+	interface StoryArgs {
+		visualization?: TreeVisualization;
+		accent_color: string;
+		is_dark?: boolean;
+	}
+
+	function make_oak(overrides: Partial<TreeVisualizationOak> = {}): TreeVisualizationOak {
+		return {
+			kind: 'oak',
+			title: 'Forest Dashboard',
+			completionRatio: 0,
+			overlays: [],
+			...overrides,
+		};
+	}
+</script>
+
+<Story
+	name="Empty (0%)"
+	args={{
+		visualization: make_oak({ completionRatio: 0 }),
+		accent_color: '#22c55e',
+		is_dark: false,
+	}}
+>
+	{#snippet template(args: StoryArgs)}
+		<div class="w-40">
+			<TreeRenderer
+				visualization={args.visualization}
+				accent_color={args.accent_color}
+				is_dark={args.is_dark}
+			/>
+		</div>
+	{/snippet}
+</Story>
+
+<Story
+	name="Quarter (25%)"
+	args={{
+		visualization: make_oak({ completionRatio: 0.25 }),
+		accent_color: '#22c55e',
+		is_dark: false,
+	}}
+>
+	{#snippet template(args: StoryArgs)}
+		<div class="w-40">
+			<TreeRenderer
+				visualization={args.visualization}
+				accent_color={args.accent_color}
+				is_dark={args.is_dark}
+			/>
+		</div>
+	{/snippet}
+</Story>
+
+<Story
+	name="Half (50%)"
+	args={{
+		visualization: make_oak({ completionRatio: 0.5 }),
+		accent_color: '#22c55e',
+		is_dark: false,
+	}}
+>
+	{#snippet template(args: StoryArgs)}
+		<div class="w-40">
+			<TreeRenderer
+				visualization={args.visualization}
+				accent_color={args.accent_color}
+				is_dark={args.is_dark}
+			/>
+		</div>
+	{/snippet}
+</Story>
+
+<Story
+	name="Full (100%)"
+	args={{
+		visualization: make_oak({ completionRatio: 1 }),
+		accent_color: '#22c55e',
+		is_dark: false,
+	}}
+>
+	{#snippet template(args: StoryArgs)}
+		<div class="w-40">
+			<TreeRenderer
+				visualization={args.visualization}
+				accent_color={args.accent_color}
+				is_dark={args.is_dark}
+			/>
+		</div>
+	{/snippet}
+</Story>
+
+<Story
+	name="Dark Mode"
+	args={{
+		visualization: make_oak({ completionRatio: 0.75 }),
+		accent_color: '#22c55e',
+		is_dark: true,
+	}}
+>
+	{#snippet template(args: StoryArgs)}
+		<div class="w-40">
+			<TreeRenderer
+				visualization={args.visualization}
+				accent_color={args.accent_color}
+				is_dark={args.is_dark}
+			/>
+		</div>
+	{/snippet}
+</Story>
+
+<Story
+	name="Long Title"
+	args={{
+		visualization: make_oak({
+			completionRatio: 0.6,
+			title: 'Very Long Epic Name That Should Truncate',
+		}),
+		accent_color: '#3b82f6',
+		is_dark: false,
+	}}
+>
+	{#snippet template(args: StoryArgs)}
+		<div class="w-40">
+			<TreeRenderer
+				visualization={args.visualization}
+				accent_color={args.accent_color}
+				is_dark={args.is_dark}
+			/>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Growth Gallery" args={{ accent_color: '#22c55e', is_dark: false }}>
+	{#snippet template(args: StoryArgs)}
+		<div class="grid grid-cols-5 gap-4">
+			{#each [0, 0.25, 0.5, 0.75, 1] as ratio (ratio)}
+				<div class="flex flex-col items-center gap-1">
+					<div class="w-32">
+						<TreeRenderer
+							visualization={make_oak({ completionRatio: ratio, title: 'Epic PRD' })}
+							accent_color={args.accent_color}
+							is_dark={args.is_dark}
+						/>
+					</div>
+					<span class="text-xs text-muted-foreground">{Math.round(ratio * 100)}%</span>
+				</div>
+			{/each}
+		</div>
+	{/snippet}
+</Story>

--- a/src/lib/components/tree/OakTree.svelte
+++ b/src/lib/components/tree/OakTree.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+	import type { AccentColors } from './types';
+	import { compute_oak_canopy_layers, compute_oak_crown_peak_y } from './oak_fullness';
+	import StoneNameplate from './StoneNameplate.svelte';
+
+	interface Props {
+		completion_ratio: number;
+		accent: AccentColors;
+		trunk_color: string;
+		ground_color: string;
+		title: string;
+		is_dark: boolean;
+	}
+
+	let { completion_ratio, accent, trunk_color, ground_color, title, is_dark }: Props = $props();
+
+	const layer_count = $derived(compute_oak_canopy_layers(completion_ratio));
+	const crown_peak_y = $derived(compute_oak_crown_peak_y(completion_ratio));
+
+	// Canopy geometry — wider than sub-issue trees (spread 30) to convey PRD scale
+	const CANOPY_BASE_Y = 60;
+	const CANOPY_SPREAD_X = 42;
+	const CANOPY_CENTER_X = 50;
+	const LAYER_BASE_HEIGHT = 18;
+	const LAYER_HEIGHT_TAPER = 6;
+	const LAYER_WIDTH_TAPER = 0.4;
+
+	const canopy_layers = $derived.by(() => {
+		const layers: Array<{
+			front: string;
+			shadow: string;
+			highlight: string;
+		}> = [];
+
+		for (let i = 0; i < layer_count; i++) {
+			const progress = i / Math.max(1, layer_count - 1);
+			const y_top = CANOPY_BASE_Y - progress * (CANOPY_BASE_Y - crown_peak_y);
+			const y_bottom = y_top + LAYER_BASE_HEIGHT - progress * LAYER_HEIGHT_TAPER;
+			const width = CANOPY_SPREAD_X * (1 - progress * LAYER_WIDTH_TAPER);
+
+			const left = CANOPY_CENTER_X - width;
+			const right = CANOPY_CENTER_X + width;
+			const height = y_bottom - y_top;
+
+			layers.push({
+				front: `${CANOPY_CENTER_X},${y_top} ${left},${y_bottom} ${right},${y_bottom}`,
+				shadow: `${CANOPY_CENTER_X},${y_top} ${right},${y_bottom} ${CANOPY_CENTER_X + width * LAYER_WIDTH_TAPER},${y_top + height * 0.5}`,
+				highlight: `${CANOPY_CENTER_X},${y_top} ${CANOPY_CENTER_X - width * 0.5},${y_top + height * 0.6} ${CANOPY_CENTER_X},${y_top + height * LAYER_WIDTH_TAPER}`,
+			});
+		}
+
+		return layers;
+	});
+</script>
+
+<g data-oak data-completion-ratio={completion_ratio}>
+	<!-- Ground shadow (wider than sub-issue trees) -->
+	<polygon points="12,120 88,120 82,115 18,115" fill={ground_color} />
+
+	<!-- Trunk (thicker: width 16 vs sub-issue 10, extends to nameplate at y=118) -->
+	<rect x="42" y="55" width="16" height="63" fill={trunk_color} />
+	<!-- Trunk bark detail lines -->
+	<rect x="44" y="60" width="2" height="50" fill={ground_color} opacity="0.3" />
+	<rect x="48" y="58" width="2" height="52" fill={ground_color} opacity="0.2" />
+	<rect x="53" y="62" width="2" height="48" fill={ground_color} opacity="0.25" />
+
+	<!-- Gnarled trunk knots -->
+	<polygon points="42,75 38,72 40,78" fill={trunk_color} />
+	<polygon points="58,68 62,65 60,71" fill={trunk_color} />
+
+	<!-- Canopy layers (bottom to top, count varies by completion) -->
+	{#each canopy_layers as layer, index (index)}
+		<polygon points={layer.front} fill={accent.front} />
+		<polygon points={layer.shadow} fill={accent.shadow} />
+		{#if index > 0}
+			<polygon points={layer.highlight} fill={accent.highlight} />
+		{/if}
+	{/each}
+
+	<!-- Stone nameplate at base -->
+	<StoneNameplate {title} {is_dark} />
+</g>

--- a/src/lib/components/tree/StoneNameplate.svelte
+++ b/src/lib/components/tree/StoneNameplate.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+	import { compute_stone_colors } from './color_utils';
+
+	interface Props {
+		title: string;
+		is_dark: boolean;
+	}
+
+	const TRUNCATE_THRESHOLD = 16;
+
+	let { title, is_dark }: Props = $props();
+
+	const stone = $derived(compute_stone_colors(is_dark));
+	const display_title = $derived(
+		title.length > TRUNCATE_THRESHOLD ? title.slice(0, TRUNCATE_THRESHOLD - 1) + '…' : title,
+	);
+</script>
+
+<g data-nameplate>
+	<!-- Stone body (angular geometric shape) -->
+	<polygon points="25,118 75,118 78,122 78,132 75,136 25,136 22,132 22,122" fill={stone.fill} />
+	<!-- Shadow facet (bottom-right depth) -->
+	<polygon points="75,118 78,122 78,132 75,136" fill={stone.shadow} />
+	<polygon points="25,136 75,136 78,132 22,132" fill={stone.shadow} />
+	<!-- Highlight facet (top-left bevel) -->
+	<polygon points="25,118 75,118 78,122 22,122" fill={stone.highlight} />
+	<polygon points="25,118 22,122 22,132 25,136" fill={stone.highlight} />
+
+	<!-- Title text -->
+	{#if title.length > 0}
+		<text
+			x="50"
+			y="129"
+			text-anchor="middle"
+			font-size="8"
+			font-family="Georgia, serif"
+			fill={stone.text}
+			textLength={display_title.length > 10 ? 50 : undefined}
+			lengthAdjust={display_title.length > 10 ? 'spacingAndGlyphs' : undefined}
+			data-nameplate-title
+		>
+			{display_title}
+		</text>
+	{/if}
+</g>

--- a/src/lib/components/tree/TreeRenderer.stories.svelte
+++ b/src/lib/components/tree/TreeRenderer.stories.svelte
@@ -17,10 +17,14 @@
 </script>
 
 <script lang="ts">
-	import type { TreeVisualizationTree, TreeStage } from '$lib/types/tree_visualization';
+	import type {
+		TreeVisualization,
+		TreeVisualizationTree,
+		TreeStage,
+	} from '$lib/types/tree_visualization';
 
 	interface StoryArgs {
-		visualization?: TreeVisualizationTree;
+		visualization?: TreeVisualization;
 		accent_color: string;
 		is_dark?: boolean;
 	}

--- a/src/lib/components/tree/TreeRenderer.svelte
+++ b/src/lib/components/tree/TreeRenderer.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { TreeVisualizationTree } from '$lib/types/tree_visualization';
+	import type { TreeVisualization } from '$lib/types/tree_visualization';
 	import { STAGE_TO_GROUP, VIEWBOX_WIDTH, VIEWBOX_HEIGHT } from './types';
 	import {
 		compute_accent_colors,
@@ -10,20 +10,37 @@
 	import Sapling from './Sapling.svelte';
 	import MatureTree from './MatureTree.svelte';
 	import DeadTree from './DeadTree.svelte';
+	import OakTree from './OakTree.svelte';
 	import { fade } from 'svelte/transition';
 
 	interface Props {
-		visualization?: TreeVisualizationTree;
+		visualization?: TreeVisualization;
 		accent_color: string;
 		is_dark?: boolean;
 	}
 
 	let { visualization, accent_color, is_dark = false }: Props = $props();
 
-	const group = $derived(visualization ? STAGE_TO_GROUP[visualization.stage] : undefined);
+	const tree_visualization = $derived(visualization?.kind === 'tree' ? visualization : undefined);
+	const group = $derived(
+		tree_visualization ? STAGE_TO_GROUP[tree_visualization.stage] : undefined,
+	);
 	const accent = $derived(compute_accent_colors(accent_color));
 	const trunk_color = $derived(compute_trunk_color(is_dark));
 	const ground_color = $derived(compute_ground_color(is_dark));
+
+	const aria_label = $derived.by(() => {
+		if (!visualization) {
+			return '';
+		}
+		if (visualization.kind === 'oak') {
+			return `Oak tree: ${visualization.title || 'PRD'}`;
+		}
+		if (visualization.kind === 'tree') {
+			return `Tree visualization: ${visualization.stage} stage`;
+		}
+		return `Potted plant visualization`;
+	});
 </script>
 
 {#if visualization}
@@ -31,41 +48,58 @@
 		viewBox="0 0 {VIEWBOX_WIDTH} {VIEWBOX_HEIGHT}"
 		xmlns="http://www.w3.org/2000/svg"
 		role="img"
-		aria-label="Tree visualization: {visualization.stage} stage"
+		aria-label={aria_label}
 	>
-		{#key group}
+		{#if visualization.kind === 'oak'}
 			<g transition:fade={{ duration: 200 }}>
-				{#if group === 'seed-sprout'}
-					<SeedSprout
-						stage={visualization.stage as 'seed' | 'sprouting'}
-						{accent}
-						{trunk_color}
-						{ground_color}
-					/>
-				{:else if group === 'sapling'}
-					<Sapling
-						stage={visualization.stage as 'sapling' | 'growing'}
-						{accent}
-						{trunk_color}
-						{ground_color}
-					/>
-				{:else if group === 'mature-tree'}
-					<MatureTree
-						stage={visualization.stage as 'leafy' | 'fruiting' | 'autumn' | 'ready'}
-						{accent}
-						{trunk_color}
-						{ground_color}
-						fruit_types={visualization.fruitTypes}
-					/>
-				{:else if group === 'dead-tree'}
-					<DeadTree
-						stage={visualization.stage as 'bare' | 'dead' | 'stump'}
-						{accent}
-						{trunk_color}
-						{ground_color}
-					/>
-				{/if}
+				<OakTree
+					completion_ratio={visualization.completionRatio}
+					{accent}
+					{trunk_color}
+					{ground_color}
+					title={visualization.title}
+					{is_dark}
+				/>
 			</g>
-		{/key}
+		{:else if tree_visualization}
+			{#key group}
+				<g transition:fade={{ duration: 200 }}>
+					{#if group === 'seed-sprout'}
+						<SeedSprout
+							stage={tree_visualization.stage as 'seed' | 'sprouting'}
+							{accent}
+							{trunk_color}
+							{ground_color}
+						/>
+					{:else if group === 'sapling'}
+						<Sapling
+							stage={tree_visualization.stage as 'sapling' | 'growing'}
+							{accent}
+							{trunk_color}
+							{ground_color}
+						/>
+					{:else if group === 'mature-tree'}
+						<MatureTree
+							stage={tree_visualization.stage as
+								| 'leafy'
+								| 'fruiting'
+								| 'autumn'
+								| 'ready'}
+							{accent}
+							{trunk_color}
+							{ground_color}
+							fruit_types={tree_visualization.fruitTypes}
+						/>
+					{:else if group === 'dead-tree'}
+						<DeadTree
+							stage={tree_visualization.stage as 'bare' | 'dead' | 'stump'}
+							{accent}
+							{trunk_color}
+							{ground_color}
+						/>
+					{/if}
+				</g>
+			{/key}
+		{/if}
 	</svg>
 {/if}

--- a/src/lib/components/tree/color_utils.ts
+++ b/src/lib/components/tree/color_utils.ts
@@ -104,3 +104,28 @@ export function compute_trunk_color(is_dark: boolean): string {
 export function compute_ground_color(is_dark: boolean): string {
 	return is_dark ? 'oklch(0.25 0.01 60)' : 'oklch(0.75 0.01 60)';
 }
+
+// ─── Stone Nameplate Colors ─────────────────────────────────────────
+
+export interface StoneColors {
+	readonly fill: string;
+	readonly shadow: string;
+	readonly highlight: string;
+	readonly text: string;
+}
+
+export function compute_stone_colors(is_dark: boolean): StoneColors {
+	return is_dark
+		? {
+				fill: 'oklch(0.35 0.01 250)',
+				shadow: 'oklch(0.25 0.01 250)',
+				highlight: 'oklch(0.42 0.005 250)',
+				text: 'oklch(0.75 0.01 250)',
+			}
+		: {
+				fill: 'oklch(0.65 0.01 250)',
+				shadow: 'oklch(0.55 0.01 250)',
+				highlight: 'oklch(0.72 0.005 250)',
+				text: 'oklch(0.3 0.01 250)',
+			};
+}

--- a/src/lib/components/tree/index.ts
+++ b/src/lib/components/tree/index.ts
@@ -1,6 +1,14 @@
 export { default as TreeRenderer } from './TreeRenderer.svelte';
-export { compute_accent_colors, compute_trunk_color, hex_to_oklch } from './color_utils';
+export { default as OakTree } from './OakTree.svelte';
+export { default as StoneNameplate } from './StoneNameplate.svelte';
+export {
+	compute_accent_colors,
+	compute_trunk_color,
+	compute_stone_colors,
+	hex_to_oklch,
+} from './color_utils';
 export { compute_attachment_points } from './attachment_points';
+export { compute_oak_canopy_layers, compute_oak_crown_peak_y } from './oak_fullness';
 export type {
 	TreeComponentProps,
 	AttachmentPoints,

--- a/src/lib/components/tree/oak_fullness.test.ts
+++ b/src/lib/components/tree/oak_fullness.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { compute_oak_canopy_layers, compute_oak_crown_peak_y } from './oak_fullness';
+
+describe('compute_oak_canopy_layers', () => {
+	it('returns minimum layers (2) at ratio 0', () => {
+		expect(compute_oak_canopy_layers(0)).toBe(2);
+	});
+
+	it('returns maximum layers (6) at ratio 1', () => {
+		expect(compute_oak_canopy_layers(1)).toBe(6);
+	});
+
+	it('returns intermediate value at ratio 0.5', () => {
+		expect(compute_oak_canopy_layers(0.5)).toBe(4);
+	});
+
+	it('clamps ratio below 0 to minimum', () => {
+		expect(compute_oak_canopy_layers(-0.5)).toBe(2);
+	});
+
+	it('clamps ratio above 1 to maximum', () => {
+		expect(compute_oak_canopy_layers(1.5)).toBe(6);
+	});
+
+	it('rounds to nearest integer', () => {
+		expect(Number.isInteger(compute_oak_canopy_layers(0.33))).toBe(true);
+	});
+});
+
+describe('compute_oak_crown_peak_y', () => {
+	it('returns high y (sparse) at ratio 0', () => {
+		expect(compute_oak_crown_peak_y(0)).toBe(30);
+	});
+
+	it('returns low y (full) at ratio 1', () => {
+		expect(compute_oak_crown_peak_y(1)).toBe(5);
+	});
+
+	it('returns intermediate y at ratio 0.5', () => {
+		expect(compute_oak_crown_peak_y(0.5)).toBe(17.5);
+	});
+
+	it('clamps ratio below 0', () => {
+		expect(compute_oak_crown_peak_y(-1)).toBe(30);
+	});
+
+	it('clamps ratio above 1', () => {
+		expect(compute_oak_crown_peak_y(2)).toBe(5);
+	});
+});

--- a/src/lib/components/tree/oak_fullness.ts
+++ b/src/lib/components/tree/oak_fullness.ts
@@ -1,0 +1,20 @@
+const MIN_LAYERS = 2;
+const MAX_LAYERS = 6;
+const CROWN_Y_SPARSE = 30;
+const CROWN_Y_FULL = 5;
+
+function clamp_ratio(ratio: number): number {
+	return Math.min(1, Math.max(0, ratio));
+}
+
+/** Maps completion ratio (0–1) to canopy polygon layer count (2–6). */
+export function compute_oak_canopy_layers(ratio: number): number {
+	const clamped = clamp_ratio(ratio);
+	return Math.round(MIN_LAYERS + clamped * (MAX_LAYERS - MIN_LAYERS));
+}
+
+/** Maps completion ratio (0–1) to crown peak Y coordinate (30→5, lower = taller). */
+export function compute_oak_crown_peak_y(ratio: number): number {
+	const clamped = clamp_ratio(ratio);
+	return CROWN_Y_SPARSE - clamped * (CROWN_Y_SPARSE - CROWN_Y_FULL);
+}

--- a/src/lib/engine/compute_tree_visualization.test.ts
+++ b/src/lib/engine/compute_tree_visualization.test.ts
@@ -26,6 +26,8 @@ function create_dimensions(overrides: Partial<StateDimensions> = {}): StateDimen
 function create_context(overrides: Partial<TreeComputeContext> = {}): TreeComputeContext {
 	return {
 		isPrd: false,
+		prdTitle: '',
+		subIssueCompletionRatio: 0,
 		hasCompletedSession: false,
 		hasCommitsOnBranch: false,
 		sessionCount: 0,
@@ -281,6 +283,31 @@ describe('compute_tree_visualization — oak', () => {
 		) as TreeVisualizationOak;
 		expect(result.kind).toBe('oak');
 		expect(result.overlays).toEqual([]);
+	});
+
+	it('oak includes title from context', () => {
+		const result = compute_tree_visualization(
+			create_dimensions(),
+			create_context({ isPrd: true, prdTitle: 'Forest Dashboard' }),
+		) as TreeVisualizationOak;
+		expect(result.title).toBe('Forest Dashboard');
+	});
+
+	it('oak includes completionRatio from context', () => {
+		const result = compute_tree_visualization(
+			create_dimensions(),
+			create_context({ isPrd: true, subIssueCompletionRatio: 0.75 }),
+		) as TreeVisualizationOak;
+		expect(result.completionRatio).toBe(0.75);
+	});
+
+	it('oak defaults to empty title and zero ratio', () => {
+		const result = compute_tree_visualization(
+			create_dimensions(),
+			create_context({ isPrd: true }),
+		) as TreeVisualizationOak;
+		expect(result.title).toBe('');
+		expect(result.completionRatio).toBe(0);
 	});
 });
 

--- a/src/lib/engine/compute_tree_visualization.ts
+++ b/src/lib/engine/compute_tree_visualization.ts
@@ -10,6 +10,8 @@ import type {
 
 export const DEFAULT_COMPUTE_CONTEXT: TreeComputeContext = {
 	isPrd: false,
+	prdTitle: '',
+	subIssueCompletionRatio: 0,
 	hasCompletedSession: false,
 	hasCommitsOnBranch: false,
 	sessionCount: 0,
@@ -125,7 +127,12 @@ export function compute_tree_visualization(
 	const overlays = compute_overlays(dimensions);
 
 	if (resolved_context.isPrd) {
-		return { kind: 'oak', overlays };
+		return {
+			kind: 'oak',
+			title: resolved_context.prdTitle,
+			completionRatio: resolved_context.subIssueCompletionRatio,
+			overlays,
+		};
 	}
 
 	if (dimensions.label === null) {

--- a/src/lib/types/tree_visualization.ts
+++ b/src/lib/types/tree_visualization.ts
@@ -105,6 +105,8 @@ export interface TreeVisualizationPottedPlant {
 
 export interface TreeVisualizationOak {
 	readonly kind: 'oak';
+	readonly title: string;
+	readonly completionRatio: number;
 	readonly overlays: readonly TreeOverlay[];
 }
 
@@ -117,6 +119,8 @@ export type TreeVisualization =
 
 export interface TreeComputeContext {
 	readonly isPrd: boolean;
+	readonly prdTitle: string;
+	readonly subIssueCompletionRatio: number;
 	/** Whether any session on this branch has previously reached 'finished' state. */
 	readonly hasCompletedSession: boolean;
 	readonly hasCommitsOnBranch: boolean;


### PR DESCRIPTION
## Description
- Adds `OakTree.svelte` SVG component with dynamic canopy growth (2–6 layers) based on sub-issue completion ratio
- Adds `StoneNameplate.svelte` at base displaying PRD/epic title with text truncation
- Extends `TreeVisualizationOak` type with `title` and `completionRatio` fields
- Wires oak rendering into `TreeRenderer.svelte` via discriminated union branching
- Adds `oak_fullness.ts` pure functions for canopy layer/crown height computation
- Adds `compute_stone_colors()` to `color_utils.ts` for themed stone nameplate colors
- Storybook stories for all growth stages, dark mode, and long title truncation

## Resolves
Closes #23

## Testing
- [x] 11 unit tests for `oak_fullness.ts` (canopy layers, crown height, clamping)
- [x] 3 engine tests for title/completionRatio passthrough
- [x] `pnpm check:all` passes (0 errors)
- [x] Storybook stories: Empty/Quarter/Half/Full/DarkMode/LongTitle/Gallery

## Note
Replaces #47 — that PR was opened from a misnamed branch (`feat/22-potted-plant-components`). This PR is on the correctly-named `23-oak-tree-stone-nameplate-component` branch and includes a merge from `dev` to pick up #22.