### PR TITLE
#25 feat(viz): Forest View page + card-list toggle

### DIFF
--- a/src/lib/components/DashboardToolbar.svelte
+++ b/src/lib/components/DashboardToolbar.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { RefreshCw, Scissors } from 'lucide-svelte';
 	import type { SortMode } from '$lib/stores/issues.svelte';
+	import type { ViewMode } from '$lib/stores/view_preference.svelte';
+	import ViewToggle from '$lib/components/ViewToggle.svelte';
 
 	interface Props {
 		sort_mode: SortMode;
@@ -9,12 +11,14 @@
 		all_expanded: boolean;
 		gh_available?: boolean;
 		syncing?: boolean;
+		view_mode?: ViewMode;
 		on_add_issue: () => void;
 		on_sort_change: (mode: SortMode) => void;
 		on_toggle_archived: () => void;
 		on_toggle_expand_all: () => void;
 		on_sync_all?: () => void;
 		on_prune_worktrees?: () => void;
+		on_view_mode_change?: (mode: ViewMode) => void;
 	}
 
 	let {
@@ -24,12 +28,14 @@
 		all_expanded,
 		gh_available = false,
 		syncing = false,
+		view_mode,
 		on_add_issue,
 		on_sort_change,
 		on_toggle_archived,
 		on_toggle_expand_all,
 		on_sync_all,
 		on_prune_worktrees,
+		on_view_mode_change,
 	}: Props = $props();
 </script>
 
@@ -67,6 +73,11 @@
 	{/if}
 
 	<div class="flex-1"></div>
+
+	<!-- View mode toggle -->
+	{#if view_mode !== undefined && on_view_mode_change}
+		<ViewToggle {view_mode} on_change={on_view_mode_change} />
+	{/if}
 
 	<!-- Collapse/expand all -->
 	<button

--- a/src/lib/components/ForestView.svelte
+++ b/src/lib/components/ForestView.svelte
@@ -1,0 +1,170 @@
+<script lang="ts">
+	import type { Issue } from '$lib/types/issue';
+	import type { GitStatusCache } from '$lib/types/git_status';
+	import type { TreeVisualization } from '$lib/types/tree_visualization';
+	import type { ForestLayoutItem, PositionedForestItem } from '$lib/engine/forest_layout';
+	import { compute_forest_layout } from '$lib/engine/forest_layout';
+	import { compute_tree_visualization } from '$lib/engine/compute_tree_visualization';
+	import {
+		map_issue_to_state_dimensions,
+		type SessionForMapping,
+	} from '$lib/engine/map_issue_to_state_dimensions';
+	import { SvelteMap } from 'svelte/reactivity';
+	import { FALLBACK_ISSUE_COLOR } from '$lib/types/color_palette';
+	import TreeRenderer from '$lib/components/tree/TreeRenderer.svelte';
+	import PottedPlantRenderer from '$lib/components/potted-plant/PottedPlantRenderer.svelte';
+
+	interface Props {
+		issues: readonly Issue[];
+		get_git_status: (issue_id: string) => GitStatusCache | undefined;
+		get_sessions_for_issue: (issue_id: string) => readonly SessionForMapping[];
+		is_dark?: boolean;
+		on_select_issue: (issue: Issue) => void;
+	}
+
+	let {
+		issues,
+		get_git_status,
+		get_sessions_for_issue,
+		is_dark = false,
+		on_select_issue,
+	}: Props = $props();
+
+	const TREE_NATURAL_WIDTH = 80;
+	const TREE_NATURAL_HEIGHT = 120;
+	const POTTED_NATURAL_WIDTH = 60;
+	const POTTED_NATURAL_HEIGHT = 90;
+
+	let viewport_width = $state(0);
+	let viewport_height = $state(0);
+
+	type RenderableVisualization = Exclude<TreeVisualization, { kind: 'oak' }>;
+
+	interface IssueEntry {
+		readonly issue: Issue;
+		readonly visualization: RenderableVisualization;
+		readonly layout_item: ForestLayoutItem;
+	}
+
+	const entries = $derived.by<readonly IssueEntry[]>(() => {
+		const results: IssueEntry[] = [];
+		for (const issue of issues) {
+			const dimensions = map_issue_to_state_dimensions(
+				issue,
+				get_git_status(issue.id),
+				get_sessions_for_issue(issue.id),
+			);
+			const visualization = compute_tree_visualization(dimensions);
+			// Oak rendering is deferred until PRD integration lands (see issues #26+).
+			// Skip oak items so they don't produce invisible clickable areas.
+			if (visualization.kind === 'oak') {
+				continue;
+			}
+			const renderable: RenderableVisualization = visualization;
+			results.push({
+				issue,
+				visualization: renderable,
+				layout_item: build_layout_item(issue, renderable),
+			});
+		}
+		return results;
+	});
+
+	const entry_by_id = $derived.by(() => {
+		const map = new SvelteMap<string, IssueEntry>();
+		for (const entry of entries) {
+			map.set(entry.issue.id, entry);
+		}
+		return map;
+	});
+
+	const layout_result = $derived(
+		compute_forest_layout(
+			entries.map((entry) => entry.layout_item),
+			{ width: viewport_width, height: viewport_height },
+		),
+	);
+
+	function build_layout_item(
+		issue: Issue,
+		visualization: RenderableVisualization,
+	): ForestLayoutItem {
+		if (visualization.kind === 'tree') {
+			return {
+				id: issue.id,
+				kind: 'tree',
+				stage: visualization.stage,
+				priority: issue.priority,
+				sortOrder: issue.sort_order,
+			};
+		}
+		return {
+			id: issue.id,
+			kind: 'potted-plant',
+			stage: visualization.stage,
+			priority: issue.priority,
+			sortOrder: issue.sort_order,
+		};
+	}
+
+	function get_natural_size(entry: IssueEntry): { width: number; height: number } {
+		if (entry.visualization.kind === 'potted-plant') {
+			return { width: POTTED_NATURAL_WIDTH, height: POTTED_NATURAL_HEIGHT };
+		}
+		return { width: TREE_NATURAL_WIDTH, height: TREE_NATURAL_HEIGHT };
+	}
+
+	function handle_select(positioned: PositionedForestItem) {
+		const entry = entry_by_id.get(positioned.id);
+		if (entry !== undefined) {
+			on_select_issue(entry.issue);
+		}
+	}
+</script>
+
+<div
+	class="relative h-[600px] w-full overflow-hidden rounded-md border border-border bg-muted/10"
+	bind:clientWidth={viewport_width}
+	bind:clientHeight={viewport_height}
+>
+	{#if issues.length === 0}
+		<p class="absolute inset-0 flex items-center justify-center text-sm text-muted-foreground">
+			No issues to visualise.
+		</p>
+	{:else}
+		{#each layout_result.items as positioned (positioned.id)}
+			{@const entry = entry_by_id.get(positioned.id)}
+			{#if entry}
+				{@const size = get_natural_size(entry)}
+				<button
+					type="button"
+					class="absolute cursor-pointer border-0 bg-transparent p-0 transition-transform hover:brightness-110 focus-visible:outline-2 focus-visible:outline-ring"
+					style:left="{positioned.x}px"
+					style:top="{positioned.y}px"
+					style:width="{size.width}px"
+					style:height="{size.height}px"
+					style:transform="translate(-50%, -50%) scale({positioned.scale})"
+					style:opacity={positioned.opacity}
+					style:z-index={positioned.zIndex}
+					onclick={() => handle_select(positioned)}
+					title={entry.issue.name}
+					aria-label="Open issue {entry.issue.name}"
+				>
+					{#if entry.visualization.kind === 'tree'}
+						<TreeRenderer
+							visualization={entry.visualization}
+							accent_color={entry.issue.color ?? FALLBACK_ISSUE_COLOR}
+							{is_dark}
+						/>
+					{:else if entry.visualization.kind === 'potted-plant'}
+						<PottedPlantRenderer
+							visualization={entry.visualization}
+							accent_color={entry.issue.color ?? FALLBACK_ISSUE_COLOR}
+							{is_dark}
+						/>
+					{/if}
+				</button>
+			{/if}
+		{/each}
+	{/if}
+</div>

--- a/src/lib/components/ViewToggle.svelte
+++ b/src/lib/components/ViewToggle.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import { List, Trees } from 'lucide-svelte';
+	import type { ViewMode } from '$lib/stores/view_preference.svelte';
+
+	interface Props {
+		view_mode: ViewMode;
+		on_change: (mode: ViewMode) => void;
+	}
+
+	let { view_mode, on_change }: Props = $props();
+
+	const options = [
+		{ value: 'cards' as const, Icon: List, label: 'Cards' },
+		{ value: 'forest' as const, Icon: Trees, label: 'Forest' },
+	];
+</script>
+
+<div
+	role="group"
+	aria-label="View mode"
+	class="flex items-center gap-0.5 rounded-md border border-border bg-muted/40 p-0.5"
+>
+	{#each options as { value, Icon, label } (value)}
+		<button
+			onclick={() => on_change(value)}
+			class="inline-flex items-center gap-1 rounded px-2 py-1 text-xs transition-colors {view_mode ===
+			value
+				? 'bg-background text-foreground shadow-sm'
+				: 'text-muted-foreground hover:text-foreground'}"
+			title="{label} view"
+			aria-pressed={view_mode === value}
+		>
+			<Icon size={13} />
+			<span>{label}</span>
+		</button>
+	{/each}
+</div>

--- a/src/lib/engine/map_issue_to_state_dimensions.test.ts
+++ b/src/lib/engine/map_issue_to_state_dimensions.test.ts
@@ -1,0 +1,361 @@
+import { describe, it, expect } from 'vitest';
+import { map_issue_to_state_dimensions } from './map_issue_to_state_dimensions';
+import type { Issue } from '$lib/types/issue';
+import type { GitStatusCache } from '$lib/types/git_status';
+import type { SessionState, ExecutionPhase } from '$lib/types/session';
+
+function create_issue(overrides: Partial<Issue> = {}): Issue {
+	return {
+		id: 'i1',
+		dashboard_id: 'd1',
+		name: 'Test Issue',
+		priority: null,
+		color: null,
+		status: 'active',
+		github_issue_url: null,
+		github_issue_number: null,
+		branch_name: null,
+		base_branch: null,
+		worktree_folder: null,
+		worktree_state: 'none',
+		parent_issue_id: null,
+		editor_folder: null,
+		dev_server_command: null,
+		dev_server_port: null,
+		dev_server_pid: null,
+		browser_url: null,
+		sort_order: 0,
+		created_at: '2026-01-01T00:00:00Z',
+		...overrides,
+	};
+}
+
+function create_git_status(overrides: Partial<GitStatusCache> = {}): GitStatusCache {
+	return {
+		issue_id: 'i1',
+		branch_status: null,
+		pr_state: null,
+		pr_number: null,
+		pr_url: null,
+		github_issue_state: null,
+		behind_base_count: null,
+		merge_conflict: null,
+		fetched_at: null,
+		...overrides,
+	};
+}
+
+interface SessionStub {
+	state: SessionState;
+	execution_phase: ExecutionPhase;
+}
+
+function create_session(overrides: Partial<SessionStub> = {}): SessionStub {
+	return { state: 'running', execution_phase: 'none', ...overrides };
+}
+
+// ─── worktreeState ──────────────────────────────────────────────────────
+
+describe('map_issue_to_state_dimensions — worktreeState', () => {
+	it('passes through issue.worktree_state verbatim', () => {
+		const dimensions = map_issue_to_state_dimensions(
+			create_issue({ worktree_state: 'active' }),
+			undefined,
+			[],
+		);
+		expect(dimensions.worktreeState).toBe('active');
+	});
+
+	it('handles every WorktreeState value', () => {
+		const states = ['none', 'pending', 'active', 'failed', 'removing', 'removed'] as const;
+		for (const state of states) {
+			const dimensions = map_issue_to_state_dimensions(
+				create_issue({ worktree_state: state }),
+				undefined,
+				[],
+			);
+			expect(dimensions.worktreeState).toBe(state);
+		}
+	});
+});
+
+// ─── aggregateSessionState ──────────────────────────────────────────────
+
+describe('map_issue_to_state_dimensions — aggregateSessionState', () => {
+	it('returns no-session when sessions array empty', () => {
+		const dimensions = map_issue_to_state_dimensions(create_issue(), undefined, []);
+		expect(dimensions.aggregateSessionState).toBe('no-session');
+	});
+
+	it('aggregates from session states using priority order', () => {
+		const dimensions = map_issue_to_state_dimensions(create_issue(), undefined, [
+			create_session({ state: 'running' }),
+			create_session({ state: 'needs-input' }),
+		]);
+		expect(dimensions.aggregateSessionState).toBe('needs-input');
+	});
+
+	it('returns running when all sessions running', () => {
+		const dimensions = map_issue_to_state_dimensions(create_issue(), undefined, [
+			create_session({ state: 'running' }),
+			create_session({ state: 'running' }),
+		]);
+		expect(dimensions.aggregateSessionState).toBe('running');
+	});
+});
+
+// ─── executionPhase ─────────────────────────────────────────────────────
+
+describe('map_issue_to_state_dimensions — executionPhase', () => {
+	it('returns none when no sessions', () => {
+		const dimensions = map_issue_to_state_dimensions(create_issue(), undefined, []);
+		expect(dimensions.executionPhase).toBe('none');
+	});
+
+	it('returns first running session execution phase', () => {
+		const dimensions = map_issue_to_state_dimensions(create_issue(), undefined, [
+			create_session({ state: 'finished', execution_phase: 'committing' }),
+			create_session({ state: 'running', execution_phase: 'tdd' }),
+		]);
+		expect(dimensions.executionPhase).toBe('tdd');
+	});
+
+	it('returns none when no running session exists', () => {
+		const dimensions = map_issue_to_state_dimensions(create_issue(), undefined, [
+			create_session({ state: 'finished', execution_phase: 'committing' }),
+		]);
+		expect(dimensions.executionPhase).toBe('none');
+	});
+});
+
+// ─── branchStatus ───────────────────────────────────────────────────────
+
+describe('map_issue_to_state_dimensions — branchStatus', () => {
+	it('returns no-branch when issue has no branch_name', () => {
+		const dimensions = map_issue_to_state_dimensions(
+			create_issue({ branch_name: null }),
+			create_git_status({ branch_status: 'active' }),
+			[],
+		);
+		expect(dimensions.branchStatus).toBe('no-branch');
+	});
+
+	it('returns no-branch when git_status is missing', () => {
+		const dimensions = map_issue_to_state_dimensions(
+			create_issue({ branch_name: 'feat/x' }),
+			undefined,
+			[],
+		);
+		expect(dimensions.branchStatus).toBe('no-branch');
+	});
+
+	it('returns no-branch when branch_status is null', () => {
+		const dimensions = map_issue_to_state_dimensions(
+			create_issue({ branch_name: 'feat/x' }),
+			create_git_status({ branch_status: null }),
+			[],
+		);
+		expect(dimensions.branchStatus).toBe('no-branch');
+	});
+
+	it('returns no-branch when branch_status is unknown', () => {
+		const dimensions = map_issue_to_state_dimensions(
+			create_issue({ branch_name: 'feat/x' }),
+			create_git_status({ branch_status: 'unknown' }),
+			[],
+		);
+		expect(dimensions.branchStatus).toBe('no-branch');
+	});
+
+	it('maps active → active', () => {
+		const dimensions = map_issue_to_state_dimensions(
+			create_issue({ branch_name: 'feat/x' }),
+			create_git_status({ branch_status: 'active' }),
+			[],
+		);
+		expect(dimensions.branchStatus).toBe('active');
+	});
+
+	it('maps local → local-only', () => {
+		const dimensions = map_issue_to_state_dimensions(
+			create_issue({ branch_name: 'feat/x' }),
+			create_git_status({ branch_status: 'local' }),
+			[],
+		);
+		expect(dimensions.branchStatus).toBe('local-only');
+	});
+
+	it('maps remote-gone → remote-gone', () => {
+		const dimensions = map_issue_to_state_dimensions(
+			create_issue({ branch_name: 'feat/x' }),
+			create_git_status({ branch_status: 'remote-gone' }),
+			[],
+		);
+		expect(dimensions.branchStatus).toBe('remote-gone');
+	});
+
+	it('maps deleted → deleted', () => {
+		const dimensions = map_issue_to_state_dimensions(
+			create_issue({ branch_name: 'feat/x' }),
+			create_git_status({ branch_status: 'deleted' }),
+			[],
+		);
+		expect(dimensions.branchStatus).toBe('deleted');
+	});
+});
+
+// ─── pullRequestState ───────────────────────────────────────────────────
+
+describe('map_issue_to_state_dimensions — pullRequestState', () => {
+	it('returns no-pr when git_status missing', () => {
+		const dimensions = map_issue_to_state_dimensions(create_issue(), undefined, []);
+		expect(dimensions.pullRequestState).toBe('no-pr');
+	});
+
+	it('returns no-pr when pr_state is null', () => {
+		const dimensions = map_issue_to_state_dimensions(
+			create_issue(),
+			create_git_status({ pr_state: null }),
+			[],
+		);
+		expect(dimensions.pullRequestState).toBe('no-pr');
+	});
+
+	it.each([
+		'draft',
+		'open',
+		'review-requested',
+		'changes-requested',
+		'approved',
+		'merged',
+		'closed',
+	] as const)('passes through known pr_state "%s"', (state) => {
+		const dimensions = map_issue_to_state_dimensions(
+			create_issue(),
+			create_git_status({ pr_state: state }),
+			[],
+		);
+		expect(dimensions.pullRequestState).toBe(state);
+	});
+
+	it('falls back to open for unrecognised pr_state string', () => {
+		const dimensions = map_issue_to_state_dimensions(
+			create_issue(),
+			create_git_status({ pr_state: 'some-new-state' }),
+			[],
+		);
+		expect(dimensions.pullRequestState).toBe('open');
+	});
+});
+
+// ─── githubIssueState ───────────────────────────────────────────────────
+
+describe('map_issue_to_state_dimensions — githubIssueState', () => {
+	it('defaults to open when git_status missing', () => {
+		const dimensions = map_issue_to_state_dimensions(create_issue(), undefined, []);
+		expect(dimensions.githubIssueState).toBe('open');
+	});
+
+	it('defaults to open when github_issue_state is null', () => {
+		const dimensions = map_issue_to_state_dimensions(
+			create_issue(),
+			create_git_status({ github_issue_state: null }),
+			[],
+		);
+		expect(dimensions.githubIssueState).toBe('open');
+	});
+
+	it('maps closed → closed', () => {
+		const dimensions = map_issue_to_state_dimensions(
+			create_issue(),
+			create_git_status({ github_issue_state: 'closed' }),
+			[],
+		);
+		expect(dimensions.githubIssueState).toBe('closed');
+	});
+
+	it('maps open → open', () => {
+		const dimensions = map_issue_to_state_dimensions(
+			create_issue(),
+			create_git_status({ github_issue_state: 'open' }),
+			[],
+		);
+		expect(dimensions.githubIssueState).toBe('open');
+	});
+});
+
+// ─── syncStatus ─────────────────────────────────────────────────────────
+
+describe('map_issue_to_state_dimensions — syncStatus', () => {
+	it('returns up-to-date when git_status missing', () => {
+		const dimensions = map_issue_to_state_dimensions(create_issue(), undefined, []);
+		expect(dimensions.syncStatus).toEqual({ type: 'up-to-date' });
+	});
+
+	it('returns merge-conflict when merge_conflict true', () => {
+		const dimensions = map_issue_to_state_dimensions(
+			create_issue(),
+			create_git_status({ merge_conflict: true, behind_base_count: 3 }),
+			[],
+		);
+		expect(dimensions.syncStatus).toEqual({ type: 'merge-conflict' });
+	});
+
+	it('returns behind-base when behind_base_count > 0 and no merge conflict', () => {
+		const dimensions = map_issue_to_state_dimensions(
+			create_issue(),
+			create_git_status({ merge_conflict: false, behind_base_count: 5 }),
+			[],
+		);
+		expect(dimensions.syncStatus).toEqual({ type: 'behind-base', count: 5 });
+	});
+
+	it('returns up-to-date when behind_base_count is 0', () => {
+		const dimensions = map_issue_to_state_dimensions(
+			create_issue(),
+			create_git_status({ merge_conflict: false, behind_base_count: 0 }),
+			[],
+		);
+		expect(dimensions.syncStatus).toEqual({ type: 'up-to-date' });
+	});
+
+	it('returns up-to-date when behind_base_count is null', () => {
+		const dimensions = map_issue_to_state_dimensions(
+			create_issue(),
+			create_git_status({ merge_conflict: false, behind_base_count: null }),
+			[],
+		);
+		expect(dimensions.syncStatus).toEqual({ type: 'up-to-date' });
+	});
+});
+
+// ─── bamgitStatus ───────────────────────────────────────────────────────
+
+describe('map_issue_to_state_dimensions — bamgitStatus', () => {
+	it('maps active issue.status → active', () => {
+		const dimensions = map_issue_to_state_dimensions(
+			create_issue({ status: 'active' }),
+			undefined,
+			[],
+		);
+		expect(dimensions.bamgitStatus).toBe('active');
+	});
+
+	it('maps archived issue.status → archived', () => {
+		const dimensions = map_issue_to_state_dimensions(
+			create_issue({ status: 'archived' }),
+			undefined,
+			[],
+		);
+		expect(dimensions.bamgitStatus).toBe('archived');
+	});
+});
+
+// ─── label ──────────────────────────────────────────────────────────────
+
+describe('map_issue_to_state_dimensions — label', () => {
+	it('stubs label as AFK (Issue has no label field yet)', () => {
+		const dimensions = map_issue_to_state_dimensions(create_issue(), undefined, []);
+		expect(dimensions.label).toBe('AFK');
+	});
+});

--- a/src/lib/engine/map_issue_to_state_dimensions.ts
+++ b/src/lib/engine/map_issue_to_state_dimensions.ts
@@ -1,0 +1,97 @@
+import type { Issue } from '$lib/types/issue';
+import type { BranchStatus, GitStatusCache } from '$lib/types/git_status';
+import type { ExecutionPhase, SessionState } from '$lib/types/session';
+import type {
+	ForestBranchStatus,
+	ForestPullRequestState,
+	ForestSyncStatus,
+	StateDimensions,
+} from '$lib/types/tree_visualization';
+import { aggregate_session_state } from './aggregate_session_state';
+
+/**
+ * Minimal session shape needed by the mapper. Matches {@link Session} but decoupled
+ * to allow callers to pass any session-like object.
+ */
+export interface SessionForMapping {
+	readonly state: SessionState;
+	readonly execution_phase: ExecutionPhase;
+}
+
+const KNOWN_PR_STATES: ReadonlySet<ForestPullRequestState> = new Set([
+	'draft',
+	'open',
+	'review-requested',
+	'changes-requested',
+	'approved',
+	'merged',
+	'closed',
+]);
+
+function map_branch_status(
+	issue_branch_name: string | null,
+	raw: BranchStatus | null | undefined,
+): ForestBranchStatus {
+	// TODO(#25): when issue.label is added, revisit 'no-branch' stub policy.
+	if (issue_branch_name === null || raw == null || raw === 'unknown') {
+		return 'no-branch';
+	}
+	if (raw === 'local') {
+		return 'local-only';
+	}
+	return raw;
+}
+
+function map_pr_state(raw: string | null | undefined): ForestPullRequestState {
+	if (raw == null) {
+		return 'no-pr';
+	}
+	if (KNOWN_PR_STATES.has(raw as ForestPullRequestState)) {
+		return raw as ForestPullRequestState;
+	}
+	return 'open';
+}
+
+function map_sync_status(git_status: GitStatusCache | undefined): ForestSyncStatus {
+	if (git_status === undefined) {
+		return { type: 'up-to-date' };
+	}
+	if (git_status.merge_conflict === true) {
+		return { type: 'merge-conflict' };
+	}
+	const behind = git_status.behind_base_count ?? 0;
+	if (behind > 0) {
+		return { type: 'behind-base', count: behind };
+	}
+	return { type: 'up-to-date' };
+}
+
+function pick_execution_phase(sessions: readonly SessionForMapping[]): ExecutionPhase {
+	const running = sessions.find((session) => session.state === 'running');
+	return running?.execution_phase ?? 'none';
+}
+
+/**
+ * Pure adapter that converts backend types (Issue, GitStatusCache, sessions) into
+ * the engine's StateDimensions contract. Safe to call in derived state — no side effects.
+ *
+ * Label is currently stubbed as 'AFK' (no label field on Issue yet) so issues render
+ * as trees instead of potted plants. Revisit when GitHub label sync lands.
+ */
+export function map_issue_to_state_dimensions(
+	issue: Issue,
+	git_status: GitStatusCache | undefined,
+	sessions: readonly SessionForMapping[],
+): StateDimensions {
+	return {
+		label: 'AFK',
+		worktreeState: issue.worktree_state,
+		aggregateSessionState: aggregate_session_state(sessions.map((session) => session.state)),
+		executionPhase: pick_execution_phase(sessions),
+		branchStatus: map_branch_status(issue.branch_name, git_status?.branch_status),
+		pullRequestState: map_pr_state(git_status?.pr_state),
+		githubIssueState: git_status?.github_issue_state === 'closed' ? 'closed' : 'open',
+		syncStatus: map_sync_status(git_status),
+		bamgitStatus: issue.status === 'archived' ? 'archived' : 'active',
+	};
+}

--- a/src/lib/stores/view_preference.svelte.ts
+++ b/src/lib/stores/view_preference.svelte.ts
@@ -1,0 +1,42 @@
+import { browser } from '$app/environment';
+
+export type ViewMode = 'cards' | 'forest';
+
+const VIEW_MODE_STORAGE_KEY = 'bamgit_view_mode';
+const DEFAULT_VIEW_MODE: ViewMode = 'cards';
+
+let view_mode = $state<ViewMode>(load_view_mode());
+
+function load_view_mode(): ViewMode {
+	if (!browser) {
+		return DEFAULT_VIEW_MODE;
+	}
+	const stored = localStorage.getItem(VIEW_MODE_STORAGE_KEY);
+	if (stored === 'cards' || stored === 'forest') {
+		return stored;
+	}
+	return DEFAULT_VIEW_MODE;
+}
+
+/**
+ * Must be called once from a root component (e.g., +layout.svelte) during initialization.
+ * Sets up reactive effect for localStorage persistence.
+ */
+export function initialize_view_preference() {
+	$effect(() => {
+		if (browser) {
+			localStorage.setItem(VIEW_MODE_STORAGE_KEY, view_mode);
+		}
+	});
+}
+
+export function get_view_preference_store() {
+	return {
+		get mode() {
+			return view_mode;
+		},
+		set mode(value: ViewMode) {
+			view_mode = value;
+		},
+	};
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -7,6 +7,7 @@
 	import { get_dashboard_store } from '$lib/stores/dashboard.svelte';
 	import { get_color_palette_store } from '$lib/stores/color_palettes.svelte';
 	import { initialize_theme } from '$lib/stores/theme.svelte';
+	import { initialize_view_preference } from '$lib/stores/view_preference.svelte';
 	import { create_dashboard, update_dashboard, delete_dashboard } from '$lib/tauri/commands';
 	import { add_repo_to_portfolio } from '$lib/tauri/portfolio_commands';
 	import type {
@@ -20,6 +21,7 @@
 	const dashboard_store = get_dashboard_store();
 	const palette_store = get_color_palette_store();
 	initialize_theme();
+	initialize_view_preference();
 
 	let editing_dashboard = $state<Dashboard | null>(null);
 

--- a/src/routes/issues/+page.svelte
+++ b/src/routes/issues/+page.svelte
@@ -8,6 +8,8 @@
 	import { get_session_store } from '$lib/stores/sessions.svelte';
 	import { NOTIFICATION_DOT_COLORS } from '$lib/types/notification';
 	import { get_color_palette_store } from '$lib/stores/color_palettes.svelte';
+	import { get_view_preference_store } from '$lib/stores/view_preference.svelte';
+	import { get_theme_store } from '$lib/stores/theme.svelte';
 	import { FALLBACK_ISSUE_COLOR } from '$lib/types/color_palette';
 	import {
 		create_issue,
@@ -28,6 +30,7 @@
 	import EmptyIssueState from '$lib/components/EmptyIssueState.svelte';
 	import DashboardToolbar from '$lib/components/DashboardToolbar.svelte';
 	import IssueCardList from '$lib/components/IssueCardList.svelte';
+	import ForestView from '$lib/components/ForestView.svelte';
 	import IssueCreateDialog from '$lib/components/IssueCreateDialog.svelte';
 	import IssueEditDialog from '$lib/components/IssueEditDialog.svelte';
 	import GhSetupBanner from '$lib/components/GhSetupBanner.svelte';
@@ -42,6 +45,8 @@
 	const notification_store = get_notification_store();
 	const session_store = get_session_store();
 	const palette_store = get_color_palette_store();
+	const view_preference_store = get_view_preference_store();
+	const theme_store = get_theme_store();
 
 	function get_notification_dot_color(issue_id: string): string | null {
 		for (const session of session_store.sessions) {
@@ -63,6 +68,14 @@
 	let next_available_color = $state<string>(FALLBACK_ISSUE_COLOR);
 	let editing_issue = $state<Issue | null>(null);
 	let all_expanded = $state(false);
+
+	// Forest view combines active issues (always) with archived issues when show_archived toggled.
+	// Archived issues render as stumps via tree state engine.
+	const forest_issues = $derived.by(() =>
+		issue_store.show_archived
+			? [...issue_store.active_issues, ...issue_store.archived_issues]
+			: issue_store.active_issues,
+	);
 	let prune_dialog_open = $state(false);
 	let prunable_issues = $state<PrunableIssue[]>([]);
 	let prune_removing = $state(false);
@@ -305,6 +318,8 @@
 			on_toggle_expand_all={() => (all_expanded = !all_expanded)}
 			on_sync_all={github_repo_parts ? handle_sync_all : undefined}
 			on_prune_worktrees={handle_open_prune_dialog}
+			view_mode={view_preference_store.mode}
+			on_view_mode_change={(mode) => (view_preference_store.mode = mode)}
 		/>
 
 		<!-- Issue list or empty state -->
@@ -314,6 +329,15 @@
 			<p class="text-destructive">Error: {issue_store.error}</p>
 		{:else if issue_store.active_issues.length === 0 && issue_store.archived_issues.length === 0}
 			<EmptyIssueState on_add_issue={open_create_dialog} />
+		{:else if view_preference_store.mode === 'forest'}
+			<ForestView
+				issues={forest_issues}
+				get_git_status={(issue_id) => git_status_store.get_status(issue_id)}
+				get_sessions_for_issue={(issue_id) =>
+					session_store.sessions.filter((session) => session.issue_id === issue_id)}
+				is_dark={theme_store.is_dark}
+				on_select_issue={(issue) => (editing_issue = issue)}
+			/>
 		{:else}
 			<IssueCardList
 				parent_issues={issue_store.parent_issues}


### PR DESCRIPTION
## Description
- Add `ForestView` component composing SVG tree renderers with the Forest Layout Manager
- Add `ViewToggle` (Cards/Forest) in the dashboard toolbar
- Add `view_preference` store persisting selection to localStorage
- Add `map_issue_to_state_dimensions` adapter (Issue + GitStatusCache + sessions → StateDimensions)
- Wire `/issues` page to conditionally render ForestView vs IssueCardList; clicking a tree opens the same IssueEditDialog
- Forest view includes archived issues (as stumps) when "Show archived" is toggled

## Resolves
Closes #25

## Notes
- `label` is stubbed as `'AFK'` in the mapper (Issue type has no label field yet). Revisit when GitHub label sync lands.
- Oak visualizations are skipped in rendering — deferred to PRD integration (#26+). Engine branch remains intact.

## Testing
- [x] 38 unit tests for `map_issue_to_state_dimensions` covering every mapping branch
- [x] `pnpm run check:all` passes (svelte-check, oxlint, eslint, stylelint, knip, prettier)
- [x] `pnpm test` — 168/168 pass
- [ ] Manual verification in Tauri app (dev/prod): toggle switches view, persistence across reload, click-to-edit, reactive state changes