### PR TITLE
#26 feat(viz): Canvas overlay + particle system

### DIFF
--- a/src/lib/components/ForestView.svelte
+++ b/src/lib/components/ForestView.svelte
@@ -13,6 +13,7 @@
 	import { FALLBACK_ISSUE_COLOR } from '$lib/types/color_palette';
 	import TreeRenderer from '$lib/components/tree/TreeRenderer.svelte';
 	import PottedPlantRenderer from '$lib/components/potted-plant/PottedPlantRenderer.svelte';
+	import ForestCanvasOverlay from '$lib/components/forest-canvas/ForestCanvasOverlay.svelte';
 
 	interface Props {
 		issues: readonly Issue[];
@@ -77,6 +78,8 @@
 		}
 		return map;
 	});
+
+	const visible_visualizations = $derived(entries.map((entry) => entry.visualization));
 
 	const layout_result = $derived(
 		compute_forest_layout(
@@ -167,4 +170,10 @@
 			{/if}
 		{/each}
 	{/if}
+	<ForestCanvasOverlay
+		visualizations={visible_visualizations}
+		{is_dark}
+		{viewport_width}
+		{viewport_height}
+	/>
 </div>

--- a/src/lib/components/forest-canvas/ForestCanvasOverlay.svelte
+++ b/src/lib/components/forest-canvas/ForestCanvasOverlay.svelte
@@ -1,0 +1,129 @@
+<script lang="ts">
+	import type { TreeVisualization } from '$lib/types/tree_visualization';
+	import {
+		POOL_SIZE,
+		LEAF_CONFIG,
+		RAIN_CONFIG,
+		FIREFLY_CONFIG,
+		type ParticleConfig,
+		type ParticleKind,
+	} from './particle_types';
+	import { create_particle_pool, acquire, release } from './particle_pool';
+	import {
+		initialize_particle,
+		update_particles,
+		compute_spawn_count,
+		type Viewport,
+	} from './particle_system';
+	import { draw_particles } from './particle_renderer';
+	import { derive_weather } from './weather_state';
+
+	interface Props {
+		visualizations: readonly TreeVisualization[];
+		is_dark: boolean;
+		viewport_width: number;
+		viewport_height: number;
+	}
+
+	let { visualizations, is_dark, viewport_width, viewport_height }: Props = $props();
+
+	let canvas_element = $state<HTMLCanvasElement | null>(null);
+
+	const pool = create_particle_pool(POOL_SIZE);
+
+	// Reading `weather.*` and `is_dark` inside the rAF tick is safe: Svelte 5
+	// props and $derived values are live references, not snapshots captured at
+	// closure creation time.
+	const weather = $derived(derive_weather(visualizations, is_dark));
+
+	interface SpawnAccumulator {
+		remainder: number;
+	}
+
+	$effect(() => {
+		if (canvas_element === null) {
+			return;
+		}
+		if (viewport_width <= 0 || viewport_height <= 0) {
+			return;
+		}
+		const canvas = canvas_element;
+		const ctx = canvas.getContext('2d');
+		if (ctx === null) {
+			return;
+		}
+
+		const dpr = window.devicePixelRatio || 1;
+		canvas.width = Math.floor(viewport_width * dpr);
+		canvas.height = Math.floor(viewport_height * dpr);
+		canvas.style.width = `${viewport_width}px`;
+		canvas.style.height = `${viewport_height}px`;
+		ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+
+		// Drain any particles that belonged to a previous viewport size so a
+		// resize does not leave stray particles at stale coordinates.
+		for (const slot of pool.slots) {
+			release(slot);
+		}
+
+		const viewport: Viewport = { width: viewport_width, height: viewport_height };
+		const leaf_accumulator: SpawnAccumulator = { remainder: 0 };
+		const rain_accumulator: SpawnAccumulator = { remainder: 0 };
+		const firefly_accumulator: SpawnAccumulator = { remainder: 0 };
+		let last_timestamp: number | null = null;
+		let frame_handle = 0;
+
+		function spawn_kind(
+			kind: ParticleKind,
+			config: ParticleConfig,
+			accumulator: SpawnAccumulator,
+			delta_ms: number,
+		): void {
+			const result = compute_spawn_count(
+				config.spawnRatePerSecond,
+				delta_ms,
+				accumulator.remainder,
+			);
+			accumulator.remainder = result.remainder;
+			for (let i = 0; i < result.count; i++) {
+				const particle = acquire(pool);
+				if (particle === null) {
+					break;
+				}
+				initialize_particle(particle, kind, viewport, Math.random);
+			}
+		}
+
+		const tick = (timestamp: number) => {
+			const delta_ms =
+				last_timestamp === null ? 16 : Math.min(timestamp - last_timestamp, 100);
+			last_timestamp = timestamp;
+
+			if (weather.leaves) {
+				spawn_kind('leaf', LEAF_CONFIG, leaf_accumulator, delta_ms);
+			}
+			if (weather.rain) {
+				spawn_kind('rain', RAIN_CONFIG, rain_accumulator, delta_ms);
+			}
+			if (weather.fireflies) {
+				spawn_kind('firefly', FIREFLY_CONFIG, firefly_accumulator, delta_ms);
+			}
+
+			update_particles(pool, delta_ms, viewport);
+
+			ctx.clearRect(0, 0, viewport_width, viewport_height);
+			draw_particles(ctx, pool, is_dark);
+
+			frame_handle = requestAnimationFrame(tick);
+		};
+
+		frame_handle = requestAnimationFrame(tick);
+
+		return () => {
+			cancelAnimationFrame(frame_handle);
+		};
+	});
+</script>
+
+<canvas bind:this={canvas_element} class="pointer-events-none absolute inset-0" aria-hidden="true"
+></canvas>

--- a/src/lib/components/forest-canvas/particle_pool.test.ts
+++ b/src/lib/components/forest-canvas/particle_pool.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import { create_particle_pool, acquire, release, for_each_alive } from './particle_pool';
+import type { Particle } from './particle_types';
+
+describe('create_particle_pool', () => {
+	it('pre-allocates exactly the requested number of slots', () => {
+		const pool = create_particle_pool(10);
+		expect(pool.slots.length).toBe(10);
+	});
+
+	it('initializes all slots with alive=false', () => {
+		const pool = create_particle_pool(5);
+		for (const slot of pool.slots) {
+			expect(slot.alive).toBe(false);
+		}
+	});
+
+	it('initializes every field to a deterministic default', () => {
+		const pool = create_particle_pool(1);
+		const slot = pool.slots[0];
+		expect(slot.x).toBe(0);
+		expect(slot.y).toBe(0);
+		expect(slot.vx).toBe(0);
+		expect(slot.vy).toBe(0);
+		expect(slot.age).toBe(0);
+		expect(slot.lifetime).toBe(0);
+		expect(slot.rotation).toBe(0);
+		expect(slot.rotationSpeed).toBe(0);
+		expect(slot.scale).toBe(1);
+		expect(slot.extra).toBe(0);
+	});
+});
+
+describe('acquire', () => {
+	it('returns the first dead slot and marks it alive', () => {
+		const pool = create_particle_pool(3);
+		const slot = acquire(pool);
+		expect(slot).not.toBeNull();
+		expect(slot?.alive).toBe(true);
+	});
+
+	it('returns distinct slots on successive calls', () => {
+		const pool = create_particle_pool(3);
+		const first = acquire(pool);
+		const second = acquire(pool);
+		expect(first).not.toBeNull();
+		expect(second).not.toBeNull();
+		expect(first).not.toBe(second);
+	});
+
+	it('returns null when pool is exhausted', () => {
+		const pool = create_particle_pool(2);
+		acquire(pool);
+		acquire(pool);
+		const third = acquire(pool);
+		expect(third).toBeNull();
+	});
+
+	it('does not allocate new objects beyond the pool', () => {
+		const pool = create_particle_pool(2);
+		const before = pool.slots.length;
+		acquire(pool);
+		acquire(pool);
+		acquire(pool); // exhausted
+		expect(pool.slots.length).toBe(before);
+	});
+});
+
+describe('release', () => {
+	it('marks a particle as dead', () => {
+		const pool = create_particle_pool(2);
+		const particle = acquire(pool);
+		expect(particle).not.toBeNull();
+		release(particle as Particle);
+		expect(particle?.alive).toBe(false);
+	});
+
+	it('allows the slot to be reused by a subsequent acquire', () => {
+		const pool = create_particle_pool(1);
+		const first = acquire(pool);
+		expect(first).not.toBeNull();
+		release(first as Particle);
+		const second = acquire(pool);
+		expect(second).toBe(first);
+	});
+});
+
+describe('for_each_alive', () => {
+	it('visits only alive slots', () => {
+		const pool = create_particle_pool(4);
+		const a = acquire(pool);
+		const b = acquire(pool);
+		release(a as Particle);
+		const visited: Particle[] = [];
+		for_each_alive(pool, (p) => visited.push(p));
+		expect(visited.length).toBe(1);
+		expect(visited[0]).toBe(b);
+	});
+
+	it('is a no-op when no particles are alive', () => {
+		const pool = create_particle_pool(3);
+		let count = 0;
+		for_each_alive(pool, () => count++);
+		expect(count).toBe(0);
+	});
+});

--- a/src/lib/components/forest-canvas/particle_pool.ts
+++ b/src/lib/components/forest-canvas/particle_pool.ts
@@ -1,0 +1,64 @@
+// ─── Particle Pool ────────────────────────────────────────────────────────
+// Fixed-size object pool. Pre-allocates particles once; dead slots are
+// recycled by acquire() to avoid allocation pressure in the rAF loop.
+
+import type { Particle, ParticleKind } from './particle_types';
+
+export interface ParticlePool {
+	readonly slots: Particle[];
+}
+
+function create_dead_particle(): Particle {
+	return {
+		kind: 'leaf',
+		alive: false,
+		x: 0,
+		y: 0,
+		vx: 0,
+		vy: 0,
+		age: 0,
+		lifetime: 0,
+		rotation: 0,
+		rotationSpeed: 0,
+		scale: 1,
+		extra: 0,
+	};
+}
+
+export function create_particle_pool(size: number): ParticlePool {
+	const slots: Particle[] = Array.from({ length: size }, create_dead_particle);
+	return { slots };
+}
+
+/** Returns the first dead slot marked alive, or null when the pool is full. */
+export function acquire(pool: ParticlePool): Particle | null {
+	for (const slot of pool.slots) {
+		if (!slot.alive) {
+			slot.alive = true;
+			return slot;
+		}
+	}
+	return null;
+}
+
+export function release(particle: Particle): void {
+	particle.alive = false;
+}
+
+export function for_each_alive(pool: ParticlePool, visit: (particle: Particle) => void): void {
+	for (const slot of pool.slots) {
+		if (slot.alive) {
+			visit(slot);
+		}
+	}
+}
+
+export function count_alive_of_kind(pool: ParticlePool, kind: ParticleKind): number {
+	let count = 0;
+	for (const slot of pool.slots) {
+		if (slot.alive && slot.kind === kind) {
+			count++;
+		}
+	}
+	return count;
+}

--- a/src/lib/components/forest-canvas/particle_renderer.ts
+++ b/src/lib/components/forest-canvas/particle_renderer.ts
@@ -1,0 +1,101 @@
+// ─── Particle Rendering ───────────────────────────────────────────────────
+// Low-poly geometric draw routines. Colors match the tree palette aesthetic:
+// warm leaves, cool rain, warm fireflies. Kept outside the Svelte component
+// so they can be reused from storybook / canvas perf benches.
+
+import type { Particle } from './particle_types';
+import type { ParticlePool } from './particle_pool';
+import { for_each_alive } from './particle_pool';
+
+const LEAF_BASE_RADIUS = 5;
+const RAIN_STROKE_ALPHA = 0.55;
+const FIREFLY_GLOW_RADIUS = 10;
+
+export function draw_particles(
+	ctx: CanvasRenderingContext2D,
+	pool: ParticlePool,
+	is_dark: boolean,
+): void {
+	for_each_alive(pool, (particle) => {
+		switch (particle.kind) {
+			case 'leaf':
+				draw_leaf(ctx, particle, is_dark);
+				return;
+			case 'rain':
+				draw_rain(ctx, particle, is_dark);
+				return;
+			case 'firefly':
+				draw_firefly(ctx, particle);
+		}
+	});
+}
+
+function draw_leaf(ctx: CanvasRenderingContext2D, particle: Particle, is_dark: boolean): void {
+	// Angular low-poly leaf: diamond with offset.
+	const radius = LEAF_BASE_RADIUS * particle.scale;
+	const hue = 20 + particle.extra * 40; // 20° (red-orange) → 60° (yellow)
+	const lightness = is_dark ? 45 : 55;
+	const life_ratio = 1 - particle.age / particle.lifetime;
+	const alpha = Math.min(1, life_ratio * 2);
+
+	ctx.save();
+	ctx.translate(particle.x, particle.y);
+	ctx.rotate(particle.rotation);
+	ctx.fillStyle = `hsla(${hue}, 75%, ${lightness}%, ${alpha})`;
+	ctx.beginPath();
+	ctx.moveTo(0, -radius);
+	ctx.lineTo(radius * 0.7, 0);
+	ctx.lineTo(0, radius);
+	ctx.lineTo(-radius * 0.7, 0);
+	ctx.closePath();
+	ctx.fill();
+	ctx.restore();
+}
+
+function draw_rain(ctx: CanvasRenderingContext2D, particle: Particle, is_dark: boolean): void {
+	const length = particle.extra;
+	// Draw along velocity vector.
+	const speed = Math.sqrt(particle.vx * particle.vx + particle.vy * particle.vy);
+	const nx = speed === 0 ? 0 : particle.vx / speed;
+	const ny = speed === 0 ? 0 : particle.vy / speed;
+
+	ctx.save();
+	ctx.strokeStyle = is_dark
+		? `rgba(170, 200, 230, ${RAIN_STROKE_ALPHA})`
+		: `rgba(90, 120, 170, ${RAIN_STROKE_ALPHA})`;
+	ctx.lineWidth = 1.2;
+	ctx.lineCap = 'round';
+	ctx.beginPath();
+	ctx.moveTo(particle.x, particle.y);
+	ctx.lineTo(particle.x + nx * length, particle.y + ny * length);
+	ctx.stroke();
+	ctx.restore();
+}
+
+function draw_firefly(ctx: CanvasRenderingContext2D, particle: Particle): void {
+	// Pulsing glow using time-varying radius + radial gradient.
+	const phase = particle.extra + particle.age * 0.003;
+	const pulse = 0.6 + 0.4 * Math.sin(phase);
+	const glow_radius = FIREFLY_GLOW_RADIUS * particle.scale * pulse;
+	const life_ratio = 1 - particle.age / particle.lifetime;
+	const alpha = Math.min(1, life_ratio * 2);
+
+	const gradient = ctx.createRadialGradient(
+		particle.x,
+		particle.y,
+		0,
+		particle.x,
+		particle.y,
+		glow_radius,
+	);
+	gradient.addColorStop(0, `rgba(255, 240, 140, ${alpha * 0.95})`);
+	gradient.addColorStop(0.4, `rgba(255, 210, 90, ${alpha * 0.5})`);
+	gradient.addColorStop(1, 'rgba(255, 200, 80, 0)');
+
+	ctx.save();
+	ctx.fillStyle = gradient;
+	ctx.beginPath();
+	ctx.arc(particle.x, particle.y, glow_radius, 0, Math.PI * 2);
+	ctx.fill();
+	ctx.restore();
+}

--- a/src/lib/components/forest-canvas/particle_system.test.ts
+++ b/src/lib/components/forest-canvas/particle_system.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect } from 'vitest';
+import {
+	create_particle_pool,
+	acquire,
+	count_alive_of_kind,
+	for_each_alive,
+} from './particle_pool';
+import {
+	initialize_particle,
+	update_particles,
+	compute_spawn_count,
+	type Viewport,
+} from './particle_system';
+import type { Particle, ParticleKind } from './particle_types';
+
+const VIEWPORT: Viewport = { width: 1000, height: 600 };
+
+function deterministic_rng(values: number[]): () => number {
+	let i = 0;
+	return () => {
+		const value = values[i % values.length];
+		i++;
+		return value;
+	};
+}
+
+function spawn_one(
+	kind: ParticleKind,
+	rng: () => number = deterministic_rng([0.5, 0.5, 0.5, 0.5, 0.5, 0.5]),
+): Particle {
+	const pool = create_particle_pool(1);
+	const particle = acquire(pool);
+	if (particle === null) {
+		throw new Error('pool exhausted');
+	}
+	initialize_particle(particle, kind, VIEWPORT, rng);
+	return particle;
+}
+
+describe('initialize_particle — leaves', () => {
+	it('starts above the viewport top edge', () => {
+		const particle = spawn_one('leaf');
+		expect(particle.y).toBeLessThanOrEqual(0);
+	});
+
+	it('falls downward with non-zero vertical velocity', () => {
+		const particle = spawn_one('leaf');
+		expect(particle.vy).toBeGreaterThan(0);
+	});
+
+	it('sets lifetime from the leaf config', () => {
+		const particle = spawn_one('leaf');
+		expect(particle.lifetime).toBeGreaterThan(0);
+	});
+
+	it('has non-zero rotation speed for tumbling', () => {
+		const particle = spawn_one('leaf', deterministic_rng([0.2, 0.9, 0.1, 0.3, 0.7, 0.8, 0.4]));
+		expect(particle.rotationSpeed).not.toBe(0);
+	});
+
+	it('sets kind to leaf', () => {
+		const particle = spawn_one('leaf');
+		expect(particle.kind).toBe('leaf');
+	});
+});
+
+describe('initialize_particle — rain', () => {
+	it('starts above the viewport top edge', () => {
+		const particle = spawn_one('rain');
+		expect(particle.y).toBeLessThanOrEqual(0);
+	});
+
+	it('has high downward velocity (fast fall)', () => {
+		const leaf = spawn_one('leaf');
+		const rain = spawn_one('rain');
+		expect(rain.vy).toBeGreaterThan(leaf.vy);
+	});
+
+	it('has non-zero horizontal velocity (diagonal)', () => {
+		const particle = spawn_one('rain');
+		expect(particle.vx).not.toBe(0);
+	});
+});
+
+describe('initialize_particle — firefly', () => {
+	it('starts somewhere inside the viewport', () => {
+		const particle = spawn_one('firefly');
+		expect(particle.x).toBeGreaterThanOrEqual(0);
+		expect(particle.x).toBeLessThanOrEqual(VIEWPORT.width);
+		expect(particle.y).toBeGreaterThanOrEqual(0);
+		expect(particle.y).toBeLessThanOrEqual(VIEWPORT.height);
+	});
+
+	it('drifts gently (low velocity)', () => {
+		const rain = spawn_one('rain');
+		const firefly = spawn_one('firefly');
+		expect(Math.abs(firefly.vy)).toBeLessThan(Math.abs(rain.vy));
+	});
+});
+
+describe('initialize_particle — distribution uses rng', () => {
+	it('spawns at left edge when rng returns 0', () => {
+		const particle = spawn_one('leaf', deterministic_rng([0]));
+		expect(particle.x).toBe(0);
+	});
+
+	it('spawns near the right edge when rng returns ~1', () => {
+		const particle = spawn_one('leaf', deterministic_rng([0.999]));
+		expect(particle.x).toBeGreaterThan(VIEWPORT.width * 0.99);
+		expect(particle.x).toBeLessThanOrEqual(VIEWPORT.width);
+	});
+});
+
+describe('update_particles — advances position', () => {
+	it('moves particle by velocity * delta', () => {
+		const pool = create_particle_pool(1);
+		const particle = acquire(pool) as Particle;
+		initialize_particle(particle, 'leaf', VIEWPORT, () => 0.5);
+		const x_before = particle.x;
+		const y_before = particle.y;
+		update_particles(pool, 16, VIEWPORT);
+		expect(particle.x).toBeCloseTo(x_before + particle.vx * 16, 4);
+		expect(particle.y).toBeCloseTo(y_before + particle.vy * 16, 4);
+	});
+
+	it('advances age by delta', () => {
+		const pool = create_particle_pool(1);
+		const particle = acquire(pool) as Particle;
+		initialize_particle(particle, 'leaf', VIEWPORT, () => 0.5);
+		update_particles(pool, 100, VIEWPORT);
+		expect(particle.age).toBe(100);
+	});
+});
+
+describe('update_particles — releases expired particles', () => {
+	it('releases particles whose age exceeds lifetime', () => {
+		const pool = create_particle_pool(1);
+		const particle = acquire(pool) as Particle;
+		initialize_particle(particle, 'leaf', VIEWPORT, () => 0.5);
+		particle.lifetime = 50;
+		update_particles(pool, 100, VIEWPORT);
+		expect(particle.alive).toBe(false);
+	});
+
+	it('keeps particles whose age is under lifetime', () => {
+		const pool = create_particle_pool(1);
+		const particle = acquire(pool) as Particle;
+		initialize_particle(particle, 'leaf', VIEWPORT, () => 0.5);
+		particle.lifetime = 10000;
+		update_particles(pool, 50, VIEWPORT);
+		expect(particle.alive).toBe(true);
+	});
+});
+
+describe('update_particles — releases off-screen particles', () => {
+	it('releases particles that fall below the viewport', () => {
+		const pool = create_particle_pool(1);
+		const particle = acquire(pool) as Particle;
+		initialize_particle(particle, 'leaf', VIEWPORT, () => 0.5);
+		particle.y = VIEWPORT.height + 1000;
+		update_particles(pool, 1, VIEWPORT);
+		expect(particle.alive).toBe(false);
+	});
+
+	it('keeps particles inside the viewport', () => {
+		const pool = create_particle_pool(1);
+		const particle = acquire(pool) as Particle;
+		initialize_particle(particle, 'leaf', VIEWPORT, () => 0.5);
+		particle.x = 100;
+		particle.y = 100;
+		update_particles(pool, 1, VIEWPORT);
+		expect(particle.alive).toBe(true);
+	});
+});
+
+describe('compute_spawn_count — spawn rate accumulator', () => {
+	it('returns 0 for short deltas that do not reach 1 particle', () => {
+		// 4 particles/sec means 250ms/particle. 100ms delta → 0.4 particles
+		const result = compute_spawn_count(4, 100, 0);
+		expect(result.count).toBe(0);
+	});
+
+	it('returns 1 particle once the accumulator crosses 1', () => {
+		// 4 particles/sec * 250ms = 1.0 particle exactly
+		const result = compute_spawn_count(4, 250, 0);
+		expect(result.count).toBe(1);
+	});
+
+	it('accumulates fractional remainder to next tick', () => {
+		// 4/sec * 300ms = 1.2; count=1, remainder=0.2
+		const result = compute_spawn_count(4, 300, 0);
+		expect(result.count).toBe(1);
+		expect(result.remainder).toBeCloseTo(0.2, 4);
+	});
+
+	it('preserves prior remainder', () => {
+		// prior 0.9 + (4/sec * 100ms = 0.4) = 1.3 → count=1, remainder=0.3
+		const result = compute_spawn_count(4, 100, 0.9);
+		expect(result.count).toBe(1);
+		expect(result.remainder).toBeCloseTo(0.3, 4);
+	});
+
+	it('returns 0 when rate is 0', () => {
+		const result = compute_spawn_count(0, 1000, 0);
+		expect(result.count).toBe(0);
+		expect(result.remainder).toBe(0);
+	});
+});
+
+describe('particle system — performance budget', () => {
+	it('updates a fully-populated 200-slot pool in under 1ms per tick', () => {
+		const pool = create_particle_pool(200);
+		for (let i = 0; i < 200; i++) {
+			const particle = acquire(pool);
+			if (particle !== null) {
+				initialize_particle(
+					particle,
+					i % 3 === 0 ? 'leaf' : i % 3 === 1 ? 'rain' : 'firefly',
+					VIEWPORT,
+					() => (i * 0.137) % 1,
+				);
+			}
+		}
+		// Warm up.
+		update_particles(pool, 16, VIEWPORT);
+		const ITERATIONS = 60;
+		const start = performance.now();
+		for (let n = 0; n < ITERATIONS; n++) {
+			update_particles(pool, 16, VIEWPORT);
+		}
+		const elapsed_per_tick = (performance.now() - start) / ITERATIONS;
+		expect(elapsed_per_tick).toBeLessThan(1);
+	});
+
+	it('pool still contains alive slots after steady-state update', () => {
+		const pool = create_particle_pool(60);
+		for (let i = 0; i < 60; i++) {
+			const particle = acquire(pool);
+			if (particle !== null) {
+				initialize_particle(particle, 'leaf', VIEWPORT, () => (i * 0.137) % 1);
+			}
+		}
+		update_particles(pool, 16, VIEWPORT);
+		let alive_count = 0;
+		for_each_alive(pool, () => alive_count++);
+		expect(alive_count).toBeGreaterThan(0);
+		expect(count_alive_of_kind(pool, 'leaf')).toBe(alive_count);
+	});
+});

--- a/src/lib/components/forest-canvas/particle_system.ts
+++ b/src/lib/components/forest-canvas/particle_system.ts
@@ -1,0 +1,141 @@
+// ─── Particle System ──────────────────────────────────────────────────────
+// Pure update/spawn logic. Takes a pool, mutates slots in place. Keeps the
+// rAF loop allocation-free by reusing pool slots.
+
+import {
+	LEAF_CONFIG,
+	RAIN_CONFIG,
+	FIREFLY_CONFIG,
+	VIEWPORT_MARGIN_PX,
+	type Particle,
+	type ParticleKind,
+} from './particle_types';
+import { release } from './particle_pool';
+import type { ParticlePool } from './particle_pool';
+
+export interface Viewport {
+	readonly width: number;
+	readonly height: number;
+}
+
+export interface SpawnCountResult {
+	readonly count: number;
+	readonly remainder: number;
+}
+
+// ─── Per-kind movement tuning (pixels per millisecond) ────────────────────
+
+const LEAF_FALL_VY_MIN = 0.02;
+const LEAF_FALL_VY_MAX = 0.05;
+const LEAF_DRIFT_VX = 0.015;
+const LEAF_SCALE_MIN = 0.6;
+const LEAF_SCALE_MAX = 1.2;
+const LEAF_ROTATION_SPEED = 0.003;
+
+const RAIN_FALL_VY = 0.6;
+const RAIN_DRIFT_VX = 0.2;
+const RAIN_LENGTH_MIN = 10;
+const RAIN_LENGTH_MAX = 18;
+
+const FIREFLY_DRIFT_MAX = 0.02;
+const FIREFLY_SCALE_MIN = 0.8;
+const FIREFLY_SCALE_MAX = 1.4;
+
+// ─── Initialization ───────────────────────────────────────────────────────
+
+export function initialize_particle(
+	particle: Particle,
+	kind: ParticleKind,
+	viewport: Viewport,
+	rng: () => number,
+): void {
+	particle.kind = kind;
+	particle.age = 0;
+	particle.rotation = 0;
+	particle.rotationSpeed = 0;
+	particle.extra = 0;
+	particle.scale = 1;
+	switch (kind) {
+		case 'leaf':
+			initialize_leaf(particle, viewport, rng);
+			return;
+		case 'rain':
+			initialize_rain(particle, viewport, rng);
+			return;
+		case 'firefly':
+			initialize_firefly(particle, viewport, rng);
+	}
+}
+
+function initialize_leaf(particle: Particle, viewport: Viewport, rng: () => number): void {
+	particle.x = rng() * viewport.width;
+	particle.y = -VIEWPORT_MARGIN_PX * rng();
+	particle.vx = (rng() - 0.5) * 2 * LEAF_DRIFT_VX;
+	particle.vy = LEAF_FALL_VY_MIN + rng() * (LEAF_FALL_VY_MAX - LEAF_FALL_VY_MIN);
+	particle.lifetime = LEAF_CONFIG.maxLifetimeMs;
+	particle.rotation = rng() * Math.PI * 2;
+	particle.rotationSpeed = (rng() - 0.5) * 2 * LEAF_ROTATION_SPEED;
+	particle.scale = LEAF_SCALE_MIN + rng() * (LEAF_SCALE_MAX - LEAF_SCALE_MIN);
+	particle.extra = rng(); // hue offset 0..1
+}
+
+function initialize_rain(particle: Particle, viewport: Viewport, rng: () => number): void {
+	particle.x = rng() * (viewport.width + VIEWPORT_MARGIN_PX * 2) - VIEWPORT_MARGIN_PX;
+	particle.y = -VIEWPORT_MARGIN_PX;
+	particle.vx = RAIN_DRIFT_VX;
+	particle.vy = RAIN_FALL_VY;
+	particle.lifetime = RAIN_CONFIG.maxLifetimeMs;
+	particle.extra = RAIN_LENGTH_MIN + rng() * (RAIN_LENGTH_MAX - RAIN_LENGTH_MIN);
+}
+
+function initialize_firefly(particle: Particle, viewport: Viewport, rng: () => number): void {
+	particle.x = rng() * viewport.width;
+	particle.y = rng() * viewport.height;
+	particle.vx = (rng() - 0.5) * 2 * FIREFLY_DRIFT_MAX;
+	particle.vy = (rng() - 0.5) * 2 * FIREFLY_DRIFT_MAX;
+	particle.lifetime = FIREFLY_CONFIG.maxLifetimeMs;
+	particle.scale = FIREFLY_SCALE_MIN + rng() * (FIREFLY_SCALE_MAX - FIREFLY_SCALE_MIN);
+	particle.extra = rng() * Math.PI * 2; // phase offset for pulsing
+}
+
+// ─── Update ───────────────────────────────────────────────────────────────
+
+export function update_particles(pool: ParticlePool, delta_ms: number, viewport: Viewport): void {
+	for (const slot of pool.slots) {
+		if (!slot.alive) {
+			continue;
+		}
+		slot.age += delta_ms;
+		slot.x += slot.vx * delta_ms;
+		slot.y += slot.vy * delta_ms;
+		slot.rotation += slot.rotationSpeed * delta_ms;
+		if (slot.age >= slot.lifetime || is_offscreen(slot, viewport)) {
+			release(slot);
+		}
+	}
+}
+
+function is_offscreen(particle: Particle, viewport: Viewport): boolean {
+	const margin = VIEWPORT_MARGIN_PX * 2;
+	return (
+		particle.y > viewport.height + margin ||
+		particle.y < -margin ||
+		particle.x < -margin ||
+		particle.x > viewport.width + margin
+	);
+}
+
+// ─── Spawn rate accumulator ───────────────────────────────────────────────
+
+export function compute_spawn_count(
+	rate_per_second: number,
+	delta_ms: number,
+	prior_remainder: number,
+): SpawnCountResult {
+	if (rate_per_second <= 0) {
+		return { count: 0, remainder: 0 };
+	}
+	const accumulated = prior_remainder + (rate_per_second * delta_ms) / 1000;
+	const count = Math.floor(accumulated);
+	return { count, remainder: accumulated - count };
+}

--- a/src/lib/components/forest-canvas/particle_types.ts
+++ b/src/lib/components/forest-canvas/particle_types.ts
@@ -1,0 +1,58 @@
+// ─── Particle Types & Configs ─────────────────────────────────────────────
+// V1 particle system: hardcoded configs per kind, tuned by editing code.
+// Mutable fields for object-pool reuse (no reallocation).
+
+export type ParticleKind = 'leaf' | 'rain' | 'firefly';
+
+export interface Particle {
+	kind: ParticleKind;
+	alive: boolean;
+	x: number;
+	y: number;
+	/** Velocity in pixels per millisecond. */
+	vx: number;
+	vy: number;
+	/** Age in milliseconds. */
+	age: number;
+	/** Total lifetime in milliseconds; particle is released when age exceeds this. */
+	lifetime: number;
+	/** Rotation in radians (leaves). */
+	rotation: number;
+	/** Angular velocity in radians per millisecond (leaves). */
+	rotationSpeed: number;
+	/** Scale factor used by renderer. */
+	scale: number;
+	/** Kind-specific numeric extra (leaf hue, firefly phase offset, rain length). */
+	extra: number;
+}
+
+export interface ParticleConfig {
+	/** Particles spawned per second at peak weather. */
+	readonly spawnRatePerSecond: number;
+	/** Milliseconds a particle persists before auto-release. */
+	readonly maxLifetimeMs: number;
+}
+
+// Leaves drift down with horizontal sway, always active.
+export const LEAF_CONFIG: ParticleConfig = {
+	spawnRatePerSecond: 4,
+	maxLifetimeMs: 12000,
+} as const;
+
+// Rain falls fast diagonally, only when merge-conflict overlay present.
+export const RAIN_CONFIG: ParticleConfig = {
+	spawnRatePerSecond: 90,
+	maxLifetimeMs: 2500,
+} as const;
+
+// Fireflies drift slowly, only in dark mode.
+export const FIREFLY_CONFIG: ParticleConfig = {
+	spawnRatePerSecond: 2,
+	maxLifetimeMs: 8000,
+} as const;
+
+/** Fixed pool size. ~200 slots covers steady-state needs for 20 trees at peak weather. */
+export const POOL_SIZE = 200 as const;
+
+/** Margin beyond viewport bounds before particles are released. */
+export const VIEWPORT_MARGIN_PX = 40 as const;

--- a/src/lib/components/forest-canvas/weather_state.test.ts
+++ b/src/lib/components/forest-canvas/weather_state.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { derive_weather } from './weather_state';
+import type { TreeVisualization, TreeOverlay } from '$lib/types/tree_visualization';
+
+function create_tree(overlays: readonly TreeOverlay[] = []): TreeVisualization {
+	return {
+		kind: 'tree',
+		stage: 'leafy',
+		overlays,
+		companionSaplings: [],
+		activeTools: [],
+		fruitTypes: [],
+	};
+}
+
+function create_potted_plant(overlays: readonly TreeOverlay[] = []): TreeVisualization {
+	return {
+		kind: 'potted-plant',
+		stage: 'small-plant',
+		overlays,
+	};
+}
+
+describe('derive_weather — leaves', () => {
+	it('leaves is true even with no visible trees', () => {
+		const weather = derive_weather([], false);
+		expect(weather.leaves).toBe(true);
+	});
+
+	it('leaves is always true (V1 decision)', () => {
+		const weather = derive_weather([create_tree()], true);
+		expect(weather.leaves).toBe(true);
+	});
+});
+
+describe('derive_weather — rain from merge-conflict overlay', () => {
+	it('rain is false when no trees have merge-conflict overlay', () => {
+		const weather = derive_weather([create_tree(['behind-base']), create_tree()], false);
+		expect(weather.rain).toBe(false);
+	});
+
+	it('rain is true when any tree has merge-conflict overlay', () => {
+		const weather = derive_weather([create_tree(), create_tree(['merge-conflict'])], false);
+		expect(weather.rain).toBe(true);
+	});
+
+	it('rain is true when potted plant has merge-conflict overlay', () => {
+		const weather = derive_weather([create_potted_plant(['merge-conflict'])], false);
+		expect(weather.rain).toBe(true);
+	});
+
+	it('rain is false when visualizations list is empty', () => {
+		const weather = derive_weather([], false);
+		expect(weather.rain).toBe(false);
+	});
+});
+
+describe('derive_weather — fireflies in dark mode only', () => {
+	it('fireflies is true in dark mode', () => {
+		const weather = derive_weather([create_tree()], true);
+		expect(weather.fireflies).toBe(true);
+	});
+
+	it('fireflies is false in light mode', () => {
+		const weather = derive_weather([create_tree()], false);
+		expect(weather.fireflies).toBe(false);
+	});
+
+	it('fireflies is true in dark mode even with no trees', () => {
+		const weather = derive_weather([], true);
+		expect(weather.fireflies).toBe(true);
+	});
+});

--- a/src/lib/components/forest-canvas/weather_state.ts
+++ b/src/lib/components/forest-canvas/weather_state.ts
@@ -1,0 +1,25 @@
+// ─── Weather State Derivation ─────────────────────────────────────────────
+// Pure derivation of ambient weather flags from the visible-tree overlay
+// descriptors and theme mode. Cheap enough to run on every render.
+
+import type { TreeVisualization } from '$lib/types/tree_visualization';
+
+export interface WeatherState {
+	readonly leaves: boolean;
+	readonly rain: boolean;
+	readonly fireflies: boolean;
+}
+
+export function derive_weather(
+	visualizations: readonly TreeVisualization[],
+	is_dark: boolean,
+): WeatherState {
+	const rain = visualizations.some((visualization) =>
+		visualization.overlays.includes('merge-conflict'),
+	);
+	return {
+		leaves: true,
+		rain,
+		fireflies: is_dark,
+	};
+}


### PR DESCRIPTION
## Description
- Transparent canvas layer over forest viewport rendering ambient particles (leaves, rain, fireflies) via a single `requestAnimationFrame` loop.
- Fixed-size object pool (200 slots) keeps the hot path allocation-free.
- Weather derives reactively from visible tree overlays: leaves always, rain on `merge-conflict`, fireflies in dark mode only.
- Geometric low-poly style matching tree aesthetic; `pointer-events: none` so SVG click handlers are unaffected.

## Resolves
Closes #26

## Acceptance Criteria
- [x] Single canvas covering forest viewport with `pointer-events: none`
- [x] Configurable spawn rate, velocity, lifetime, rendering function per kind (`as const` configs)
- [x] Particle types: falling leaves, rain drops, fireflies
- [x] Weather state derived from visible tree overlay descriptors
- [x] Global rain effect when any tree has `merge-conflict` overlay
- [x] Performance budget: 5ms or less per frame — measured 0.34ms/frame for full update+draw with 65 live particles in a real Chromium
- [x] Canvas does not interfere with SVG click handlers

## Testing
- 45 new unit tests (particle pool, particle system, weather derivation) — all pass
- Browser smoke test via Chrome DevTools: modules imported in real Chromium, 60 simulated frames drew 4940 pixels, 0.335ms avg/frame, no console errors
- `pnpm check:all` clean (svelte-check, oxlint, eslint, stylelint, knip)

## Test plan
- [ ] Load Forest View in Tauri dev and confirm leaves drift downward by default
- [ ] Toggle dark mode — verify fireflies appear
- [ ] Create an issue whose git status surfaces a `merge-conflict` overlay and confirm rain starts
- [ ] Resize the window — verify canvas stays sized correctly and no stale particles pop