### PR TITLE
#56 feat(viz): Tree art gallery — 10 variants for style pick

### DIFF
--- a/src/lib/components/tree/gallery/BonsaiTwist.svelte
+++ b/src/lib/components/tree/gallery/BonsaiTwist.svelte
@@ -1,0 +1,100 @@
+<script lang="ts">
+	import type { AccentColors, AttachmentPoints } from '../types';
+
+	interface Props {
+		accent: AccentColors;
+		trunk_color: string;
+		ground_color: string;
+	}
+
+	let { accent, trunk_color, ground_color }: Props = $props();
+
+	const attachment_points: AttachmentPoints = {
+		crown: { x: 50, y: 18 },
+		trunkBase: { x: 50, y: 105 },
+		roots: { x: 50, y: 118 },
+	};
+</script>
+
+<g data-variant="bonsai-twist" data-attachment-points={JSON.stringify(attachment_points)}>
+	<!-- Ground shadow (compact, bonsai pot-style oval footprint) -->
+	<polygon points="28,118 72,118 68,113 32,113" fill={ground_color} />
+	<polygon points="30,120 70,120 72,118 28,118" fill={ground_color} opacity="0.6" />
+
+	<!-- ── S-curve trunk: 5 angular tapered segments, base(50,105) → top(58,50) ── -->
+	<!-- Segment 1: base curves right -->
+	<polygon points="46,105 54,105 56,92 44,92" fill={trunk_color} />
+	<polygon points="54,105 56,92 55,92 53,105" fill={ground_color} opacity="0.35" />
+
+	<!-- Segment 2: curves back left (belly of S) -->
+	<polygon points="44,92 56,92 50,78 38,80" fill={trunk_color} />
+	<polygon points="56,92 50,78 49,78 55,92" fill={ground_color} opacity="0.35" />
+
+	<!-- Segment 3: curves right across middle -->
+	<polygon points="38,80 50,78 58,66 46,64" fill={trunk_color} />
+	<polygon points="50,78 58,66 57,66 49,78" fill={ground_color} opacity="0.35" />
+
+	<!-- Segment 4: curves left upper -->
+	<polygon points="46,64 58,66 54,54 42,54" fill={trunk_color} />
+	<polygon points="58,66 54,54 53,54 57,66" fill={ground_color} opacity="0.35" />
+
+	<!-- Segment 5: top taper pushing right (windswept cap) -->
+	<polygon points="42,54 54,54 60,48 48,46" fill={trunk_color} />
+	<polygon points="54,54 60,48 59,48 53,54" fill={ground_color} opacity="0.35" />
+
+	<!-- ── Branch connectors (windswept right, reaching to canopy pads) ── -->
+	<!-- Branch A: lower-right pad (horizontal sweep right) -->
+	<polygon points="56,88 72,84 74,86 57,90" fill={trunk_color} />
+	<polygon points="72,84 78,82 79,84 74,86" fill={trunk_color} />
+
+	<!-- Branch B: mid pad upper-right -->
+	<polygon points="56,68 70,60 72,62 57,70" fill={trunk_color} />
+	<polygon points="70,60 80,54 81,56 72,62" fill={trunk_color} />
+
+	<!-- Branch C: left-facing small pad (lone back-branch) -->
+	<polygon points="44,74 32,70 31,72 44,76" fill={trunk_color} />
+	<polygon points="32,70 24,68 23,70 31,72" fill={trunk_color} />
+
+	<!-- Branch D: upper-right pad (near top of trunk) -->
+	<polygon points="58,52 72,44 74,46 59,54" fill={trunk_color} />
+	<polygon points="72,44 82,38 83,40 74,46" fill={trunk_color} />
+
+	<!-- Branch E: crown pad (top) -->
+	<polygon points="56,48 62,36 64,36 58,50" fill={trunk_color} />
+
+	<!-- ── Canopy pads: 5 asymmetric clusters pushed right (windswept) ── -->
+
+	<!-- Pad 1: lower-right (largest) -->
+	<polygon points="78,84 88,82 92,86 90,90 82,92 76,88" fill={accent.front} />
+	<polygon points="88,82 92,86 90,90 86,88" fill={accent.shadow} />
+	<polygon points="78,84 88,82 86,85 80,86" fill={accent.highlight} />
+	<polygon points="76,88 82,92 80,90 77,89" fill={accent.shadow} />
+	<polygon points="78,84 76,88 77,89 79,86" fill={accent.front} />
+
+	<!-- Pad 2: mid-right -->
+	<polygon points="80,54 90,52 94,56 92,60 84,62 78,58" fill={accent.front} />
+	<polygon points="90,52 94,56 92,60 88,58" fill={accent.shadow} />
+	<polygon points="80,54 90,52 88,55 82,56" fill={accent.highlight} />
+	<polygon points="78,58 84,62 82,60 79,59" fill={accent.shadow} />
+	<polygon points="80,54 78,58 79,59 81,56" fill={accent.front} />
+
+	<!-- Pad 3: small back-left pad (lone counter-balance) -->
+	<polygon points="23,68 30,66 33,70 31,73 25,74 20,71" fill={accent.front} />
+	<polygon points="30,66 33,70 31,73 29,71" fill={accent.shadow} />
+	<polygon points="23,68 30,66 28,69 24,70" fill={accent.highlight} />
+	<polygon points="20,71 25,74 23,72 21,72" fill={accent.shadow} />
+
+	<!-- Pad 4: upper-right cluster -->
+	<polygon points="82,38 92,36 96,40 94,44 86,46 80,42" fill={accent.front} />
+	<polygon points="92,36 96,40 94,44 90,42" fill={accent.shadow} />
+	<polygon points="82,38 92,36 90,39 84,40" fill={accent.highlight} />
+	<polygon points="80,42 86,46 84,44 81,43" fill={accent.shadow} />
+	<polygon points="82,38 80,42 81,43 83,40" fill={accent.front} />
+
+	<!-- Pad 5: crown top pad -->
+	<polygon points="62,32 70,30 74,34 72,38 66,40 60,36" fill={accent.front} />
+	<polygon points="70,30 74,34 72,38 68,36" fill={accent.shadow} />
+	<polygon points="62,32 70,30 68,33 64,34" fill={accent.highlight} />
+	<polygon points="60,36 66,40 64,38 61,37" fill={accent.shadow} />
+	<polygon points="62,32 60,36 61,37 63,34" fill={accent.front} />
+</g>

--- a/src/lib/components/tree/gallery/ClusterBirch.svelte
+++ b/src/lib/components/tree/gallery/ClusterBirch.svelte
@@ -1,0 +1,115 @@
+<script lang="ts">
+	import type { AccentColors, AttachmentPoints } from '../types';
+
+	interface Props {
+		accent: AccentColors;
+		trunk_color: string;
+		ground_color: string;
+	}
+
+	let { accent, trunk_color, ground_color }: Props = $props();
+
+	const attachment_points: AttachmentPoints = {
+		crown: { x: 50, y: 18 },
+		trunkBase: { x: 50, y: 105 },
+		roots: { x: 50, y: 118 },
+	};
+</script>
+
+<g data-variant="cluster-birch" data-attachment-points={JSON.stringify(attachment_points)}>
+	<!-- Ground shadow -->
+	<polygon points="18,120 82,120 76,114 24,114" fill={ground_color} />
+
+	<!-- Trunk 1 (left, x=38) -->
+	<rect x="36" y="54" width="4" height="56" fill={trunk_color} />
+	<rect x="36" y="58" width="4" height="1.2" fill={ground_color} opacity="0.85" />
+	<rect x="36" y="68" width="4" height="1" fill={ground_color} opacity="0.85" />
+	<rect x="36" y="80" width="4" height="1.3" fill={ground_color} opacity="0.85" />
+	<rect x="36" y="92" width="4" height="1" fill={ground_color} opacity="0.85" />
+	<rect x="36" y="102" width="4" height="1.2" fill={ground_color} opacity="0.85" />
+
+	<!-- Trunk 2 (center, x=50) -->
+	<rect x="48" y="50" width="4.5" height="60" fill={trunk_color} />
+	<rect x="48" y="55" width="4.5" height="1.3" fill={ground_color} opacity="0.85" />
+	<rect x="48" y="64" width="4.5" height="1" fill={ground_color} opacity="0.85" />
+	<rect x="48" y="74" width="4.5" height="1.2" fill={ground_color} opacity="0.85" />
+	<rect x="48" y="86" width="4.5" height="1" fill={ground_color} opacity="0.85" />
+	<rect x="48" y="97" width="4.5" height="1.3" fill={ground_color} opacity="0.85" />
+
+	<!-- Trunk 3 (right, x=62) -->
+	<rect x="60" y="56" width="4" height="54" fill={trunk_color} />
+	<rect x="60" y="60" width="4" height="1.2" fill={ground_color} opacity="0.85" />
+	<rect x="60" y="70" width="4" height="1" fill={ground_color} opacity="0.85" />
+	<rect x="60" y="82" width="4" height="1.3" fill={ground_color} opacity="0.85" />
+	<rect x="60" y="95" width="4" height="1" fill={ground_color} opacity="0.85" />
+
+	<!-- Airy scattered canopy: leaf clusters (diamonds/rhombus) -->
+
+	<!-- Cluster 1: top-left high -->
+	<polygon points="28,18 32,22 28,26 24,22" fill={accent.front} />
+	<polygon points="28,18 32,22 28,22" fill={accent.shadow} />
+
+	<!-- Cluster 2: top-center -->
+	<polygon points="50,10 54,14 50,18 46,14" fill={accent.front} />
+	<polygon points="50,10 54,14 50,14" fill={accent.shadow} />
+	<polygon points="50,10 52,12 50,13 48,12" fill={accent.highlight} />
+
+	<!-- Cluster 3: top-right high -->
+	<polygon points="70,14 74,18 70,22 66,18" fill={accent.front} />
+	<polygon points="70,14 74,18 70,18" fill={accent.shadow} />
+
+	<!-- Cluster 4: upper-left -->
+	<polygon points="22,28 26,32 22,36 18,32" fill={accent.front} />
+	<polygon points="22,28 26,32 22,32" fill={accent.shadow} />
+
+	<!-- Cluster 5: upper-mid-left -->
+	<polygon points="38,22 42,26 38,30 34,26" fill={accent.front} />
+	<polygon points="38,22 42,26 38,26" fill={accent.shadow} />
+
+	<!-- Cluster 6: upper-mid-right -->
+	<polygon points="60,24 64,28 60,32 56,28" fill={accent.front} />
+	<polygon points="60,24 64,28 60,28" fill={accent.shadow} />
+	<polygon points="60,24 62,26 60,27 58,26" fill={accent.highlight} />
+
+	<!-- Cluster 7: upper-right -->
+	<polygon points="78,26 82,30 78,34 74,30" fill={accent.front} />
+	<polygon points="78,26 82,30 78,30" fill={accent.shadow} />
+
+	<!-- Cluster 8: mid-left -->
+	<polygon points="15,38 19,42 15,46 11,42" fill={accent.front} />
+	<polygon points="15,38 19,42 15,42" fill={accent.shadow} />
+
+	<!-- Cluster 9: center-mid -->
+	<polygon points="48,32 52,36 48,40 44,36" fill={accent.front} />
+	<polygon points="48,32 52,36 48,36" fill={accent.shadow} />
+
+	<!-- Cluster 10: mid-right -->
+	<polygon points="84,40 88,44 84,48 80,44" fill={accent.front} />
+	<polygon points="84,40 88,44 84,44" fill={accent.shadow} />
+
+	<!-- Cluster 11: mid-center-left -->
+	<polygon points="30,42 34,46 30,50 26,46" fill={accent.front} />
+	<polygon points="30,42 34,46 30,46" fill={accent.shadow} />
+	<polygon points="30,42 32,44 30,45 28,44" fill={accent.highlight} />
+
+	<!-- Cluster 12: mid-center-right -->
+	<polygon points="70,38 74,42 70,46 66,42" fill={accent.front} />
+	<polygon points="70,38 74,42 70,42" fill={accent.shadow} />
+
+	<!-- Cluster 13: lower-left -->
+	<polygon points="20,48 24,52 20,56 16,52" fill={accent.front} />
+	<polygon points="20,48 24,52 20,52" fill={accent.shadow} />
+
+	<!-- Cluster 14: lower-mid -->
+	<polygon points="42,44 46,48 42,52 38,48" fill={accent.front} />
+	<polygon points="42,44 46,48 42,48" fill={accent.shadow} />
+
+	<!-- Cluster 15: lower-right -->
+	<polygon points="76,48 80,52 76,56 72,52" fill={accent.front} />
+	<polygon points="76,48 80,52 76,52" fill={accent.shadow} />
+	<polygon points="76,48 78,50 76,51 74,50" fill={accent.highlight} />
+
+	<!-- Cluster 16: center-low -->
+	<polygon points="56,46 60,50 56,54 52,50" fill={accent.front} />
+	<polygon points="56,46 60,50 56,50" fill={accent.shadow} />
+</g>

--- a/src/lib/components/tree/gallery/GhibliHill.svelte
+++ b/src/lib/components/tree/gallery/GhibliHill.svelte
@@ -1,0 +1,125 @@
+<script lang="ts">
+	import type { AccentColors, AttachmentPoints } from '../types';
+
+	interface Props {
+		accent: AccentColors;
+		trunk_color: string;
+		ground_color: string;
+	}
+
+	let { accent, trunk_color, ground_color }: Props = $props();
+
+	const attachment_points: AttachmentPoints = {
+		crown: { x: 50, y: 18 },
+		trunkBase: { x: 50, y: 105 },
+		roots: { x: 50, y: 118 },
+	};
+</script>
+
+<g data-variant="ghibli-hill" data-attachment-points={JSON.stringify(attachment_points)}>
+	<!-- Ground shadow -->
+	<polygon points="18,120 82,120 76,114 24,114" fill={ground_color} />
+
+	<!-- Stubby short trunk (width 12, height 25) -->
+	<rect x="44" y="80" width="12" height="25" fill={trunk_color} />
+	<rect x="46" y="84" width="2" height="20" fill={ground_color} opacity="0.35" />
+
+	<!-- ============================================================ -->
+	<!-- Canopy: 6 cloud-puffs, each subdivided into ~9-10 facets      -->
+	<!-- Layered mound: 3 bottom, 2 middle, 1 top                      -->
+	<!-- Per puff: 4-5 front facets, 2-3 shadow facets, 2 highlights   -->
+	<!-- ============================================================ -->
+
+	<!-- ─── Puff 1: bottom-left ──────────────────────────────────── -->
+	<!-- Shadow facets (right/bottom arc) -->
+	<polygon points="25,50 32,50 38,56 30,58" fill={accent.shadow} />
+	<polygon points="30,58 38,56 38,64 34,66" fill={accent.shadow} />
+	<polygon points="34,66 38,64 36,70 30,76 25,72" fill={accent.shadow} />
+	<!-- Front facets (core) -->
+	<polygon points="22,50 25,50 30,58 25,60 20,58" fill={accent.front} />
+	<polygon points="20,58 25,60 25,72 22,72 18,68" fill={accent.front} />
+	<polygon points="18,68 22,72 25,72 22,76 18,72 14,66" fill={accent.front} />
+	<polygon points="13,60 16,54 22,50 20,58 18,62 14,64" fill={accent.front} />
+	<polygon points="25,60 30,58 34,66 30,70 25,72" fill={accent.front} />
+	<!-- Highlight facets (top-left arc) -->
+	<polygon points="16,54 22,50 22,54 18,56" fill={accent.highlight} />
+	<polygon points="22,50 28,48 26,52 22,54" fill={accent.highlight} />
+
+	<!-- ─── Puff 2: bottom-center ────────────────────────────────── -->
+	<!-- Shadow facets (right/bottom arc) -->
+	<polygon points="48,46 58,46 56,52 50,52" fill={accent.shadow} />
+	<polygon points="56,52 64,52 62,58 56,60" fill={accent.shadow} />
+	<polygon points="56,60 62,58 66,60 64,70 58,70" fill={accent.shadow} />
+	<polygon points="58,70 64,70 56,78 46,80 44,72" fill={accent.shadow} />
+	<!-- Front facets (core) -->
+	<polygon points="40,46 48,46 50,52 44,54 38,50" fill={accent.front} />
+	<polygon points="38,50 44,54 44,62 36,60 32,52" fill={accent.front} />
+	<polygon points="36,60 44,62 44,72 38,74 32,68 28,60" fill={accent.front} />
+	<polygon points="32,68 38,74 46,80 38,78 32,74 28,68" fill={accent.front} />
+	<polygon points="44,54 50,52 56,52 56,60 50,62 44,62" fill={accent.front} />
+	<polygon points="44,62 50,62 56,60 58,70 50,72 44,72" fill={accent.front} />
+	<!-- Highlight facets (top-left arc) -->
+	<polygon points="32,52 40,46 38,50 34,54" fill={accent.highlight} />
+	<polygon points="40,46 48,46 44,50 38,52" fill={accent.highlight} />
+
+	<!-- ─── Puff 3: bottom-right ─────────────────────────────────── -->
+	<!-- Shadow facets (right/bottom arc) -->
+	<polygon points="76,46 82,50 78,54 72,54" fill={accent.shadow} />
+	<polygon points="78,54 86,56 85,62 78,62" fill={accent.shadow} />
+	<polygon points="78,62 85,62 85,68 80,74 74,70" fill={accent.shadow} />
+	<!-- Front facets (core) -->
+	<polygon points="68,46 76,46 72,54 66,52 62,50" fill={accent.front} />
+	<polygon points="62,50 66,52 68,58 60,60 58,56" fill={accent.front} />
+	<polygon points="58,56 60,60 64,66 58,68 56,64" fill={accent.front} />
+	<polygon points="56,64 64,66 66,72 62,76 58,70" fill={accent.front} />
+	<polygon points="66,52 72,54 78,54 78,62 72,64 68,58" fill={accent.front} />
+	<polygon points="68,58 72,64 78,62 74,70 66,72 64,66" fill={accent.front} />
+	<!-- Highlight facets (top-left arc) -->
+	<polygon points="58,56 62,50 62,54 60,56" fill={accent.highlight} />
+	<polygon points="62,50 68,46 66,50 62,54" fill={accent.highlight} />
+
+	<!-- ─── Puff 4: middle-left ──────────────────────────────────── -->
+	<!-- Shadow facets (right/bottom arc) -->
+	<polygon points="36,26 44,30 40,34 34,32" fill={accent.shadow} />
+	<polygon points="40,34 46,36 44,42 38,42" fill={accent.shadow} />
+	<polygon points="38,42 44,42 38,48 30,50 30,44" fill={accent.shadow} />
+	<!-- Front facets (core) -->
+	<polygon points="30,26 36,26 34,32 28,30 24,30" fill={accent.front} />
+	<polygon points="24,30 28,30 30,38 22,38 20,36" fill={accent.front} />
+	<polygon points="22,38 30,38 30,44 24,48 20,42" fill={accent.front} />
+	<polygon points="24,48 30,44 30,50 24,48" fill={accent.front} />
+	<polygon points="28,30 34,32 38,42 30,44 30,38" fill={accent.front} />
+	<!-- Highlight facets (top-left arc) -->
+	<polygon points="24,30 30,26 28,30 26,32" fill={accent.highlight} />
+	<polygon points="30,26 36,26 34,28 30,30" fill={accent.highlight} />
+
+	<!-- ─── Puff 5: middle-right ─────────────────────────────────── -->
+	<!-- Shadow facets (right/bottom arc) -->
+	<polygon points="66,24 74,28 70,32 64,30" fill={accent.shadow} />
+	<polygon points="70,32 78,34 78,40 70,40" fill={accent.shadow} />
+	<polygon points="70,40 78,40 74,46 66,50 62,44" fill={accent.shadow} />
+	<!-- Front facets (core) -->
+	<polygon points="58,24 66,24 64,30 58,28 52,28" fill={accent.front} />
+	<polygon points="52,28 58,28 60,36 52,36 48,34" fill={accent.front} />
+	<polygon points="52,36 60,36 62,44 56,46 52,48 48,42" fill={accent.front} />
+	<polygon points="56,46 62,44 66,50 58,50 54,48" fill={accent.front} />
+	<polygon points="58,28 64,30 70,40 62,44 60,36" fill={accent.front} />
+	<!-- Highlight facets (top-left arc) -->
+	<polygon points="52,28 58,24 56,28 54,30" fill={accent.highlight} />
+	<polygon points="58,24 66,24 62,26 58,28" fill={accent.highlight} />
+
+	<!-- ─── Puff 6: top peak ─────────────────────────────────────── -->
+	<!-- Shadow facets (right/bottom arc) -->
+	<polygon points="52,8 58,10 54,14 48,12" fill={accent.shadow} />
+	<polygon points="54,14 62,14 62,20 56,20" fill={accent.shadow} />
+	<polygon points="56,20 62,20 58,26 50,28 48,22" fill={accent.shadow} />
+	<!-- Front facets (core) -->
+	<polygon points="44,8 52,8 48,12 42,12 38,10" fill={accent.front} />
+	<polygon points="38,10 42,12 44,18 36,18 34,14" fill={accent.front} />
+	<polygon points="36,18 44,18 48,22 42,24 38,24 34,20" fill={accent.front} />
+	<polygon points="42,24 48,22 50,28 42,28" fill={accent.front} />
+	<polygon points="42,12 48,12 54,14 56,20 48,22 44,18" fill={accent.front} />
+	<!-- Highlight facets (top-left arc) -->
+	<polygon points="38,10 44,8 42,12 40,14" fill={accent.highlight} />
+	<polygon points="44,8 52,8 48,10 44,12" fill={accent.highlight} />
+</g>

--- a/src/lib/components/tree/gallery/GnarledAncient.svelte
+++ b/src/lib/components/tree/gallery/GnarledAncient.svelte
@@ -1,0 +1,112 @@
+<script lang="ts">
+	import type { AccentColors, AttachmentPoints } from '../types';
+
+	interface Props {
+		accent: AccentColors;
+		trunk_color: string;
+		ground_color: string;
+	}
+
+	let { accent, trunk_color, ground_color }: Props = $props();
+
+	const attachment_points: AttachmentPoints = {
+		crown: { x: 50, y: 18 },
+		trunkBase: { x: 50, y: 105 },
+		roots: { x: 50, y: 118 },
+	};
+</script>
+
+<g data-variant="gnarled-ancient" data-attachment-points={JSON.stringify(attachment_points)}>
+	<!-- Ground shadow (asymmetric, extending further right) -->
+	<polygon points="14,120 84,120 78,115 22,115" fill={ground_color} />
+	<polygon points="16,118 82,118 74,114 26,114" fill={ground_color} opacity="0.6" />
+
+	<!-- Trunk: tapered wide-at-base, narrow-at-top, leans slightly right -->
+	<polygon points="42,110 58,110 56,50 48,50" fill={trunk_color} />
+	<!-- Trunk shadow side -->
+	<polygon points="52,110 58,110 56,50 53,50" fill={ground_color} opacity="0.35" />
+	<!-- Trunk highlight side -->
+	<polygon points="42,110 45,110 47,55 48,50" fill={trunk_color} opacity="0.7" />
+
+	<!-- Knot protrusions on trunk (asymmetric, 6 knots) -->
+	<polygon points="42,92 39,94 40,98 43,97" fill={trunk_color} />
+	<polygon points="58,82 62,83 62,87 58,86" fill={trunk_color} />
+	<polygon points="42,72 38,73 39,77 43,76" fill={trunk_color} />
+	<polygon points="57,65 61,66 61,69 57,68" fill={trunk_color} />
+	<polygon points="43,58 40,59 41,62 44,61" fill={trunk_color} />
+	<polygon points="57,100 60,101 60,104 57,103" fill={trunk_color} />
+	<!-- Knot shadows -->
+	<polygon points="40,94 40,98 43,97" fill={ground_color} opacity="0.4" />
+	<polygon points="62,83 62,87 58,86" fill={ground_color} opacity="0.4" />
+	<polygon points="38,73 39,77 43,76" fill={ground_color} opacity="0.4" />
+	<polygon points="61,66 61,69 57,68" fill={ground_color} opacity="0.4" />
+
+	<!-- Branch stubs extending into canopy -->
+	<polygon points="48,52 30,44 28,46 47,54" fill={trunk_color} />
+	<polygon points="56,50 74,40 76,42 57,52" fill={trunk_color} />
+	<polygon points="50,48 46,30 48,30 52,48" fill={trunk_color} />
+	<polygon points="54,52 68,52 68,54 54,54" fill={trunk_color} />
+	<polygon points="48,55 34,58 34,60 48,57" fill={trunk_color} />
+	<polygon points="56,46 64,35 66,36 58,46" fill={trunk_color} />
+
+	<!-- Dark interior core polygons (visible through canopy gaps) -->
+	<polygon points="40,40 34,36 32,42 38,44" fill={accent.shadow} />
+	<polygon points="60,32 68,28 70,36 62,38" fill={accent.shadow} />
+	<polygon points="48,28 44,22 50,20 52,26" fill={accent.shadow} />
+	<polygon points="72,44 78,40 80,46 74,48" fill={accent.shadow} />
+	<polygon points="28,44 22,42 22,48 30,48" fill={accent.shadow} />
+	<polygon points="54,40 48,38 50,44 56,44" fill={accent.shadow} />
+	<polygon points="40,30 36,26 42,24 44,30" fill={accent.shadow} />
+
+	<!-- Canopy: asymmetric wide crown (~60 wide, 35 tall), off-center weight -->
+
+	<!-- Cluster 1: Left-upper mass -->
+	<polygon points="28,38 18,44 22,50 32,48 30,40" fill={accent.front} />
+	<polygon points="32,48 22,50 26,54 34,52" fill={accent.shadow} />
+	<polygon points="28,38 22,42 26,45 30,42" fill={accent.highlight} />
+	<polygon points="18,44 14,48 18,52 22,50" fill={accent.front} />
+	<polygon points="22,50 18,52 20,55 24,54" fill={accent.shadow} />
+
+	<!-- Cluster 2: Right-dominant mass (widest point) -->
+	<polygon points="64,26 78,30 82,40 76,48 66,44" fill={accent.front} />
+	<polygon points="76,48 82,40 86,44 80,52" fill={accent.shadow} />
+	<polygon points="64,26 72,28 70,34 66,32" fill={accent.highlight} />
+	<polygon points="78,30 84,34 82,40" fill={accent.front} />
+	<polygon points="82,40 86,44 88,48 84,50" fill={accent.shadow} />
+	<polygon points="66,44 76,48 72,54 64,52" fill={accent.front} />
+	<polygon points="72,54 64,52 66,58 74,56" fill={accent.shadow} />
+
+	<!-- Cluster 3: Top-center mass (slightly left of center) -->
+	<polygon points="44,14 56,16 58,26 46,28 40,22" fill={accent.front} />
+	<polygon points="56,16 58,26 54,24 56,18" fill={accent.shadow} />
+	<polygon points="44,14 52,18 48,22 44,20" fill={accent.highlight} />
+	<polygon points="40,22 46,28 42,32 36,30" fill={accent.front} />
+	<polygon points="42,32 36,30 38,34 44,34" fill={accent.shadow} />
+
+	<!-- Cluster 4: Lower-right twisted branch mass -->
+	<polygon points="58,48 68,50 72,56 64,60 56,56" fill={accent.front} />
+	<polygon points="68,50 72,56 74,58 70,52" fill={accent.shadow} />
+	<polygon points="58,48 64,52 60,54 56,52" fill={accent.highlight} />
+	<polygon points="64,60 56,56 58,62 66,62" fill={accent.shadow} />
+
+	<!-- Connecting foliage between clusters -->
+	<polygon points="34,34 44,30 46,38 36,40" fill={accent.front} />
+	<polygon points="44,30 46,38 42,36" fill={accent.shadow} />
+	<polygon points="56,30 64,26 66,36 58,38" fill={accent.front} />
+	<polygon points="64,26 66,36 62,34" fill={accent.shadow} />
+	<polygon points="46,42 56,42 54,48 48,48" fill={accent.front} />
+	<polygon points="54,48 48,48 50,46 52,46" fill={accent.highlight} />
+
+	<!-- Small twisted outcrops -->
+	<polygon points="30,30 36,28 36,34 32,34" fill={accent.front} />
+	<polygon points="36,28 36,34 34,32" fill={accent.shadow} />
+	<polygon points="70,22 76,24 74,30 68,28" fill={accent.front} />
+	<polygon points="76,24 74,30 72,26" fill={accent.shadow} />
+	<polygon points="50,10 56,12 54,16 48,14" fill={accent.front} />
+	<polygon points="56,12 54,16 52,14" fill={accent.highlight} />
+
+	<!-- Additional dark core peek-throughs at edges -->
+	<polygon points="36,46 32,50 36,52 38,48" fill={accent.shadow} />
+	<polygon points="70,38 74,36 74,42 70,42" fill={accent.shadow} />
+	<polygon points="50,36 54,34 54,38 50,38" fill={accent.shadow} />
+</g>

--- a/src/lib/components/tree/gallery/LayeredBeech.svelte
+++ b/src/lib/components/tree/gallery/LayeredBeech.svelte
@@ -1,0 +1,186 @@
+<script lang="ts">
+	import type { AccentColors, AttachmentPoints } from '../types';
+
+	interface Props {
+		accent: AccentColors;
+		trunk_color: string;
+		ground_color: string;
+	}
+
+	let { accent, trunk_color, ground_color }: Props = $props();
+
+	const attachment_points: AttachmentPoints = {
+		crown: { x: 50, y: 18 },
+		trunkBase: { x: 50, y: 105 },
+		roots: { x: 50, y: 118 },
+	};
+</script>
+
+<g data-variant="layered-beech" data-attachment-points={JSON.stringify(attachment_points)}>
+	<defs>
+		<radialGradient id="beech-canopy-glow" cx="50%" cy="55%" r="65%">
+			<stop offset="0%" stop-color={accent.highlight} stop-opacity="0.95" />
+			<stop offset="55%" stop-color={accent.front} stop-opacity="0.85" />
+			<stop offset="100%" stop-color={accent.shadow} stop-opacity="0.7" />
+		</radialGradient>
+	</defs>
+
+	<!-- Ground shadow -->
+	<polygon points="18,122 82,122 76,115 24,115" fill={ground_color} />
+	<polygon points="24,115 76,115 72,112 28,112" fill={ground_color} opacity="0.6" />
+
+	<!-- Tapered trunk (wider at base ~14, narrower at top ~9) -->
+	<polygon points="43,110 57,110 54.5,50 45.5,50" fill={trunk_color} />
+	<!-- Bark detail lines -->
+	<polygon points="46,108 47,108 46.5,55 45.5,55" fill={ground_color} opacity="0.35" />
+	<polygon points="50,107 50.8,107 50.6,52 49.8,52" fill={ground_color} opacity="0.25" />
+	<polygon points="53,109 54,109 53.6,58 52.6,58" fill={ground_color} opacity="0.3" />
+
+	<!-- Canopy base glow layer (radialGradient) -->
+	<polygon
+		points="50,6 72,10 88,22 92,38 82,50 68,52 50,50 32,52 18,50 8,38 12,22 28,10"
+		fill="url(#beech-canopy-glow)"
+	/>
+
+	<!-- ═══════════════════════════════════════════════════════════════ -->
+	<!-- PUFF 1: Bottom-left cluster (11 facets)                           -->
+	<!-- ═══════════════════════════════════════════════════════════════ -->
+	<!-- front face A (upper) -->
+	<polygon points="24,34 18,40 20,44 26,42 30,40 30,34" fill={accent.front} />
+	<!-- front face B (mid) -->
+	<polygon points="20,44 16,48 22,50 28,48 30,44 26,42" fill={accent.front} opacity="0.95" />
+	<!-- front face C (lower) -->
+	<polygon points="16,48 16,52 22,54 28,54 30,50 28,48 22,50" fill={accent.front} opacity="0.9" />
+	<!-- front face D (right cheek) -->
+	<polygon points="30,40 30,50 36,50 38,44 36,38 30,34" fill={accent.front} opacity="0.92" />
+	<!-- shadow-right upper -->
+	<polygon points="30,34 36,38 38,44 34,42 32,38" fill={accent.shadow} />
+	<!-- shadow-right lower -->
+	<polygon points="38,44 36,50 30,50 32,46 34,42" fill={accent.shadow} opacity="0.9" />
+	<!-- shadow-right edge -->
+	<polygon points="30,50 36,50 34,52 30,54" fill={accent.shadow} opacity="0.7" />
+	<!-- shadow-left upper -->
+	<polygon points="18,40 14,46 16,48 18,44" fill={accent.shadow} opacity="0.85" />
+	<!-- shadow-left lower -->
+	<polygon points="14,46 16,52 22,54 20,50 16,48" fill={accent.shadow} opacity="0.8" />
+	<!-- highlight-top left -->
+	<polygon points="22,38 26,36 26,40 22,42" fill={accent.highlight} />
+	<!-- highlight-top right -->
+	<polygon points="26,36 30,36 28,40 26,40" fill={accent.highlight} opacity="0.9" />
+
+	<!-- ═══════════════════════════════════════════════════════════════ -->
+	<!-- PUFF 2: Bottom-right cluster (11 facets)                          -->
+	<!-- ═══════════════════════════════════════════════════════════════ -->
+	<!-- front face A (upper-left cheek) -->
+	<polygon points="70,34 64,36 62,42 66,44 70,42 72,38" fill={accent.front} />
+	<!-- front face B (center) -->
+	<polygon points="66,44 62,48 66,52 72,52 74,48 70,42" fill={accent.front} opacity="0.95" />
+	<!-- front face C (lower-center) -->
+	<polygon points="62,48 66,54 72,56 74,52 72,52 66,52" fill={accent.front} opacity="0.88" />
+	<!-- front face D (right center) -->
+	<polygon points="70,42 74,48 74,52 80,54 82,48 80,42" fill={accent.front} opacity="0.92" />
+	<!-- shadow-right upper -->
+	<polygon points="80,34 86,38 88,44 84,42 80,40" fill={accent.shadow} />
+	<!-- shadow-right lower -->
+	<polygon points="88,44 86,50 80,54 82,48 84,42" fill={accent.shadow} opacity="0.9" />
+	<!-- shadow-right edge -->
+	<polygon points="80,54 86,50 82,52 76,54" fill={accent.shadow} opacity="0.7" />
+	<!-- shadow-left upper -->
+	<polygon points="64,36 62,42 62,46 64,40" fill={accent.shadow} opacity="0.85" />
+	<!-- shadow-left lower -->
+	<polygon points="62,46 62,48 66,54 66,50 64,46" fill={accent.shadow} opacity="0.8" />
+	<!-- highlight-top left -->
+	<polygon points="68,38 72,36 72,40 68,40" fill={accent.highlight} />
+	<!-- highlight-top right -->
+	<polygon points="72,36 76,38 74,42 72,40" fill={accent.highlight} opacity="0.9" />
+
+	<!-- ═══════════════════════════════════════════════════════════════ -->
+	<!-- PUFF 3: Middle-left cluster (11 facets)                           -->
+	<!-- ═══════════════════════════════════════════════════════════════ -->
+	<!-- front face A (upper) -->
+	<polygon points="30,18 24,22 26,26 32,26 36,24 38,18" fill={accent.front} />
+	<!-- front face B (mid) -->
+	<polygon points="26,26 22,30 24,34 30,34 34,30 32,26" fill={accent.front} opacity="0.95" />
+	<!-- front face C (lower) -->
+	<polygon points="22,30 20,34 24,40 30,42 32,38 30,34 24,34" fill={accent.front} opacity="0.9" />
+	<!-- front face D (right cheek) -->
+	<polygon
+		points="36,24 34,30 30,34 32,38 38,40 42,36 44,28"
+		fill={accent.front}
+		opacity="0.92"
+	/>
+	<!-- shadow-right upper -->
+	<polygon points="38,18 44,22 46,28 42,26 40,22" fill={accent.shadow} />
+	<!-- shadow-right lower -->
+	<polygon points="46,28 44,36 38,40 42,36 44,28" fill={accent.shadow} opacity="0.9" />
+	<!-- shadow-right edge -->
+	<polygon points="38,40 44,36 40,39 32,42" fill={accent.shadow} opacity="0.7" />
+	<!-- shadow-left upper -->
+	<polygon points="24,22 20,28 22,32 24,26" fill={accent.shadow} opacity="0.85" />
+	<!-- shadow-left lower -->
+	<polygon points="22,32 20,28 20,34 24,40 24,34" fill={accent.shadow} opacity="0.8" />
+	<!-- highlight-top left -->
+	<polygon points="28,22 32,20 32,24 28,26" fill={accent.highlight} />
+	<!-- highlight-top right -->
+	<polygon points="32,20 36,22 34,26 32,24" fill={accent.highlight} opacity="0.9" />
+
+	<!-- ═══════════════════════════════════════════════════════════════ -->
+	<!-- PUFF 4: Middle-right cluster (11 facets)                          -->
+	<!-- ═══════════════════════════════════════════════════════════════ -->
+	<!-- front face A (upper-left cheek) -->
+	<polygon points="62,18 56,22 58,26 64,26 68,24 70,18" fill={accent.front} />
+	<!-- front face B (mid) -->
+	<polygon points="58,26 54,28 56,32 62,32 66,30 64,26" fill={accent.front} opacity="0.95" />
+	<!-- front face C (lower) -->
+	<polygon points="56,32 56,36 60,40 66,42 68,38 66,34 62,32" fill={accent.front} opacity="0.9" />
+	<!-- front face D (right cheek) -->
+	<polygon
+		points="68,24 66,30 66,34 68,38 74,40 78,36 80,28"
+		fill={accent.front}
+		opacity="0.92"
+	/>
+	<!-- shadow-right upper -->
+	<polygon points="74,18 80,22 82,30 78,28 76,22" fill={accent.shadow} />
+	<!-- shadow-right lower -->
+	<polygon points="82,30 80,36 74,40 78,36 80,28" fill={accent.shadow} opacity="0.9" />
+	<!-- shadow-right edge -->
+	<polygon points="74,40 80,36 76,39 68,42" fill={accent.shadow} opacity="0.7" />
+	<!-- shadow-left upper -->
+	<polygon points="56,22 54,28 56,32 58,26" fill={accent.shadow} opacity="0.85" />
+	<!-- shadow-left lower -->
+	<polygon points="56,32 54,28 56,36 60,40 58,34" fill={accent.shadow} opacity="0.8" />
+	<!-- highlight-top left -->
+	<polygon points="60,22 64,20 64,24 60,26" fill={accent.highlight} />
+	<!-- highlight-top right -->
+	<polygon points="64,20 68,22 66,26 64,24" fill={accent.highlight} opacity="0.9" />
+
+	<!-- ═══════════════════════════════════════════════════════════════ -->
+	<!-- PUFF 5: Top-center crown cluster (11 facets)                      -->
+	<!-- ═══════════════════════════════════════════════════════════════ -->
+	<!-- front face A (upper-left) -->
+	<polygon points="50,4 42,8 44,12 50,12 54,10" fill={accent.front} />
+	<!-- front face B (mid-left) -->
+	<polygon points="44,12 38,14 40,20 46,20 48,16 50,12" fill={accent.front} opacity="0.95" />
+	<!-- front face C (lower-center) -->
+	<polygon points="40,20 38,22 42,28 50,30 52,24 48,20 46,20" fill={accent.front} opacity="0.9" />
+	<!-- front face D (right cheek) -->
+	<polygon
+		points="54,10 50,12 48,16 52,24 58,24 60,18 58,12"
+		fill={accent.front}
+		opacity="0.92"
+	/>
+	<!-- shadow-right upper -->
+	<polygon points="54,10 58,8 62,14 60,14 58,12" fill={accent.shadow} />
+	<!-- shadow-right lower -->
+	<polygon points="62,14 62,22 58,28 58,24 60,18" fill={accent.shadow} opacity="0.9" />
+	<!-- shadow-right edge -->
+	<polygon points="50,30 58,28 54,29 50,30" fill={accent.shadow} opacity="0.7" />
+	<!-- shadow-left upper -->
+	<polygon points="42,8 38,14 40,16 42,12" fill={accent.shadow} opacity="0.85" />
+	<!-- shadow-left lower -->
+	<polygon points="40,16 38,14 38,22 42,28 42,20" fill={accent.shadow} opacity="0.8" />
+	<!-- highlight-top left -->
+	<polygon points="46,8 50,6 50,10 46,12" fill={accent.highlight} />
+	<!-- highlight-top right -->
+	<polygon points="50,6 54,8 52,12 50,10" fill={accent.highlight} opacity="0.9" />
+</g>

--- a/src/lib/components/tree/gallery/MosaicPoplar.svelte
+++ b/src/lib/components/tree/gallery/MosaicPoplar.svelte
@@ -1,0 +1,105 @@
+<script lang="ts">
+	import type { AccentColors, AttachmentPoints } from '../types';
+
+	interface Props {
+		accent: AccentColors;
+		trunk_color: string;
+		ground_color: string;
+	}
+
+	let { accent, trunk_color, ground_color }: Props = $props();
+
+	const attachment_points: AttachmentPoints = {
+		crown: { x: 50, y: 18 },
+		trunkBase: { x: 50, y: 105 },
+		roots: { x: 50, y: 118 },
+	};
+</script>
+
+<g data-variant="mosaic-poplar" data-attachment-points={JSON.stringify(attachment_points)}>
+	<!-- Ground shadow -->
+	<polygon points="22,120 78,120 72,114 28,114" fill={ground_color} />
+
+	<!-- Trunk (slim segmented) -->
+	<rect x="46" y="50" width="8" height="60" fill={trunk_color} />
+	<rect x="46" y="58" width="8" height="1" fill={ground_color} opacity="0.55" />
+	<rect x="46" y="70" width="8" height="1" fill={ground_color} opacity="0.55" />
+	<rect x="46" y="82" width="8" height="1" fill={ground_color} opacity="0.55" />
+	<rect x="46" y="94" width="8" height="1" fill={ground_color} opacity="0.55" />
+
+	<!-- Canopy: columnar tessellated tall poplar (crown zone y 5-50) -->
+	<!-- Row 1: peak (y 5-14) -->
+	<polygon points="50,5 46,14 54,14" fill={accent.front} />
+	<polygon points="50,5 54,14 52,9" fill={accent.highlight} />
+	<polygon points="50,5 46,14 48,9" fill={accent.shadow} />
+
+	<!-- Row 2: y 14-20 -->
+	<polygon points="46,14 50,14 48,20" fill={accent.front} />
+	<polygon points="50,14 54,14 52,20" fill={accent.highlight} />
+	<polygon points="46,14 48,20 44,20" fill={accent.shadow} />
+	<polygon points="54,14 56,20 52,20" fill={accent.front} />
+	<polygon points="50,14 52,20 48,20" fill={accent.shadow} />
+
+	<!-- Row 3: y 20-26 -->
+	<polygon points="44,20 48,20 46,26" fill={accent.front} />
+	<polygon points="48,20 52,20 50,26" fill={accent.highlight} />
+	<polygon points="52,20 56,20 54,26" fill={accent.front} />
+	<polygon points="44,20 46,26 42,26" fill={accent.shadow} />
+	<polygon points="56,20 58,26 54,26" fill={accent.front} />
+	<polygon points="48,20 50,26 46,26" fill={accent.shadow} />
+	<polygon points="52,20 54,26 50,26" fill={accent.shadow} />
+
+	<!-- Row 4: y 26-32 -->
+	<polygon points="42,26 46,26 44,32" fill={accent.front} />
+	<polygon points="46,26 50,26 48,32" fill={accent.highlight} />
+	<polygon points="50,26 54,26 52,32" fill={accent.front} />
+	<polygon points="54,26 58,26 56,32" fill={accent.highlight} />
+	<polygon points="42,26 44,32 40,32" fill={accent.shadow} />
+	<polygon points="58,26 60,32 56,32" fill={accent.front} />
+	<polygon points="46,26 48,32 44,32" fill={accent.shadow} />
+	<polygon points="50,26 52,32 48,32" fill={accent.shadow} />
+	<polygon points="54,26 56,32 52,32" fill={accent.shadow} />
+
+	<!-- Row 5: y 32-38 (widest middle) -->
+	<polygon points="40,32 44,32 42,38" fill={accent.front} />
+	<polygon points="44,32 48,32 46,38" fill={accent.front} />
+	<polygon points="48,32 52,32 50,38" fill={accent.highlight} />
+	<polygon points="52,32 56,32 54,38" fill={accent.front} />
+	<polygon points="56,32 60,32 58,38" fill={accent.highlight} />
+	<polygon points="40,32 42,38 38,38" fill={accent.shadow} />
+	<polygon points="60,32 62,38 58,38" fill={accent.front} />
+	<polygon points="44,32 46,38 42,38" fill={accent.shadow} />
+	<polygon points="48,32 50,38 46,38" fill={accent.shadow} />
+	<polygon points="52,32 54,38 50,38" fill={accent.shadow} />
+	<polygon points="56,32 58,38 54,38" fill={accent.shadow} />
+
+	<!-- Row 6: y 38-44 -->
+	<polygon points="38,38 42,38 40,44" fill={accent.front} />
+	<polygon points="42,38 46,38 44,44" fill={accent.highlight} />
+	<polygon points="46,38 50,38 48,44" fill={accent.front} />
+	<polygon points="50,38 54,38 52,44" fill={accent.highlight} />
+	<polygon points="54,38 58,38 56,44" fill={accent.front} />
+	<polygon points="58,38 62,38 60,44" fill={accent.front} />
+	<polygon points="38,38 40,44 36,44" fill={accent.shadow} />
+	<polygon points="62,38 64,44 60,44" fill={accent.shadow} />
+	<polygon points="42,38 44,44 40,44" fill={accent.shadow} />
+	<polygon points="46,38 48,44 44,44" fill={accent.shadow} />
+	<polygon points="50,38 52,44 48,44" fill={accent.shadow} />
+	<polygon points="54,38 56,44 52,44" fill={accent.shadow} />
+	<polygon points="58,38 60,44 56,44" fill={accent.shadow} />
+
+	<!-- Row 7: y 44-50 (base) -->
+	<polygon points="36,44 40,44 38,50" fill={accent.front} />
+	<polygon points="40,44 44,44 42,50" fill={accent.front} />
+	<polygon points="44,44 48,44 46,50" fill={accent.front} />
+	<polygon points="48,44 52,44 50,50" fill={accent.highlight} />
+	<polygon points="52,44 56,44 54,50" fill={accent.front} />
+	<polygon points="56,44 60,44 58,50" fill={accent.front} />
+	<polygon points="60,44 64,44 62,50" fill={accent.front} />
+	<polygon points="40,44 42,50 38,50" fill={accent.shadow} />
+	<polygon points="44,44 46,50 42,50" fill={accent.shadow} />
+	<polygon points="48,44 50,50 46,50" fill={accent.shadow} />
+	<polygon points="52,44 54,50 50,50" fill={accent.shadow} />
+	<polygon points="56,44 58,50 54,50" fill={accent.shadow} />
+	<polygon points="60,44 62,50 58,50" fill={accent.shadow} />
+</g>

--- a/src/lib/components/tree/gallery/PrismPine.svelte
+++ b/src/lib/components/tree/gallery/PrismPine.svelte
@@ -1,0 +1,183 @@
+<script lang="ts">
+	import type { AccentColors, AttachmentPoints } from '../types';
+
+	interface Props {
+		accent: AccentColors;
+		trunk_color: string;
+		ground_color: string;
+	}
+
+	let { accent, trunk_color, ground_color }: Props = $props();
+
+	const attachment_points: AttachmentPoints = {
+		crown: { x: 50, y: 18 },
+		trunkBase: { x: 50, y: 105 },
+		roots: { x: 50, y: 118 },
+	};
+</script>
+
+<g data-variant="prism-pine" data-attachment-points={JSON.stringify(attachment_points)}>
+	<!-- Ground shadow -->
+	<polygon points="18,120 82,120 76,114 24,114" fill={ground_color} />
+
+	<!-- Trunk (straight dark) -->
+	<polygon points="45,50 55,50 55,110 45,110" fill={trunk_color} />
+	<!-- Trunk bark grain highlights -->
+	<polygon points="46.5,53 47.3,53 47.3,108 46.5,108" fill={ground_color} opacity="0.35" />
+	<polygon points="49.5,52 50.3,52 50.3,109 49.5,109" fill={ground_color} opacity="0.25" />
+	<polygon points="52.6,54 53.4,54 53.4,107 52.6,107" fill={ground_color} opacity="0.35" />
+
+	<!-- Conical canopy - triangular tile facets in 10 horizontal rows -->
+	<!-- Row 10 (bottom, widest) y: 45-52, width 36 (x: 14-86) -->
+	<polygon points="14,52 23,52 18.5,45" fill={accent.front} />
+	<polygon points="23,52 18.5,45 27.5,45" fill={accent.shadow} />
+	<polygon points="23,52 32,52 27.5,45" fill={accent.front} />
+	<polygon points="32,52 27.5,45 36.5,45" fill={accent.highlight} />
+	<polygon points="32,52 41,52 36.5,45" fill={accent.shadow} />
+	<polygon points="41,52 36.5,45 45.5,45" fill={accent.front} />
+	<polygon points="41,52 50,52 45.5,45" fill={accent.shadow} />
+	<polygon points="50,52 45.5,45 54.5,45" fill={accent.front} />
+	<polygon points="50,52 59,52 54.5,45" fill={accent.highlight} />
+	<polygon points="59,52 54.5,45 63.5,45" fill={accent.shadow} />
+	<polygon points="59,52 68,52 63.5,45" fill={accent.front} />
+	<polygon points="68,52 63.5,45 72.5,45" fill={accent.shadow} />
+	<polygon points="68,52 77,52 72.5,45" fill={accent.front} />
+	<polygon points="77,52 72.5,45 81.5,45" fill={accent.shadow} opacity="0.7" />
+	<polygon points="77,52 86,52 81.5,45" fill={accent.shadow} />
+
+	<!-- Row 9 y: 38-45, width 32 (x: 18-82) -->
+	<polygon points="18,45 26,45 22,38" fill={accent.shadow} />
+	<polygon points="26,45 22,38 30,38" fill={accent.front} />
+	<polygon points="26,45 34,45 30,38" fill={accent.shadow} />
+	<polygon points="34,45 30,38 38,38" fill={accent.highlight} />
+	<polygon points="34,45 42,45 38,38" fill={accent.front} />
+	<polygon points="42,45 38,38 46,38" fill={accent.shadow} />
+	<polygon points="42,45 50,45 46,38" fill={accent.front} />
+	<polygon points="50,45 46,38 54,38" fill={accent.shadow} />
+	<polygon points="50,45 58,45 54,38" fill={accent.front} />
+	<polygon points="58,45 54,38 62,38" fill={accent.highlight} />
+	<polygon points="58,45 66,45 62,38" fill={accent.shadow} />
+	<polygon points="66,45 62,38 70,38" fill={accent.front} />
+	<polygon points="66,45 74,45 70,38" fill={accent.shadow} opacity="0.7" />
+	<polygon points="74,45 70,38 78,38" fill={accent.shadow} />
+	<polygon points="74,45 82,45 78,38" fill={accent.front} />
+
+	<!-- Row 8 y: 32-38, width 28 (x: 22-78) -->
+	<polygon points="22,38 29,38 25.5,32" fill={accent.front} />
+	<polygon points="29,38 25.5,32 32.5,32" fill={accent.shadow} />
+	<polygon points="29,38 36,38 32.5,32" fill={accent.front} />
+	<polygon points="36,38 32.5,32 39.5,32" fill={accent.shadow} />
+	<polygon points="36,38 43,38 39.5,32" fill={accent.highlight} />
+	<polygon points="43,38 39.5,32 46.5,32" fill={accent.front} />
+	<polygon points="43,38 50,38 46.5,32" fill={accent.shadow} />
+	<polygon points="50,38 46.5,32 53.5,32" fill={accent.front} />
+	<polygon points="50,38 57,38 53.5,32" fill={accent.shadow} />
+	<polygon points="57,38 53.5,32 60.5,32" fill={accent.front} />
+	<polygon points="57,38 64,38 60.5,32" fill={accent.shadow} opacity="0.7" />
+	<polygon points="64,38 60.5,32 67.5,32" fill={accent.highlight} />
+	<polygon points="64,38 71,38 67.5,32" fill={accent.shadow} />
+	<polygon points="71,38 67.5,32 74.5,32" fill={accent.front} />
+	<polygon points="71,38 78,38 74.5,32" fill={accent.shadow} />
+
+	<!-- Row 7 y: 27-32, width 24 (x: 26-74) -->
+	<polygon points="26,32 32,32 29,27" fill={accent.shadow} />
+	<polygon points="32,32 29,27 35,27" fill={accent.front} />
+	<polygon points="32,32 38,32 35,27" fill={accent.shadow} />
+	<polygon points="38,32 35,27 41,27" fill={accent.front} />
+	<polygon points="38,32 44,32 41,27" fill={accent.highlight} />
+	<polygon points="44,32 41,27 47,27" fill={accent.shadow} />
+	<polygon points="44,32 50,32 47,27" fill={accent.front} />
+	<polygon points="50,32 47,27 53,27" fill={accent.shadow} />
+	<polygon points="50,32 56,32 53,27" fill={accent.front} />
+	<polygon points="56,32 53,27 59,27" fill={accent.shadow} />
+	<polygon points="56,32 62,32 59,27" fill={accent.front} />
+	<polygon points="62,32 59,27 65,27" fill={accent.highlight} />
+	<polygon points="62,32 68,32 65,27" fill={accent.shadow} opacity="0.7" />
+	<polygon points="68,32 65,27 71,27" fill={accent.front} />
+	<polygon points="68,32 74,32 71,27" fill={accent.shadow} />
+
+	<!-- Row 6 y: 23-27, width 20 (x: 30-70) -->
+	<polygon points="30,27 35,27 32.5,23" fill={accent.front} />
+	<polygon points="35,27 32.5,23 37.5,23" fill={accent.shadow} />
+	<polygon points="35,27 40,27 37.5,23" fill={accent.front} />
+	<polygon points="40,27 37.5,23 42.5,23" fill={accent.highlight} />
+	<polygon points="40,27 45,27 42.5,23" fill={accent.shadow} />
+	<polygon points="45,27 42.5,23 47.5,23" fill={accent.front} />
+	<polygon points="45,27 50,27 47.5,23" fill={accent.shadow} />
+	<polygon points="50,27 47.5,23 52.5,23" fill={accent.front} />
+	<polygon points="50,27 55,27 52.5,23" fill={accent.shadow} />
+	<polygon points="55,27 52.5,23 57.5,23" fill={accent.front} />
+	<polygon points="55,27 60,27 57.5,23" fill={accent.highlight} />
+	<polygon points="60,27 57.5,23 62.5,23" fill={accent.shadow} />
+	<polygon points="60,27 65,27 62.5,23" fill={accent.front} />
+	<polygon points="65,27 62.5,23 67.5,23" fill={accent.shadow} />
+	<polygon points="65,27 70,27 67.5,23" fill={accent.front} />
+
+	<!-- Row 5 y: 19-23, width 16 (x: 34-66) -->
+	<polygon points="34,23 38,23 36,19" fill={accent.shadow} />
+	<polygon points="38,23 36,19 40,19" fill={accent.front} />
+	<polygon points="38,23 42,23 40,19" fill={accent.shadow} />
+	<polygon points="42,23 40,19 44,19" fill={accent.front} />
+	<polygon points="42,23 46,23 44,19" fill={accent.highlight} />
+	<polygon points="46,23 44,19 48,19" fill={accent.shadow} />
+	<polygon points="46,23 50,23 48,19" fill={accent.front} />
+	<polygon points="50,23 48,19 52,19" fill={accent.shadow} />
+	<polygon points="50,23 54,23 52,19" fill={accent.front} />
+	<polygon points="54,23 52,19 56,19" fill={accent.shadow} />
+	<polygon points="54,23 58,23 56,19" fill={accent.front} />
+	<polygon points="58,23 56,19 60,19" fill={accent.highlight} />
+	<polygon points="58,23 62,23 60,19" fill={accent.shadow} />
+	<polygon points="62,23 60,19 64,19" fill={accent.front} />
+	<polygon points="62,23 66,23 64,19" fill={accent.shadow} />
+
+	<!-- Row 4 y: 15-19, width 12 (x: 38-62) -->
+	<polygon points="38,19 41,19 39.5,15" fill={accent.front} />
+	<polygon points="41,19 39.5,15 42.5,15" fill={accent.shadow} />
+	<polygon points="41,19 44,19 42.5,15" fill={accent.front} />
+	<polygon points="44,19 42.5,15 45.5,15" fill={accent.shadow} />
+	<polygon points="44,19 47,19 45.5,15" fill={accent.highlight} />
+	<polygon points="47,19 45.5,15 48.5,15" fill={accent.shadow} />
+	<polygon points="47,19 50,19 48.5,15" fill={accent.front} />
+	<polygon points="50,19 48.5,15 51.5,15" fill={accent.shadow} />
+	<polygon points="50,19 53,19 51.5,15" fill={accent.front} />
+	<polygon points="53,19 51.5,15 54.5,15" fill={accent.shadow} />
+	<polygon points="53,19 56,19 54.5,15" fill={accent.front} />
+	<polygon points="56,19 54.5,15 57.5,15" fill={accent.shadow} />
+	<polygon points="56,19 59,19 57.5,15" fill={accent.highlight} />
+	<polygon points="59,19 57.5,15 60.5,15" fill={accent.shadow} />
+	<polygon points="59,19 62,19 60.5,15" fill={accent.front} />
+
+	<!-- Row 3 y: 11-15, width 8 (x: 42-58) -->
+	<polygon points="42,15 44.5,15 43.25,11" fill={accent.shadow} />
+	<polygon points="44.5,15 43.25,11 45.75,11" fill={accent.front} />
+	<polygon points="44.5,15 47,15 45.75,11" fill={accent.shadow} />
+	<polygon points="47,15 45.75,11 48.25,11" fill={accent.front} />
+	<polygon points="47,15 49.5,15 48.25,11" fill={accent.highlight} />
+	<polygon points="49.5,15 48.25,11 50.75,11" fill={accent.shadow} />
+	<polygon points="49.5,15 52,15 50.75,11" fill={accent.front} />
+	<polygon points="52,15 50.75,11 53.25,11" fill={accent.shadow} />
+	<polygon points="52,15 54.5,15 53.25,11" fill={accent.front} />
+	<polygon points="54.5,15 53.25,11 55.75,11" fill={accent.shadow} />
+	<polygon points="54.5,15 57,15 55.75,11" fill={accent.front} />
+	<polygon points="57,15 55.75,11 58.25,11" fill={accent.shadow} />
+
+	<!-- Row 2 y: 7-11, width 5 (x: 45-55) -->
+	<polygon points="45,11 47,11 46,7" fill={accent.front} />
+	<polygon points="47,11 46,7 48,7" fill={accent.shadow} />
+	<polygon points="47,11 49,11 48,7" fill={accent.front} />
+	<polygon points="49,11 48,7 50,7" fill={accent.highlight} />
+	<polygon points="49,11 51,11 50,7" fill={accent.shadow} />
+	<polygon points="51,11 50,7 52,7" fill={accent.front} />
+	<polygon points="51,11 53,11 52,7" fill={accent.shadow} />
+	<polygon points="53,11 52,7 54,7" fill={accent.front} />
+	<polygon points="53,11 55,11 54,7" fill={accent.shadow} />
+
+	<!-- Row 1 (peak) y: 3-7, width 3 (x: 47-53) -->
+	<polygon points="47,7 48.5,7 47.75,3" fill={accent.shadow} />
+	<polygon points="48.5,7 47.75,3 49.25,3" fill={accent.front} />
+	<polygon points="48.5,7 50,7 49.25,3" fill={accent.highlight} />
+	<polygon points="50,7 49.25,3 50.75,3" fill={accent.shadow} />
+	<polygon points="50,7 51.5,7 50.75,3" fill={accent.front} />
+	<polygon points="51.5,7 50.75,3 52.25,3" fill={accent.shadow} />
+	<polygon points="51.5,7 53,7 52.25,3" fill={accent.front} />
+</g>

--- a/src/lib/components/tree/gallery/RoundedOak.svelte
+++ b/src/lib/components/tree/gallery/RoundedOak.svelte
@@ -1,0 +1,112 @@
+<script lang="ts">
+	import type { AccentColors, AttachmentPoints } from '../types';
+
+	interface Props {
+		accent: AccentColors;
+		trunk_color: string;
+		ground_color: string;
+	}
+
+	let { accent, trunk_color, ground_color }: Props = $props();
+
+	const attachment_points: AttachmentPoints = {
+		crown: { x: 50, y: 18 },
+		trunkBase: { x: 50, y: 105 },
+		roots: { x: 50, y: 118 },
+	};
+</script>
+
+<g data-variant="rounded-oak" data-attachment-points={JSON.stringify(attachment_points)}>
+	<defs>
+		<linearGradient id="rounded-oak-canopy-gradient" x1="0" y1="0" x2="0" y2="1">
+			<stop offset="0%" stop-color={accent.highlight} stop-opacity="0.9" />
+			<stop offset="55%" stop-color={accent.front} stop-opacity="1" />
+			<stop offset="100%" stop-color={accent.shadow} stop-opacity="1" />
+		</linearGradient>
+	</defs>
+
+	<!-- Ground shadow -->
+	<polygon points="18,120 82,120 76,114 24,114" fill={ground_color} />
+
+	<!-- Trunk (thick, ~16 wide) -->
+	<polygon points="42,50 58,50 59,108 41,108" fill={trunk_color} />
+	<!-- Trunk shadow side -->
+	<polygon points="54,50 58,50 59,108 55,108" fill={ground_color} opacity="0.35" />
+	<!-- Trunk highlight stripe -->
+	<polygon points="44,52 46,52 46,106 44,106" fill={accent.highlight} opacity="0.18" />
+
+	<!-- Trunk knots (3 small dark polygons protruding from sides) -->
+	<polygon points="41,62 38,64 39,68 41,67" fill={trunk_color} opacity="0.65" />
+	<polygon points="59,76 62,78 61,82 59,81" fill={trunk_color} opacity="0.65" />
+	<polygon points="41,90 37,92 38,96 41,95" fill={trunk_color} opacity="0.65" />
+	<polygon points="59,54 61,55 60,58 59,58" fill={trunk_color} opacity="0.55" />
+
+	<!-- Canopy background mass (gradient, broad rounded silhouette) -->
+	<polygon
+		points="50,6 62,7 73,10 82,16 87,24 88,32 85,40 78,46 68,49 56,50 44,50 32,49 22,46 15,40 12,32 13,24 18,16 27,10 38,7"
+		fill="url(#rounded-oak-canopy-gradient)"
+	/>
+
+	<!-- ═══ PUFF 1: Top-left puff ═══ -->
+	<polygon points="26,14 32,9 38,8 42,11 43,18 40,24 33,26 27,24 23,19" fill={accent.front} />
+	<polygon points="40,24 43,18 42,11 43,14 42,22" fill={accent.shadow} />
+	<polygon points="33,26 40,24 42,22 40,26 34,28" fill={accent.shadow} />
+	<polygon points="32,9 38,8 36,11 31,12" fill={accent.highlight} />
+
+	<!-- ═══ PUFF 2: Top-center puff ═══ -->
+	<polygon points="42,6 50,4 58,6 62,12 60,19 54,22 46,22 40,19 40,12" fill={accent.front} />
+	<polygon points="60,19 62,12 58,6 59,10 61,15" fill={accent.shadow} />
+	<polygon points="54,22 60,19 61,15 58,22 52,24" fill={accent.shadow} />
+	<polygon points="50,4 58,6 54,7 48,7 44,7" fill={accent.highlight} />
+
+	<!-- ═══ PUFF 3: Top-right puff ═══ -->
+	<polygon points="58,11 64,8 70,9 76,14 77,19 73,24 67,26 61,24 57,18" fill={accent.front} />
+	<polygon points="73,24 77,19 76,14 78,17 76,22" fill={accent.shadow} />
+	<polygon points="67,26 73,24 76,22 73,26 68,28" fill={accent.shadow} />
+	<polygon points="64,8 70,9 68,11 63,12" fill={accent.highlight} />
+
+	<!-- ═══ PUFF 4: Left-shoulder puff ═══ -->
+	<polygon points="14,22 20,17 26,17 30,22 30,29 26,34 19,34 14,30 12,26" fill={accent.front} />
+	<polygon points="30,29 30,22 26,17 29,20 31,26" fill={accent.shadow} />
+	<polygon points="26,34 30,29 31,26 29,33 24,35" fill={accent.shadow} />
+	<polygon points="20,17 26,17 23,19 18,20" fill={accent.highlight} />
+
+	<!-- ═══ PUFF 5: Right-shoulder puff ═══ -->
+	<polygon points="70,22 74,17 80,17 86,22 88,26 86,30 80,34 73,34 69,29" fill={accent.front} />
+	<polygon points="86,30 88,26 86,22 87,25 88,29" fill={accent.shadow} />
+	<polygon points="80,34 86,30 88,29 84,34 78,35" fill={accent.shadow} />
+	<polygon points="74,17 80,17 77,19 72,20" fill={accent.highlight} />
+
+	<!-- ═══ PUFF 6: Center puff (large, dominant) ═══ -->
+	<polygon
+		points="38,18 46,14 54,14 62,18 64,26 60,34 52,37 44,37 36,33 34,26"
+		fill={accent.front}
+	/>
+	<polygon points="60,34 64,26 62,18 64,22 65,30" fill={accent.shadow} />
+	<polygon points="52,37 60,34 65,30 58,37 50,39" fill={accent.shadow} />
+	<polygon points="46,14 54,14 50,16 44,16" fill={accent.highlight} />
+
+	<!-- ═══ PUFF 7: Lower-left puff ═══ -->
+	<polygon points="20,32 26,28 32,29 37,33 37,40 32,45 24,45 19,41 17,36" fill={accent.front} />
+	<polygon points="37,40 37,33 32,29 36,32 38,38" fill={accent.shadow} />
+	<polygon points="32,45 37,40 38,38 35,45 29,47" fill={accent.shadow} />
+	<polygon points="26,28 32,29 28,31 23,31" fill={accent.highlight} />
+
+	<!-- ═══ PUFF 8: Lower-center puff ═══ -->
+	<polygon points="40,32 48,29 56,29 62,33 63,40 58,45 50,47 42,46 38,41" fill={accent.front} />
+	<polygon points="58,45 63,40 62,33 64,37 62,44" fill={accent.shadow} />
+	<polygon points="50,47 58,45 62,44 56,48 48,49" fill={accent.shadow} />
+	<polygon points="48,29 56,29 52,31 46,31" fill={accent.highlight} />
+
+	<!-- ═══ PUFF 9: Lower-right puff ═══ -->
+	<polygon points="64,32 70,29 76,30 80,34 81,40 77,45 71,45 65,42 63,37" fill={accent.front} />
+	<polygon points="77,45 81,40 80,34 82,38 81,44" fill={accent.shadow} />
+	<polygon points="71,45 77,45 81,44 76,47 70,47" fill={accent.shadow} />
+	<polygon points="70,29 76,30 72,31 68,31" fill={accent.highlight} />
+
+	<!-- ═══ PUFF 10: Bottom-bridge puff ═══ -->
+	<polygon points="32,42 40,39 50,40 60,40 68,42 66,48 56,50 44,50 34,48" fill={accent.front} />
+	<polygon points="66,48 68,42 60,40 64,44 66,46" fill={accent.shadow} />
+	<polygon points="56,50 66,48 66,46 58,50 50,51" fill={accent.shadow} />
+	<polygon points="40,39 50,40 60,40 50,41 42,41" fill={accent.highlight} />
+</g>

--- a/src/lib/components/tree/gallery/StackedFir.svelte
+++ b/src/lib/components/tree/gallery/StackedFir.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+	import type { AccentColors, AttachmentPoints } from '../types';
+
+	interface Props {
+		accent: AccentColors;
+		trunk_color: string;
+		ground_color: string;
+	}
+
+	let { accent, trunk_color, ground_color }: Props = $props();
+
+	const attachment_points: AttachmentPoints = {
+		crown: { x: 50, y: 18 },
+		trunkBase: { x: 50, y: 105 },
+		roots: { x: 50, y: 118 },
+	};
+</script>
+
+<g data-variant="stacked-fir" data-attachment-points={JSON.stringify(attachment_points)}>
+	<!-- Ground shadow -->
+	<polygon points="18,120 82,120 76,114 24,114" fill={ground_color} />
+
+	<!-- Trunk -->
+	<rect x="45" y="48" width="10" height="62" fill={trunk_color} />
+	<!-- Trunk bark lines -->
+	<rect x="47" y="52" width="1" height="54" fill={ground_color} opacity="0.45" />
+	<rect x="52" y="54" width="1" height="52" fill={ground_color} opacity="0.45" />
+
+	<!-- Layer 1 (bottom, widest) y: 40-50 -->
+	<polygon points="50,40 18,50 82,50" fill={accent.front} />
+	<polygon points="50,40 82,50 68,47" fill={accent.shadow} />
+	<polygon points="50,40 32,47 18,50" fill={accent.shadow} opacity="0.75" />
+	<polygon points="50,40 40,45 50,44" fill={accent.highlight} />
+	<polygon points="50,40 68,47 82,50" fill={accent.shadow} />
+	<polygon points="50,50 62,48 72,50" fill={accent.highlight} opacity="0.35" />
+	<polygon points="28,50 38,49 50,50" fill={accent.front} opacity="0.7" />
+
+	<!-- Layer 2 y: 34-43 -->
+	<polygon points="50,34 22,43 78,43" fill={accent.front} />
+	<polygon points="50,34 78,43 66,40" fill={accent.shadow} />
+	<polygon points="50,34 34,40 22,43" fill={accent.shadow} opacity="0.75" />
+	<polygon points="50,34 42,38 50,37" fill={accent.highlight} />
+	<polygon points="50,43 60,41 68,43" fill={accent.highlight} opacity="0.35" />
+	<polygon points="32,43 40,42 50,43" fill={accent.front} opacity="0.7" />
+
+	<!-- Layer 3 y: 28-37 -->
+	<polygon points="50,28 26,37 74,37" fill={accent.front} />
+	<polygon points="50,28 74,37 62,34" fill={accent.shadow} />
+	<polygon points="50,28 36,34 26,37" fill={accent.shadow} opacity="0.75" />
+	<polygon points="50,28 42,32 50,31" fill={accent.highlight} />
+	<polygon points="50,37 58,35 64,37" fill={accent.highlight} opacity="0.35" />
+	<polygon points="36,37 42,36 50,37" fill={accent.front} opacity="0.7" />
+
+	<!-- Layer 4 y: 22-31 -->
+	<polygon points="50,22 30,31 70,31" fill={accent.front} />
+	<polygon points="50,22 70,31 60,28" fill={accent.shadow} />
+	<polygon points="50,22 38,28 30,31" fill={accent.shadow} opacity="0.75" />
+	<polygon points="50,22 43,26 50,25" fill={accent.highlight} />
+	<polygon points="50,31 56,29 62,31" fill={accent.highlight} opacity="0.35" />
+	<polygon points="38,31 44,30 50,31" fill={accent.front} opacity="0.7" />
+
+	<!-- Layer 5 y: 16-25 -->
+	<polygon points="50,16 34,25 66,25" fill={accent.front} />
+	<polygon points="50,16 66,25 58,23" fill={accent.shadow} />
+	<polygon points="50,16 42,23 34,25" fill={accent.shadow} opacity="0.75" />
+	<polygon points="50,16 44,21 50,20" fill={accent.highlight} />
+	<polygon points="50,25 55,24 60,25" fill={accent.highlight} opacity="0.35" />
+
+	<!-- Layer 6 y: 10-19 -->
+	<polygon points="50,10 38,19 62,19" fill={accent.front} />
+	<polygon points="50,10 62,19 55,17" fill={accent.shadow} />
+	<polygon points="50,10 45,17 38,19" fill={accent.shadow} opacity="0.75" />
+	<polygon points="50,10 46,15 50,15" fill={accent.highlight} />
+	<polygon points="50,19 54,18 58,19" fill={accent.highlight} opacity="0.35" />
+
+	<!-- Layer 7 (peak) y: 4-13 -->
+	<polygon points="50,4 42,13 58,13" fill={accent.front} />
+	<polygon points="50,4 58,13 53,11" fill={accent.shadow} />
+	<polygon points="50,4 47,11 42,13" fill={accent.shadow} opacity="0.75" />
+	<polygon points="50,4 47,9 50,9" fill={accent.highlight} />
+	<polygon points="50,13 53,12 56,13" fill={accent.highlight} opacity="0.35" />
+</g>

--- a/src/lib/components/tree/gallery/TreeGallery.stories.svelte
+++ b/src/lib/components/tree/gallery/TreeGallery.stories.svelte
@@ -1,0 +1,155 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import ThemeDecorator from '$lib/storybook/ThemeDecorator.svelte';
+
+	const { Story } = defineMeta({
+		title: 'Viz/Tree Gallery',
+		// @ts-expect-error — Storybook decorator typing doesn't match Svelte 5 Component type
+		decorators: [() => ThemeDecorator],
+		tags: ['autodocs'],
+	});
+</script>
+
+<script lang="ts">
+	import type { Component } from 'svelte';
+	import { VIEWBOX_WIDTH, VIEWBOX_HEIGHT } from '../types';
+	import type { AccentColors } from '../types';
+	import {
+		compute_accent_colors,
+		compute_trunk_color,
+		compute_ground_color,
+	} from '../color_utils';
+	import StackedFir from './StackedFir.svelte';
+	import RoundedOak from './RoundedOak.svelte';
+	import MosaicPoplar from './MosaicPoplar.svelte';
+	import GnarledAncient from './GnarledAncient.svelte';
+	import ClusterBirch from './ClusterBirch.svelte';
+	import GhibliHill from './GhibliHill.svelte';
+	import WillowDrape from './WillowDrape.svelte';
+	import BonsaiTwist from './BonsaiTwist.svelte';
+	import LayeredBeech from './LayeredBeech.svelte';
+	import PrismPine from './PrismPine.svelte';
+
+	type VariantComponent = Component<{
+		accent: AccentColors;
+		trunk_color: string;
+		ground_color: string;
+	}>;
+
+	interface VariantEntry {
+		readonly name: string;
+		readonly component: VariantComponent;
+		readonly poly_count: number;
+	}
+
+	const VARIANTS: readonly VariantEntry[] = [
+		{ name: 'Stacked Fir', component: StackedFir as VariantComponent, poly_count: 47 },
+		{ name: 'Rounded Oak', component: RoundedOak as VariantComponent, poly_count: 50 },
+		{ name: 'Mosaic Poplar', component: MosaicPoplar as VariantComponent, poly_count: 62 },
+		{ name: 'Gnarled Ancient', component: GnarledAncient as VariantComponent, poly_count: 63 },
+		{ name: 'Cluster Birch', component: ClusterBirch as VariantComponent, poly_count: 53 },
+		{ name: 'Ghibli Hill', component: GhibliHill as VariantComponent, poly_count: 64 },
+		{ name: 'Willow Drape', component: WillowDrape as VariantComponent, poly_count: 41 },
+		{ name: 'Bonsai Twist', component: BonsaiTwist as VariantComponent, poly_count: 45 },
+		{ name: 'Layered Beech', component: LayeredBeech as VariantComponent, poly_count: 62 },
+		{ name: 'Prism Pine', component: PrismPine as VariantComponent, poly_count: 118 },
+	];
+
+	// Fixed accent for fair cross-variant comparison (approximates OKLCH 0.62 0.15 140)
+	const GALLERY_ACCENT_HEX = '#22c55e';
+
+	const accent = compute_accent_colors(GALLERY_ACCENT_HEX);
+	const trunk_color_light = compute_trunk_color(false);
+	const ground_color_light = compute_ground_color(false);
+	const trunk_color_dark = compute_trunk_color(true);
+	const ground_color_dark = compute_ground_color(true);
+</script>
+
+<Story name="All Variants">
+	{#snippet template()}
+		<div class="grid grid-cols-5 gap-4 p-4">
+			{#each VARIANTS as variant (variant.name)}
+				{@const Variant = variant.component}
+				<div class="flex flex-col items-center gap-2">
+					<svg
+						viewBox="0 0 {VIEWBOX_WIDTH} {VIEWBOX_HEIGHT}"
+						xmlns="http://www.w3.org/2000/svg"
+						class="h-[240px] w-[200px]"
+						role="img"
+						aria-label={variant.name}
+					>
+						<Variant
+							{accent}
+							trunk_color={trunk_color_light}
+							ground_color={ground_color_light}
+						/>
+					</svg>
+					<div class="text-center">
+						<div class="text-sm font-medium">{variant.name}</div>
+						<div class="text-muted-foreground text-xs">{variant.poly_count} polys</div>
+					</div>
+				</div>
+			{/each}
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="All Variants (Dark Mode)">
+	{#snippet template()}
+		<div class="grid grid-cols-5 gap-4 bg-neutral-900 p-4">
+			{#each VARIANTS as variant (variant.name)}
+				{@const Variant = variant.component}
+				<div class="flex flex-col items-center gap-2">
+					<svg
+						viewBox="0 0 {VIEWBOX_WIDTH} {VIEWBOX_HEIGHT}"
+						xmlns="http://www.w3.org/2000/svg"
+						class="h-[240px] w-[200px]"
+						role="img"
+						aria-label={variant.name}
+					>
+						<Variant
+							{accent}
+							trunk_color={trunk_color_dark}
+							ground_color={ground_color_dark}
+						/>
+					</svg>
+					<div class="text-center">
+						<div class="text-sm font-medium text-neutral-100">{variant.name}</div>
+						<div class="text-xs text-neutral-400">{variant.poly_count} polys</div>
+					</div>
+				</div>
+			{/each}
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Forest Scale Preview">
+	{#snippet template()}
+		<div class="flex flex-col gap-6 p-4">
+			<p class="text-muted-foreground text-sm">
+				How each variant reads at actual forest-grid scale (100px wide, ~20 trees on screen)
+			</p>
+			<div class="grid grid-cols-10 gap-2">
+				{#each VARIANTS as variant (variant.name)}
+					{@const Variant = variant.component}
+					<div class="flex flex-col items-center gap-1">
+						<svg
+							viewBox="0 0 {VIEWBOX_WIDTH} {VIEWBOX_HEIGHT}"
+							xmlns="http://www.w3.org/2000/svg"
+							class="h-[120px] w-[100px]"
+							role="img"
+							aria-label={variant.name}
+						>
+							<Variant
+								{accent}
+								trunk_color={trunk_color_light}
+								ground_color={ground_color_light}
+							/>
+						</svg>
+						<div class="text-center text-[10px]">{variant.name}</div>
+					</div>
+				{/each}
+			</div>
+		</div>
+	{/snippet}
+</Story>

--- a/src/lib/components/tree/gallery/WillowDrape.svelte
+++ b/src/lib/components/tree/gallery/WillowDrape.svelte
@@ -1,0 +1,127 @@
+<script lang="ts">
+	import type { AccentColors, AttachmentPoints } from '../types';
+
+	interface Props {
+		accent: AccentColors;
+		trunk_color: string;
+		ground_color: string;
+	}
+
+	let { accent, trunk_color, ground_color }: Props = $props();
+
+	const attachment_points: AttachmentPoints = {
+		crown: { x: 50, y: 18 },
+		trunkBase: { x: 50, y: 105 },
+		roots: { x: 50, y: 118 },
+	};
+
+	// Hanging strands: top_x, bottom_y (longest in center, shorter at edges)
+	// Strands originate from crown cap y~22, hang down to varying depths
+	const strands: ReadonlyArray<{
+		top_x: number;
+		top_width: number;
+		mid_width: number;
+		bottom_y: number;
+		sway: number;
+	}> = [
+		{ top_x: 30, top_width: 1.2, mid_width: 2.0, bottom_y: 52, sway: -1.5 },
+		{ top_x: 33, top_width: 1.2, mid_width: 2.2, bottom_y: 58, sway: -1.2 },
+		{ top_x: 36, top_width: 1.3, mid_width: 2.3, bottom_y: 64, sway: -0.8 },
+		{ top_x: 39, top_width: 1.4, mid_width: 2.4, bottom_y: 70, sway: -0.5 },
+		{ top_x: 42, top_width: 1.4, mid_width: 2.5, bottom_y: 74, sway: -0.3 },
+		{ top_x: 44, top_width: 1.5, mid_width: 2.6, bottom_y: 76, sway: 0 },
+		{ top_x: 46, top_width: 1.5, mid_width: 2.7, bottom_y: 78, sway: 0.2 },
+		{ top_x: 48, top_width: 1.5, mid_width: 2.7, bottom_y: 80, sway: 0 },
+		{ top_x: 50, top_width: 1.5, mid_width: 2.8, bottom_y: 82, sway: 0.3 },
+		{ top_x: 52, top_width: 1.5, mid_width: 2.7, bottom_y: 80, sway: 0.5 },
+		{ top_x: 54, top_width: 1.5, mid_width: 2.7, bottom_y: 78, sway: 0.7 },
+		{ top_x: 56, top_width: 1.5, mid_width: 2.6, bottom_y: 76, sway: 0.4 },
+		{ top_x: 58, top_width: 1.4, mid_width: 2.5, bottom_y: 74, sway: 0.8 },
+		{ top_x: 61, top_width: 1.4, mid_width: 2.4, bottom_y: 70, sway: 1.0 },
+		{ top_x: 64, top_width: 1.3, mid_width: 2.3, bottom_y: 64, sway: 1.2 },
+		{ top_x: 67, top_width: 1.2, mid_width: 2.2, bottom_y: 58, sway: 1.5 },
+		{ top_x: 70, top_width: 1.2, mid_width: 2.0, bottom_y: 52, sway: 1.8 },
+	];
+
+	const strand_top_y = 22;
+</script>
+
+<g data-variant="willow-drape" data-attachment-points={JSON.stringify(attachment_points)}>
+	<defs>
+		<linearGradient id="willow-strand-grad" x1="0" y1="0" x2="0" y2="1">
+			<stop offset="0%" stop-color={accent.highlight} />
+			<stop offset="55%" stop-color={accent.front} />
+			<stop offset="100%" stop-color={accent.shadow} />
+		</linearGradient>
+		<linearGradient id="willow-trunk-grad" x1="0" y1="0" x2="1" y2="0">
+			<stop offset="0%" stop-color={trunk_color} stop-opacity="0.85" />
+			<stop offset="100%" stop-color={trunk_color} />
+		</linearGradient>
+	</defs>
+
+	<!-- Ground shadow -->
+	<polygon points="22,122 78,122 72,116 28,116" fill={ground_color} />
+	<polygon points="28,116 72,116 68,114 32,114" fill={ground_color} opacity="0.6" />
+
+	<!-- Thin curved trunk (4 angled polygon segments, narrow ~width 6) -->
+	<!-- Segment 1: base, leans slightly right -->
+	<polygon points="47,115 53,115 54,98 48,98" fill={trunk_color} />
+	<!-- Segment 2: mid-lower, curving left -->
+	<polygon points="48,98 54,98 55,82 49,82" fill="url(#willow-trunk-grad)" />
+	<!-- Segment 3: mid-upper, curving back right -->
+	<polygon points="49,82 55,82 54,62 48,62" fill={trunk_color} />
+	<!-- Segment 4: top, narrowing into crown -->
+	<polygon points="48,62 54,62 52,42 49,42" fill="url(#willow-trunk-grad)" />
+
+	<!-- Trunk shading accents -->
+	<polygon points="48,98 50,98 51,82 49,82" fill={ground_color} opacity="0.2" />
+	<polygon points="49,62 51,62 50,42 49,42" fill={ground_color} opacity="0.2" />
+
+	<!-- Crown cap at top (4 polygons from which strands hang) -->
+	<polygon points="50,10 38,22 62,22" fill={accent.shadow} />
+	<polygon points="50,12 40,22 60,22" fill={accent.front} />
+	<polygon points="50,14 44,22 56,22" fill={accent.highlight} />
+	<polygon points="50,16 46,22 54,22" fill={accent.front} />
+	<polygon points="42,20 58,20 56,23 44,23" fill={accent.shadow} />
+
+	<!-- Hanging strands: each = elongated tapered polygon (thin top, wider mid, pointed bottom) -->
+	{#each strands as strand, index (index)}
+		{@const top_left_x = strand.top_x - strand.top_width}
+		{@const top_right_x = strand.top_x + strand.top_width}
+		{@const mid_y = (strand_top_y + strand.bottom_y) / 2}
+		{@const mid_left_x = strand.top_x - strand.mid_width + strand.sway * 0.3}
+		{@const mid_right_x = strand.top_x + strand.mid_width + strand.sway * 0.3}
+		{@const bottom_x = strand.top_x + strand.sway}
+		<polygon
+			points="{top_left_x},{strand_top_y} {top_right_x},{strand_top_y} {mid_right_x},{mid_y} {bottom_x},{strand.bottom_y} {mid_left_x},{mid_y}"
+			fill="url(#willow-strand-grad)"
+		/>
+	{/each}
+
+	<!-- Shadow-side strand overlays (depth) every 3rd strand -->
+	{#each strands as strand, index (index)}
+		{#if index % 3 === 0}
+			{@const mid_y = (strand_top_y + strand.bottom_y) / 2}
+			{@const bottom_x = strand.top_x + strand.sway}
+			<polygon
+				points="{strand.top_x},{strand_top_y} {strand.top_x +
+					strand.mid_width * 0.6 +
+					strand.sway * 0.3},{mid_y} {bottom_x},{strand.bottom_y}"
+				fill={accent.shadow}
+				opacity="0.5"
+			/>
+		{/if}
+	{/each}
+
+	<!-- Highlight tips on front-center strands -->
+	{#each strands as strand, index (index)}
+		{#if index >= 6 && index <= 10}
+			<polygon
+				points="{strand.top_x - strand.top_width},{strand_top_y} {strand.top_x +
+					strand.top_width},{strand_top_y} {strand.top_x},{strand_top_y + 8}"
+				fill={accent.highlight}
+				opacity="0.7"
+			/>
+		{/if}
+	{/each}
+</g>


### PR DESCRIPTION
## Summary

Adds 10 tree-art variants as a Storybook gallery (issue #56, part of PRD #55). User picks one style, then it's rolled out to all 11 lifecycle stages + OakTree + potted plants (#57).

Each variant stays inside the low-poly/geometric art direction from PRD #18, but at ~3-4x polygon density vs. the current ~10-15 polys.

## Variants

| # | Name | Polys | Silhouette |
|---|---|---|---|
| 1 | Stacked Fir | 47 | horizontal fir-like layers |
| 2 | Rounded Oak | 50 | broad spreading rounded canopy |
| 3 | Mosaic Poplar | 62 | tall columnar tessellated |
| 4 | Gnarled Ancient | 63 | wide twisted asymmetric |
| 5 | Cluster Birch | 53 | 3 thin trunks, airy canopy |
| 6 | Ghibli Hill | 64 | soft cloud-like puffs |
| 7 | Willow Drape | 41 | hanging polygon strands |
| 8 | Bonsai Twist | 45 | windswept S-curve trunk |
| 9 | Layered Beech | 62 | 5 overlapping puff clusters |
| 10 | Prism Pine | 118 | conical tile mosaic |

## Review flow

1. Run Storybook, open **Viz / Tree Gallery / All Variants**
2. Compare all 10 at fixed green accent + light mode
3. Switch to **All Variants (Dark Mode)** for dark-mode check
4. Switch to **Forest Scale Preview** for actual forest-grid readability
5. Pick 1 winner, comment on #56 with name
6. Optional: up to 2 refinement rounds on winner
7. After pick, #57 rolls out chosen style to all stages

## Contract preserved

- Shared props: `{ accent: AccentColors, trunk_color: string, ground_color: string }`
- Renders in viewBox 100×150 final coordinate space
- Emits `data-attachment-points` matching leafy-stage contract (crown, trunkBase, roots)
- No filters, 0-3 gradients per variant
- svelte-check clean, oxlint clean, `attachment_points.test.ts` passes

## Test plan

- [ ] Run Storybook and view all 3 gallery stories
- [ ] Verify each variant renders at 200×240 grid tile
- [ ] Verify dark mode story swaps trunk/ground colors
- [ ] Verify forest scale preview still reads at 100px wide
- [ ] Pick winner

## Related

- PRD: #55
- This issue: #56
- Follow-up rollout: #57
- Blocks: #27, #28, #29 until #57 merges