### PR TITLE
#66 refactor: resolve fallow findings — dead code, duplication, complexity

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,6 +13,7 @@ export default [
 			'.storybook',
 			'build',
 			'node_modules',
+			'scripts',
 			'src-tauri',
 			'**/*.config.*',
 			'*.d.ts',

--- a/fallow-baselines/dead-code-regression.json
+++ b/fallow-baselines/dead-code-regression.json
@@ -1,13 +1,13 @@
 {
 	"schema_version": 1,
 	"fallow_version": "2.48.4",
-	"timestamp": "2026-04-24T16:28:07Z",
-	"git_sha": "11396bfab0fd82756fb07e49ee2d814263dc83b4",
+	"timestamp": "2026-04-25T06:30:58Z",
+	"git_sha": "23466665552c4e217a0486aa1d7a97269432087f",
 	"check": {
-		"total_issues": 62,
+		"total_issues": 0,
 		"unused_files": 0,
-		"unused_exports": 37,
-		"unused_types": 25,
+		"unused_exports": 0,
+		"unused_types": 0,
 		"unused_dependencies": 0,
 		"unused_dev_dependencies": 0,
 		"unused_optional_dependencies": 0,

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 		"format": "prettier --write .",
 		"test": "vitest",
 		"test:e2e": "playwright test --pass-with-no-tests",
+		"postinstall": "node scripts/fix-worktree-links.js",
 		"prepare": "husky",
 		"tauri": "tauri",
 		"storybook": "svelte-kit sync && storybook dev -p 6006",

--- a/scripts/fix-worktree-links.js
+++ b/scripts/fix-worktree-links.js
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+
+// Fixes linked dependency resolution in git worktrees.
+//
+// Problem: "link:..\\low-poly-2d-trees" resolves relative to the working
+// directory. In worktrees this points to the worktree's parent instead of
+// the main repo's parent, so the package can't be found.
+//
+// Fix: detect worktree, find the main repo, create a directory junction
+// in the worktree's parent so the relative path resolves correctly.
+
+import { execSync } from 'node:child_process';
+import { existsSync, symlinkSync, readlinkSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+
+const LINKED_PACKAGES = ['low-poly-2d-trees'];
+
+const projectRoot = process.cwd();
+
+for (const pkg of LINKED_PACKAGES) {
+	const expectedTarget = resolve(projectRoot, '..', pkg);
+
+	if (existsSync(resolve(expectedTarget, 'package.json'))) {
+		continue;
+	}
+
+	// Already a symlink/junction (possibly dangling from a previous run)
+	try {
+		readlinkSync(expectedTarget);
+		continue;
+	} catch {
+		// Not a symlink — proceed
+	}
+
+	try {
+		const gitCommonDir = execSync('git rev-parse --git-common-dir', {
+			encoding: 'utf8',
+			cwd: projectRoot,
+		}).trim();
+
+		const resolvedCommonDir = resolve(projectRoot, gitCommonDir);
+		const mainRepoRoot = dirname(resolvedCommonDir);
+
+		if (resolve(mainRepoRoot) === resolve(projectRoot)) {
+			console.warn(`[fix-worktree-links] ${pkg} not found at ${expectedTarget}`);
+			continue;
+		}
+
+		const actualTarget = resolve(mainRepoRoot, '..', pkg);
+
+		if (!existsSync(resolve(actualTarget, 'package.json'))) {
+			console.warn(
+				`[fix-worktree-links] ${pkg} not found at main repo parent either (${actualTarget})`,
+			);
+			continue;
+		}
+
+		symlinkSync(actualTarget, expectedTarget, 'junction');
+		console.log(`[fix-worktree-links] ${expectedTarget} -> ${actualTarget}`);
+	} catch (err) {
+		console.warn(`[fix-worktree-links] Could not fix ${pkg}: ${err.message}`);
+	}
+}

--- a/src/lib/components/IssueCard.svelte
+++ b/src/lib/components/IssueCard.svelte
@@ -3,6 +3,7 @@
 	import type { Action } from '$lib/types/action';
 	import type { GitHubStatusCache } from '$lib/types/github';
 	import type { GitStatusCache } from '$lib/types/git_status';
+	import type { IssueCardCallbacks } from '$lib/types/issue_card_callbacks';
 	import PullRequestBadge from './PullRequestBadge.svelte';
 	import GitHubIssueBadge from './GitHubIssueBadge.svelte';
 	import SyncStatusIndicator from './SyncStatusIndicator.svelte';
@@ -10,7 +11,7 @@
 	import WorktreeProgressIndicator from './WorktreeProgressIndicator.svelte';
 	import ActionButtonGroup from './ActionButtonGroup.svelte';
 
-	interface Props {
+	interface Props extends IssueCardCallbacks {
 		issue: Issue;
 		actions?: Action[];
 		github_cache?: GitHubStatusCache | null;
@@ -22,13 +23,6 @@
 		child_count?: number;
 		force_expanded?: boolean;
 		progress_lines?: readonly string[];
-		on_archive: (id: string) => void;
-		on_unarchive: (id: string) => void;
-		on_edit: (issue: Issue) => void;
-		on_delete: (id: string) => void;
-		on_setup_worktree?: (issue: Issue) => void;
-		on_remove_worktree?: (issue: Issue) => void;
-		on_execute_action?: (action_id: string, issue_id: string) => void;
 	}
 
 	let {

--- a/src/lib/components/IssueCardList.svelte
+++ b/src/lib/components/IssueCardList.svelte
@@ -3,9 +3,10 @@
 	import type { Action } from '$lib/types/action';
 	import type { GitHubStatusCache } from '$lib/types/github';
 	import type { GitStatusCache } from '$lib/types/git_status';
+	import type { IssueCardCallbacks } from '$lib/types/issue_card_callbacks';
 	import IssueCard from './IssueCard.svelte';
 
-	interface Props {
+	interface Props extends IssueCardCallbacks {
 		parent_issues: Issue[];
 		archived_issues: Issue[];
 		show_archived: boolean;
@@ -18,13 +19,6 @@
 		get_git_status: (issue_id: string) => GitStatusCache | undefined;
 		get_notification_dot_color?: (issue_id: string) => string | null;
 		get_progress_lines?: (issue_id: string) => readonly string[];
-		on_archive: (id: string) => void;
-		on_unarchive: (id: string) => void;
-		on_edit: (issue: Issue) => void;
-		on_delete: (id: string) => void;
-		on_setup_worktree?: (issue: Issue) => void;
-		on_remove_worktree?: (issue: Issue) => void;
-		on_execute_action?: (action_id: string, issue_id: string) => void;
 	}
 
 	let {

--- a/src/lib/components/PullRequestBadge.svelte
+++ b/src/lib/components/PullRequestBadge.svelte
@@ -12,6 +12,64 @@
 	} from 'lucide-svelte';
 	import GitHubBadge from './GitHubBadge.svelte';
 
+	interface PullRequestStateConfig {
+		icon: typeof GitPullRequest;
+		color: string;
+		bg: string;
+		label: string;
+	}
+
+	const STATE_CONFIG: Record<PullRequestState, PullRequestStateConfig> = {
+		open: {
+			icon: GitPullRequest,
+			color: 'text-green-400',
+			bg: 'bg-green-400/10',
+			label: 'Open',
+		},
+		draft: {
+			icon: GitPullRequestDraft,
+			color: 'text-neutral-400',
+			bg: 'bg-neutral-400/10',
+			label: 'Draft',
+		},
+		'review-requested': {
+			icon: Eye,
+			color: 'text-yellow-400',
+			bg: 'bg-yellow-400/10',
+			label: 'Review',
+		},
+		'changes-requested': {
+			icon: MessageSquareWarning,
+			color: 'text-orange-400',
+			bg: 'bg-orange-400/10',
+			label: 'Changes',
+		},
+		approved: {
+			icon: Check,
+			color: 'text-emerald-400',
+			bg: 'bg-emerald-400/10',
+			label: 'Approved',
+		},
+		'ready-to-merge': {
+			icon: Sparkles,
+			color: 'text-cyan-400',
+			bg: 'bg-cyan-400/10',
+			label: 'Ready',
+		},
+		merged: {
+			icon: GitMerge,
+			color: 'text-purple-400',
+			bg: 'bg-purple-400/10',
+			label: 'Merged',
+		},
+		closed: {
+			icon: GitPullRequestClosed,
+			color: 'text-red-400',
+			bg: 'bg-red-400/10',
+			label: 'Closed',
+		},
+	};
+
 	interface Props {
 		state: PullRequestState | null;
 		url: string | null;
@@ -21,68 +79,7 @@
 
 	let { state, url, pr_number, disabled = false }: Props = $props();
 
-	const config = $derived.by(() => {
-		switch (state) {
-			case 'open':
-				return {
-					icon: GitPullRequest,
-					color: 'text-green-400',
-					bg: 'bg-green-400/10',
-					label: 'Open',
-				};
-			case 'draft':
-				return {
-					icon: GitPullRequestDraft,
-					color: 'text-neutral-400',
-					bg: 'bg-neutral-400/10',
-					label: 'Draft',
-				};
-			case 'review-requested':
-				return {
-					icon: Eye,
-					color: 'text-yellow-400',
-					bg: 'bg-yellow-400/10',
-					label: 'Review',
-				};
-			case 'changes-requested':
-				return {
-					icon: MessageSquareWarning,
-					color: 'text-orange-400',
-					bg: 'bg-orange-400/10',
-					label: 'Changes',
-				};
-			case 'approved':
-				return {
-					icon: Check,
-					color: 'text-emerald-400',
-					bg: 'bg-emerald-400/10',
-					label: 'Approved',
-				};
-			case 'ready-to-merge':
-				return {
-					icon: Sparkles,
-					color: 'text-cyan-400',
-					bg: 'bg-cyan-400/10',
-					label: 'Ready',
-				};
-			case 'merged':
-				return {
-					icon: GitMerge,
-					color: 'text-purple-400',
-					bg: 'bg-purple-400/10',
-					label: 'Merged',
-				};
-			case 'closed':
-				return {
-					icon: GitPullRequestClosed,
-					color: 'text-red-400',
-					bg: 'bg-red-400/10',
-					label: 'Closed',
-				};
-			default:
-				return null;
-		}
-	});
+	const config = $derived(state ? STATE_CONFIG[state] : null);
 </script>
 
 {#if config && state}

--- a/src/lib/components/SessionChatView.svelte
+++ b/src/lib/components/SessionChatView.svelte
@@ -32,6 +32,78 @@
 			(session.state === 'needs-review' || session.state === 'needs-input'),
 	);
 
+	function append_message(message: ChatMessage) {
+		messages = [...messages, message];
+	}
+
+	function handle_message_delta(event: Record<string, unknown>) {
+		current_streaming_text += event.text as string;
+	}
+
+	function handle_message_complete() {
+		if (current_streaming_text) {
+			append_message({
+				role: 'assistant',
+				content: current_streaming_text,
+				timestamp: Date.now(),
+			});
+			current_streaming_text = '';
+		}
+	}
+
+	function handle_tool_start(event: Record<string, unknown>) {
+		append_message({
+			role: 'tool',
+			content: `Running ${event.tool_name as string}...`,
+			tool_name: event.tool_name as string,
+			timestamp: Date.now(),
+		});
+	}
+
+	function handle_tool_end(event: Record<string, unknown>) {
+		const output = event.output;
+		const content = typeof output === 'string' ? output : JSON.stringify(output, null, 2);
+		const truncated = content.length > 500 ? content.slice(0, 497) + '...' : content;
+		append_message({
+			role: 'tool',
+			content: truncated,
+			tool_name: event.tool_name as string,
+			is_error: event.is_error as boolean,
+			timestamp: Date.now(),
+		});
+	}
+
+	function handle_run_state(event: Record<string, unknown>) {
+		const state = event.state as string;
+		if (state === 'failed' || state === 'completed') {
+			append_message({
+				role: 'system',
+				content:
+					state === 'failed'
+						? `Session errored: ${(event.error as string) ?? 'unknown'}`
+						: 'Session completed.',
+				timestamp: Date.now(),
+			});
+		}
+	}
+
+	function handle_permission_prompt(event: Record<string, unknown>) {
+		append_message({
+			role: 'system',
+			content: `Permission needed: ${event.tool_name as string}`,
+			timestamp: Date.now(),
+		});
+	}
+
+	const SESSION_EVENT_HANDLERS: Record<string, (event: Record<string, unknown>) => void> = {
+		message_delta: handle_message_delta,
+		message_complete: handle_message_complete,
+		tool_start: handle_tool_start,
+		tool_end: handle_tool_end,
+		run_state: handle_run_state,
+		permission_prompt: handle_permission_prompt,
+	};
+
 	onMount(async () => {
 		unlisten_fn = await listen<SessionEventPayload>('session-event', (event) => {
 			const { session_id, event: session_event } = event.payload;
@@ -39,86 +111,7 @@
 				return;
 			}
 
-			switch (session_event.type) {
-				case 'message_delta': {
-					current_streaming_text += session_event.text as string;
-					break;
-				}
-				case 'message_complete': {
-					if (current_streaming_text) {
-						messages = [
-							...messages,
-							{
-								role: 'assistant',
-								content: current_streaming_text,
-								timestamp: Date.now(),
-							},
-						];
-						current_streaming_text = '';
-					}
-					break;
-				}
-				case 'tool_start': {
-					messages = [
-						...messages,
-						{
-							role: 'tool',
-							content: `Running ${session_event.tool_name as string}...`,
-							tool_name: session_event.tool_name as string,
-							timestamp: Date.now(),
-						},
-					];
-					break;
-				}
-				case 'tool_end': {
-					const output = session_event.output;
-					const content =
-						typeof output === 'string' ? output : JSON.stringify(output, null, 2);
-					const truncated =
-						content.length > 500 ? content.slice(0, 497) + '...' : content;
-					messages = [
-						...messages,
-						{
-							role: 'tool',
-							content: truncated,
-							tool_name: session_event.tool_name as string,
-							is_error: session_event.is_error as boolean,
-							timestamp: Date.now(),
-						},
-					];
-					break;
-				}
-				case 'run_state': {
-					const state = session_event.state as string;
-					if (state === 'failed' || state === 'completed') {
-						messages = [
-							...messages,
-							{
-								role: 'system',
-								content:
-									state === 'failed'
-										? `Session errored: ${(session_event.error as string) ?? 'unknown'}`
-										: 'Session completed.',
-								timestamp: Date.now(),
-							},
-						];
-					}
-					break;
-				}
-				case 'permission_prompt': {
-					messages = [
-						...messages,
-						{
-							role: 'system',
-							content: `Permission needed: ${session_event.tool_name as string}`,
-							timestamp: Date.now(),
-						},
-					];
-					break;
-				}
-				default:
-					break;
-			}
+			SESSION_EVENT_HANDLERS[session_event.type]?.(session_event);
 		});
 	});
 

--- a/src/lib/engine/compute_tree_visualization.ts
+++ b/src/lib/engine/compute_tree_visualization.ts
@@ -15,7 +15,7 @@ import type {
 	TreeVisualization,
 } from '$lib/types/tree_visualization';
 
-export const DEFAULT_COMPUTE_CONTEXT: TreeComputeContext = {
+const DEFAULT_COMPUTE_CONTEXT: TreeComputeContext = {
 	isPrd: false,
 	prdTitle: '',
 	subIssueCompletionRatio: 0,
@@ -51,46 +51,66 @@ function compute_tool_visibility(dimensions: StateDimensions): ToolVisibility {
 	return tools;
 }
 
-function compute_tree_stage(dimensions: StateDimensions, context: TreeComputeContext): TreeStage {
-	if (dimensions.worktreeState === 'removed' && dimensions.grovekeeperStatus === 'archived') {
-		return TREE_STAGES.stump;
-	}
-	if (dimensions.branchStatus === 'deleted') {
-		return TREE_STAGES.dead;
-	}
-	if (dimensions.pullRequestState === 'merged' && dimensions.githubIssueState === 'closed') {
-		return TREE_STAGES.bare;
-	}
-	if (dimensions.pullRequestState === 'approved') {
-		return TREE_STAGES.flowering;
-	}
-	if (
-		dimensions.pullRequestState === 'ready-to-merge' ||
-		dimensions.pullRequestState === 'review-requested' ||
-		dimensions.pullRequestState === 'changes-requested'
-	) {
-		return TREE_STAGES.seasonal;
-	}
-	if (dimensions.pullRequestState === 'draft' || dimensions.pullRequestState === 'open') {
-		return TREE_STAGES.fruiting;
-	}
-	if (dimensions.aggregateSessionState === 'finished' && context.hasCommitsOnBranch) {
-		return TREE_STAGES.leafy;
-	}
-	if (dimensions.aggregateSessionState === 'running') {
-		return TREE_STAGES.growing;
-	}
-	if (
-		dimensions.worktreeState === 'active' &&
-		dimensions.branchStatus !== 'no-branch' &&
-		dimensions.aggregateSessionState === 'no-session'
-	) {
-		return TREE_STAGES.sapling;
-	}
-	if (dimensions.worktreeState === 'pending') {
-		return TREE_STAGES.sprouting;
-	}
+interface TreeStageRule {
+	readonly condition: (dimensions: StateDimensions, context: TreeComputeContext) => boolean;
+	readonly stage: TreeStage;
+}
 
+const TREE_STAGE_RULES: readonly TreeStageRule[] = [
+	{
+		condition: (d) => d.worktreeState === 'removed' && d.grovekeeperStatus === 'archived',
+		stage: TREE_STAGES.stump,
+	},
+	{
+		condition: (d) => d.branchStatus === 'deleted',
+		stage: TREE_STAGES.dead,
+	},
+	{
+		condition: (d) => d.pullRequestState === 'merged' && d.githubIssueState === 'closed',
+		stage: TREE_STAGES.bare,
+	},
+	{
+		condition: (d) => d.pullRequestState === 'approved',
+		stage: TREE_STAGES.flowering,
+	},
+	{
+		condition: (d) =>
+			d.pullRequestState === 'ready-to-merge' ||
+			d.pullRequestState === 'review-requested' ||
+			d.pullRequestState === 'changes-requested',
+		stage: TREE_STAGES.seasonal,
+	},
+	{
+		condition: (d) => d.pullRequestState === 'draft' || d.pullRequestState === 'open',
+		stage: TREE_STAGES.fruiting,
+	},
+	{
+		condition: (d, c) => d.aggregateSessionState === 'finished' && c.hasCommitsOnBranch,
+		stage: TREE_STAGES.leafy,
+	},
+	{
+		condition: (d) => d.aggregateSessionState === 'running',
+		stage: TREE_STAGES.growing,
+	},
+	{
+		condition: (d) =>
+			d.worktreeState === 'active' &&
+			d.branchStatus !== 'no-branch' &&
+			d.aggregateSessionState === 'no-session',
+		stage: TREE_STAGES.sapling,
+	},
+	{
+		condition: (d) => d.worktreeState === 'pending',
+		stage: TREE_STAGES.sprouting,
+	},
+];
+
+function compute_tree_stage(dimensions: StateDimensions, context: TreeComputeContext): TreeStage {
+	for (const rule of TREE_STAGE_RULES) {
+		if (rule.condition(dimensions, context)) {
+			return rule.stage;
+		}
+	}
 	return TREE_STAGES.seed;
 }
 

--- a/src/lib/engine/forest_layout.ts
+++ b/src/lib/engine/forest_layout.ts
@@ -48,7 +48,7 @@ export interface PositionedForestItem {
 	readonly zIndex: number;
 }
 
-export interface ForestLayoutResult {
+interface ForestLayoutResult {
 	readonly items: readonly PositionedForestItem[];
 	readonly oakPosition: PositionedForestItem | null;
 	readonly shelfY: number;
@@ -304,6 +304,71 @@ function enforce_minimum_spacing(
 	return positions;
 }
 
+// ─── Section Placers ───────────────────────────────────────────────────
+
+function place_oak(oak: ForestLayoutItem, center_x: number, oak_y: number): PositionedForestItem {
+	return {
+		id: oak.id,
+		x: center_x,
+		y: oak_y,
+		scale: 1.0,
+		opacity: 1.0,
+		zIndex: Z_OAK,
+	};
+}
+
+function place_stumps(
+	stumps: readonly ForestLayoutItem[],
+	tree_count: number,
+	center_x: number,
+	tree_center_y: number,
+	viewport_width: number,
+): PositionedForestItem[] {
+	if (stumps.length === 0) {
+		return [];
+	}
+
+	const tree_ring_count = count_tree_rings(tree_count) || 1;
+	const base_radius = viewport_width * BASE_RING_RADIUS_FRACTION;
+	const radius_step = viewport_width * RING_RADIUS_STEP_FRACTION;
+	const stump_radius = base_radius + (tree_ring_count + 0.5) * radius_step;
+	const stump_angles = semicircle_angles(stumps.length);
+
+	return stumps.map((stump, i) => ({
+		id: stump.id,
+		x: center_x + stump_radius * Math.cos(stump_angles[i]),
+		y: tree_center_y + stump_radius * Math.sin(stump_angles[i]) * SEMICIRCLE_VERTICAL_FLATTEN,
+		scale: STUMP_SCALE,
+		opacity: STUMP_OPACITY,
+		zIndex: Z_STUMP,
+	}));
+}
+
+function place_potted_plants(
+	potted_plants: readonly ForestLayoutItem[],
+	center_x: number,
+	shelf_y: number,
+	viewport_width: number,
+): PositionedForestItem[] {
+	if (potted_plants.length === 0) {
+		return [];
+	}
+
+	const margin = viewport_width * SHELF_MARGIN_FRACTION;
+	const available_width = viewport_width - 2 * margin;
+	const spacing = potted_plants.length > 1 ? available_width / (potted_plants.length - 1) : 0;
+	const start_x = potted_plants.length > 1 ? margin : center_x;
+
+	return potted_plants.map((plant, i) => ({
+		id: plant.id,
+		x: start_x + i * spacing,
+		y: shelf_y,
+		scale: POTTED_PLANT_SCALE,
+		opacity: 1.0,
+		zIndex: Z_POTTED_PLANT,
+	}));
+}
+
 // ─── Layout Engine ──────────────────────────────────────────────────────
 
 export function compute_forest_layout(
@@ -317,70 +382,19 @@ export function compute_forest_layout(
 	const { oak, trees, stumps, potted_plants } = classify_items(items);
 	const center_x = viewport.width / 2;
 	const shelf_y = viewport.height * SHELF_Y_FRACTION;
-	const all_positioned: PositionedForestItem[] = [];
-
-	// ── Oak ──────────────────────────────────────────────────────────────
 	const oak_y = viewport.height * OAK_Y_FRACTION;
-	if (oak) {
-		all_positioned.push({
-			id: oak.id,
-			x: center_x,
-			y: oak_y,
-			scale: 1.0,
-			opacity: 1.0,
-			zIndex: Z_OAK,
-		});
-	}
 
-	// ── Trees (semicircle rings) ────────────────────────────────────────
 	const tree_center_y = oak
 		? oak_y + viewport.height * TREE_CENTER_OFFSET_FRACTION
 		: viewport.height * TREE_CENTER_NO_OAK_FRACTION;
-	const tree_positions = place_on_semicircles(trees, center_x, tree_center_y, viewport.width);
-	all_positioned.push(...tree_positions);
 
-	// ── Stumps (periphery beyond last tree ring) ────────────────────────
-	if (stumps.length > 0) {
-		const tree_ring_count = count_tree_rings(trees.length) || 1;
-		const base_radius = viewport.width * BASE_RING_RADIUS_FRACTION;
-		const radius_step = viewport.width * RING_RADIUS_STEP_FRACTION;
-		const stump_radius = base_radius + (tree_ring_count + 0.5) * radius_step;
-		const stump_angles = semicircle_angles(stumps.length);
+	const all_positioned: PositionedForestItem[] = [
+		...(oak ? [place_oak(oak, center_x, oak_y)] : []),
+		...place_on_semicircles(trees, center_x, tree_center_y, viewport.width),
+		...place_stumps(stumps, trees.length, center_x, tree_center_y, viewport.width),
+		...place_potted_plants(potted_plants, center_x, shelf_y, viewport.width),
+	];
 
-		for (let i = 0; i < stumps.length; i++) {
-			all_positioned.push({
-				id: stumps[i].id,
-				x: center_x + stump_radius * Math.cos(stump_angles[i]),
-				y:
-					tree_center_y +
-					stump_radius * Math.sin(stump_angles[i]) * SEMICIRCLE_VERTICAL_FLATTEN,
-				scale: STUMP_SCALE,
-				opacity: STUMP_OPACITY,
-				zIndex: Z_STUMP,
-			});
-		}
-	}
-
-	// ── Potted Plants (shelf strip) ─────────────────────────────────────
-	if (potted_plants.length > 0) {
-		const margin = viewport.width * SHELF_MARGIN_FRACTION;
-		const available_width = viewport.width - 2 * margin;
-		const spacing = potted_plants.length > 1 ? available_width / (potted_plants.length - 1) : 0;
-		const start_x = potted_plants.length > 1 ? margin : center_x;
-
-		for (let i = 0; i < potted_plants.length; i++) {
-			all_positioned.push({
-				id: potted_plants[i].id,
-				x: start_x + i * spacing,
-				y: shelf_y,
-				scale: POTTED_PLANT_SCALE,
-				opacity: 1.0,
-				zIndex: Z_POTTED_PLANT,
-			});
-		}
-	}
-
-	// ── Collision resolution ────────────────────────────────────────────
 	const resolved = enforce_minimum_spacing(all_positioned, center_x, tree_center_y);
 	const resolved_oak = oak ? (resolved.find((item) => item.id === oak.id) ?? null) : null;
 

--- a/src/lib/stores/sessions.svelte.ts
+++ b/src/lib/stores/sessions.svelte.ts
@@ -29,6 +29,43 @@ const finished_sessions = $derived(
 	sessions.filter((session) => session.state === 'finished' || session.state === 'errored'),
 );
 
+const RUN_STATE_MAP: Record<string, SessionState> = {
+	running: 'running',
+	idle: 'needs-review',
+	failed: 'errored',
+	completed: 'finished',
+	stopped: 'finished',
+};
+
+function apply_run_state(session: Session, session_id: string, event: Record<string, unknown>) {
+	const new_state = RUN_STATE_MAP[event.state as string];
+	if (new_state) {
+		session.state = new_state;
+		const notification_type = NOTIFICATION_STATES[new_state];
+		if (notification_type) {
+			get_notification_store().add_pending(session_id, notification_type);
+		} else {
+			get_notification_store().clear_pending(session_id);
+		}
+	}
+}
+
+function apply_usage_update(session: Session, event: Record<string, unknown>) {
+	session.cost_usd = (event.cost_usd as number) ?? session.cost_usd;
+	session.token_count =
+		((event.input_tokens as number) ?? 0) + ((event.output_tokens as number) ?? 0);
+}
+
+function apply_message_complete(session: Session, event: Record<string, unknown>) {
+	const text = event.text as string;
+	session.last_response_summary = text.length > 200 ? text.slice(0, 197) + '...' : text;
+}
+
+function apply_input_prompt(session: Session, session_id: string) {
+	session.state = 'needs-input';
+	get_notification_store().add_pending(session_id, 'needs-input');
+}
+
 function handle_session_event(payload: SessionEventPayload) {
 	const { session_id, event } = payload;
 
@@ -38,43 +75,19 @@ function handle_session_event(payload: SessionEventPayload) {
 	}
 
 	switch (event.type) {
-		case 'run_state': {
-			const state_map: Record<string, SessionState> = {
-				running: 'running',
-				idle: 'needs-review',
-				failed: 'errored',
-				completed: 'finished',
-				stopped: 'finished',
-			};
-			const new_state = state_map[event.state as string];
-			if (new_state) {
-				session.state = new_state;
-				const notification_type = NOTIFICATION_STATES[new_state];
-				if (notification_type) {
-					get_notification_store().add_pending(session_id, notification_type);
-				} else {
-					get_notification_store().clear_pending(session_id);
-				}
-			}
+		case 'run_state':
+			apply_run_state(session, session_id, event);
 			break;
-		}
-		case 'usage_update': {
-			session.cost_usd = (event.cost_usd as number) ?? session.cost_usd;
-			session.token_count =
-				((event.input_tokens as number) ?? 0) + ((event.output_tokens as number) ?? 0);
+		case 'usage_update':
+			apply_usage_update(session, event);
 			break;
-		}
-		case 'message_complete': {
-			const text = event.text as string;
-			session.last_response_summary = text.length > 200 ? text.slice(0, 197) + '...' : text;
+		case 'message_complete':
+			apply_message_complete(session, event);
 			break;
-		}
 		case 'permission_prompt':
-		case 'elicitation_prompt': {
-			session.state = 'needs-input';
-			get_notification_store().add_pending(session_id, 'needs-input');
+		case 'elicitation_prompt':
+			apply_input_prompt(session, session_id);
 			break;
-		}
 	}
 }
 

--- a/src/lib/tauri/action_commands.ts
+++ b/src/lib/tauri/action_commands.ts
@@ -1,6 +1,7 @@
 import { invoke } from '@tauri-apps/api/core';
 import type { Action, CreateActionRequest, UpdateActionRequest } from '$lib/types/action';
 
+// fallow-ignore-next-line unused-export
 export async function create_action(request: CreateActionRequest): Promise<Action> {
 	return invoke('create_action', { request });
 }
@@ -9,18 +10,22 @@ export async function get_actions_for_dashboard(dashboard_id: string): Promise<A
 	return invoke('get_actions_for_dashboard', { dashboardId: dashboard_id });
 }
 
+// fallow-ignore-next-line unused-export
 export async function get_action(id: string): Promise<Action> {
 	return invoke('get_action', { id });
 }
 
+// fallow-ignore-next-line unused-export
 export async function update_action(request: UpdateActionRequest): Promise<Action> {
 	return invoke('update_action', { request });
 }
 
+// fallow-ignore-next-line unused-export
 export async function delete_action(id: string): Promise<void> {
 	return invoke('delete_action', { id });
 }
 
+// fallow-ignore-next-line unused-export
 export async function reorder_actions(action_ids: string[]): Promise<void> {
 	return invoke('reorder_actions', { actionIds: action_ids });
 }

--- a/src/lib/tauri/color_palette_commands.ts
+++ b/src/lib/tauri/color_palette_commands.ts
@@ -9,6 +9,7 @@ export async function get_all_color_palettes(): Promise<ColorPalette[]> {
 	return invoke('get_all_color_palettes');
 }
 
+// fallow-ignore-next-line unused-export
 export async function get_color_palette(id: string): Promise<ColorPalette> {
 	return invoke('get_color_palette', { id });
 }

--- a/src/lib/tauri/commands.ts
+++ b/src/lib/tauri/commands.ts
@@ -13,6 +13,7 @@ export async function get_dashboards(): Promise<Dashboard[]> {
 	return invoke('get_dashboards');
 }
 
+// fallow-ignore-next-line unused-export
 export async function get_dashboard(id: string): Promise<Dashboard> {
 	return invoke('get_dashboard', { id });
 }

--- a/src/lib/tauri/git_status_commands.ts
+++ b/src/lib/tauri/git_status_commands.ts
@@ -5,6 +5,7 @@ export async function refresh_git_status(issue_id: string): Promise<GitStatusCac
 	return invoke('refresh_git_status', { issueId: issue_id });
 }
 
+// fallow-ignore-next-line unused-export
 export async function get_cached_git_status(issue_id: string): Promise<GitStatusCache | null> {
 	return invoke('get_cached_git_status', { issueId: issue_id });
 }

--- a/src/lib/tauri/github_commands.ts
+++ b/src/lib/tauri/github_commands.ts
@@ -6,6 +6,7 @@ import type {
 	SyncAllResult,
 } from '$lib/types/github';
 
+// fallow-ignore-next-line unused-export
 export async function get_github_status_cache(issue_id: string): Promise<GitHubStatusCache | null> {
 	return invoke('get_github_status_cache', { issueId: issue_id });
 }
@@ -20,6 +21,7 @@ export async function check_gh_availability(): Promise<GhCliAvailability> {
 	return invoke('check_gh_availability');
 }
 
+// fallow-ignore-next-line unused-export
 export async function fetch_issue_state(
 	issue_id: string,
 	owner: string,
@@ -34,6 +36,7 @@ export async function fetch_issue_state(
 	});
 }
 
+// fallow-ignore-next-line unused-export
 export async function fetch_pr_for_branch(
 	issue_id: string,
 	owner: string,

--- a/src/lib/tauri/issue_commands.ts
+++ b/src/lib/tauri/issue_commands.ts
@@ -15,6 +15,7 @@ export async function get_issues_for_dashboard(
 	});
 }
 
+// fallow-ignore-next-line unused-export
 export async function get_issue(id: string): Promise<Issue> {
 	return invoke('get_issue', { id });
 }

--- a/src/lib/tauri/portfolio_commands.ts
+++ b/src/lib/tauri/portfolio_commands.ts
@@ -7,6 +7,7 @@ export async function add_repo_to_portfolio(
 	return invoke('add_repo_to_portfolio', { request });
 }
 
+// fallow-ignore-next-line unused-export
 export async function remove_repo_from_portfolio(
 	portfolio_dashboard_id: string,
 	repo_dashboard_id: string,
@@ -17,6 +18,7 @@ export async function remove_repo_from_portfolio(
 	});
 }
 
+// fallow-ignore-next-line unused-export
 export async function get_portfolio_repos(
 	portfolio_dashboard_id: string,
 ): Promise<PortfolioDashboardPointer[]> {

--- a/src/lib/tauri/session_commands.ts
+++ b/src/lib/tauri/session_commands.ts
@@ -26,10 +26,12 @@ export async function get_sessions(): Promise<Session[]> {
 	return invoke('get_sessions');
 }
 
+// fallow-ignore-next-line unused-export
 export async function get_session(id: string): Promise<Session> {
 	return invoke('get_session', { id });
 }
 
+// fallow-ignore-next-line unused-export
 export async function discover_external_sessions(): Promise<DiscoveredSession[]> {
 	return invoke('discover_external_sessions');
 }
@@ -38,10 +40,12 @@ export async function adopt_session(request: AdoptSessionRequest): Promise<strin
 	return invoke('adopt_session', { request });
 }
 
+// fallow-ignore-next-line unused-export
 export async function start_discovery_polling(interval_milliseconds?: number): Promise<void> {
 	return invoke('start_discovery_polling', { intervalMilliseconds: interval_milliseconds });
 }
 
+// fallow-ignore-next-line unused-export
 export async function stop_discovery_polling(): Promise<void> {
 	return invoke('stop_discovery_polling');
 }

--- a/src/lib/tauri/worktree_commands.ts
+++ b/src/lib/tauri/worktree_commands.ts
@@ -13,6 +13,7 @@ export async function remove_worktree(request: RemoveWorktreeRequest): Promise<v
 	return invoke('remove_worktree', { request });
 }
 
+// fallow-ignore-next-line unused-export
 export async function refresh_worktree_state(issue_id: string): Promise<string> {
 	return invoke('refresh_worktree_state', { issueId: issue_id });
 }

--- a/src/lib/types/issue_card_callbacks.ts
+++ b/src/lib/types/issue_card_callbacks.ts
@@ -1,0 +1,11 @@
+import type { Issue } from './issue';
+
+export interface IssueCardCallbacks {
+	on_archive: (id: string) => void;
+	on_unarchive: (id: string) => void;
+	on_edit: (issue: Issue) => void;
+	on_delete: (id: string) => void;
+	on_setup_worktree?: (issue: Issue) => void;
+	on_remove_worktree?: (issue: Issue) => void;
+	on_execute_action?: (action_id: string, issue_id: string) => void;
+}

--- a/src/lib/types/session.ts
+++ b/src/lib/types/session.ts
@@ -41,7 +41,7 @@ export interface SpawnSessionRequest {
 	model?: string | null;
 }
 
-export type SessionEventType =
+type SessionEventType =
 	| 'session_init'
 	| 'message_delta'
 	| 'message_complete'

--- a/src/lib/types/tree_visualization.ts
+++ b/src/lib/types/tree_visualization.ts
@@ -24,7 +24,7 @@ export const TREE_STAGES = {
 	stump: 'stump',
 } as const satisfies Record<string, TreeStage>;
 
-export const TREE_SHAPES = {
+const TREE_SHAPES = {
 	oak: 'oak',
 	pine: 'pine',
 	birch: 'birch',
@@ -59,8 +59,6 @@ export const TOOL_TYPES = {
 	speechBubble: 'speechBubble',
 	stormCloud: 'stormCloud',
 } as const;
-
-export type ToolTypeKey = (typeof TOOL_TYPES)[keyof typeof TOOL_TYPES];
 
 export const OVERLAY_DEFAULTS = {
 	glow: { enabled: false, color: '#ffd700', intensity: 3, pulse: false },
@@ -183,13 +181,9 @@ export const DEFAULT_TREE_CONFIG: TreeConfig = {
 
 // ─── R12 State Dimensions ─────────────────────────────────────────────────
 
-export type GitHubLabel = string;
-
-export type ForestWorktreeState = WorktreeState;
+type ForestWorktreeState = WorktreeState;
 
 export type AggregateSessionState = SessionState | 'no-session';
-
-export type { ExecutionPhase };
 
 export type ForestBranchStatus = 'no-branch' | 'active' | 'local-only' | 'remote-gone' | 'deleted';
 
@@ -204,14 +198,14 @@ export type ForestPullRequestState =
 	| 'merged'
 	| 'closed';
 
-export type ForestGitHubIssueState = 'open' | 'closed';
+type ForestGitHubIssueState = 'open' | 'closed';
 
 export type ForestSyncStatus =
 	| { readonly type: 'up-to-date' }
 	| { readonly type: 'behind-base'; readonly count: number }
 	| { readonly type: 'merge-conflict' };
 
-export type ForestGrovekeeperStatus = 'active' | 'archived';
+type ForestGrovekeeperStatus = 'active' | 'archived';
 
 export interface StateDimensions {
 	readonly labels: readonly string[];


### PR DESCRIPTION
## Summary

- Ran fallow fully (dead-code, health, dupes) and resolved all actionable findings
- Removed 10 unused exports/types, suppressed 20 Tauri IPC wrappers as intentional API surface
- Extracted `IssueCardCallbacks` shared type eliminating 31-line IssueCard/IssueCardList duplication
- Decomposed 5 complex functions into data-driven tables and extracted helpers
- Added postinstall worktree link fix for `low-poly-2d-trees` (resolves all 8 pre-existing svelte-check errors in worktrees)

**Before → After:**
| Metric | Before | After |
|--------|--------|-------|
| Dead code findings | 29 | 0 |
| Health score | 93/A | 97/A |
| Complexity hotspots | 27 | 24 |
| Duplication | 1.4% (112 lines) | 0.6% (51 lines) |
| svelte-check errors | 8 | 0 |

## Test plan

- [x] `pnpm exec fallow dead-code` — 0 issues
- [x] `pnpm exec fallow health --score --summary` — 97/A
- [x] `pnpm exec fallow dupes` — 0.6%
- [x] `pnpm run check:all` — all 7 checks pass (0 errors)
- [x] `pnpm exec vitest run --project server` — 118 tests pass
- [x] Existing `compute_tree_visualization.test.ts` validates rule table refactor
- [x] Existing `forest_layout.test.ts` validates layout helper extraction

Fixes #66
Related: #76 (future monorepo migration to replace worktree link fix)