### PR TITLE
#44 refactor: extract test helpers, add typed enums for state models

### DIFF
--- a/src-tauri/src/commands/github_commands.rs
+++ b/src-tauri/src/commands/github_commands.rs
@@ -253,7 +253,7 @@ pub async fn fetch_pr_for_branch(
 
     let (pr_state, pr_number, pr_url) = if let Some(pr) = prs.first() {
         (
-            Some(resolve_pull_request_state(pr).to_string()),
+            Some(resolve_pull_request_state(pr)),
             Some(pr.number),
             Some(pr.url.clone()),
         )
@@ -428,7 +428,7 @@ pub async fn sync_all_github_state(
                             },
                             latest_reviews,
                         };
-                        pr_state = Some(resolve_pull_request_state(&pr).to_string());
+                        pr_state = Some(resolve_pull_request_state(&pr));
                         pr_number = Some(pr.number);
                         pr_url = Some(pr.url);
                     }
@@ -473,17 +473,8 @@ mod tests {
     use super::*;
     use rusqlite::Connection;
 
-    use crate::database::schema;
-    use crate::models::github::GhReviewRequest;
-
-    fn setup_test_database() -> Connection {
-        let connection = Connection::open_in_memory().unwrap();
-        connection
-            .execute_batch("PRAGMA foreign_keys = ON;")
-            .unwrap();
-        schema::create_tables(&connection).unwrap();
-        connection
-    }
+    use crate::database::test_helpers::setup_test_database;
+    use crate::models::github::{GhReviewRequest, PullRequestState};
 
     fn insert_dashboard(connection: &Connection, id: &str) {
         connection
@@ -521,7 +512,7 @@ mod tests {
         let cache = GitHubStatusCache {
             issue_id: "i1".to_string(),
             branch_status: None,
-            pr_state: Some("open".to_string()),
+            pr_state: Some(PullRequestState::Open),
             pr_number: Some(10),
             pr_url: Some("https://github.com/owner/repo/pull/10".to_string()),
             github_issue_state: Some("open".to_string()),
@@ -533,7 +524,7 @@ mod tests {
         upsert_cache(&connection, &cache).unwrap();
 
         let result = read_cache(&connection, "i1").unwrap().unwrap();
-        assert_eq!(result.pr_state.as_deref(), Some("open"));
+        assert_eq!(result.pr_state, Some(PullRequestState::Open));
         assert_eq!(result.pr_number, Some(10));
         assert_eq!(result.github_issue_state.as_deref(), Some("open"));
         assert!(result.fetched_at.is_some(), "fetched_at should be set by DB");
@@ -548,7 +539,7 @@ mod tests {
         let initial = GitHubStatusCache {
             issue_id: "i1".to_string(),
             branch_status: None,
-            pr_state: Some("open".to_string()),
+            pr_state: Some(PullRequestState::Open),
             pr_number: Some(10),
             pr_url: Some("https://github.com/owner/repo/pull/10".to_string()),
             github_issue_state: Some("open".to_string()),
@@ -562,7 +553,7 @@ mod tests {
         let update = GitHubStatusCache {
             issue_id: "i1".to_string(),
             branch_status: None,
-            pr_state: Some("merged".to_string()),
+            pr_state: Some(PullRequestState::Merged),
             pr_number: Some(10),
             pr_url: Some("https://github.com/owner/repo/pull/10".to_string()),
             github_issue_state: None, // Should preserve "open" via COALESCE
@@ -573,7 +564,7 @@ mod tests {
         upsert_cache(&connection, &update).unwrap();
 
         let result = read_cache(&connection, "i1").unwrap().unwrap();
-        assert_eq!(result.pr_state.as_deref(), Some("merged"));
+        assert_eq!(result.pr_state, Some(PullRequestState::Merged));
         assert_eq!(
             result.github_issue_state.as_deref(),
             Some("open"),
@@ -601,7 +592,7 @@ mod tests {
             let cache = GitHubStatusCache {
                 issue_id: id.to_string(),
                 branch_status: None,
-                pr_state: Some("open".to_string()),
+                pr_state: Some(PullRequestState::Open),
                 pr_number: None,
                 pr_url: None,
                 github_issue_state: Some("open".to_string()),
@@ -641,7 +632,7 @@ mod tests {
             review_requests: vec![],
             latest_reviews: vec![],
         };
-        assert_eq!(resolve_pull_request_state(&pr), "open");
+        assert_eq!(resolve_pull_request_state(&pr), PullRequestState::Open);
     }
 
     #[test]
@@ -654,7 +645,7 @@ mod tests {
             review_requests: vec![],
             latest_reviews: vec![],
         };
-        assert_eq!(resolve_pull_request_state(&pr), "draft");
+        assert_eq!(resolve_pull_request_state(&pr), PullRequestState::Draft);
     }
 
     #[test]
@@ -670,7 +661,7 @@ mod tests {
             }],
             latest_reviews: vec![],
         };
-        assert_eq!(resolve_pull_request_state(&pr), "review-requested");
+        assert_eq!(resolve_pull_request_state(&pr), PullRequestState::ReviewRequested);
     }
 
     #[test]
@@ -683,7 +674,7 @@ mod tests {
             review_requests: vec![],
             latest_reviews: vec![],
         };
-        assert_eq!(resolve_pull_request_state(&pr), "merged");
+        assert_eq!(resolve_pull_request_state(&pr), PullRequestState::Merged);
     }
 
     #[test]
@@ -696,7 +687,7 @@ mod tests {
             review_requests: vec![],
             latest_reviews: vec![],
         };
-        assert_eq!(resolve_pull_request_state(&pr), "closed");
+        assert_eq!(resolve_pull_request_state(&pr), PullRequestState::Closed);
     }
 
     // --- Issue state resolution tests ---
@@ -846,7 +837,7 @@ mod tests {
             },
             latest_reviews: vec![],
         };
-        assert_eq!(resolve_pull_request_state(&pr), "review-requested");
+        assert_eq!(resolve_pull_request_state(&pr), PullRequestState::ReviewRequested);
     }
 
     #[test]
@@ -870,6 +861,6 @@ mod tests {
             review_requests: vec![],
             latest_reviews: vec![],
         };
-        assert_eq!(resolve_pull_request_state(&pr), "open");
+        assert_eq!(resolve_pull_request_state(&pr), PullRequestState::Open);
     }
 }

--- a/src-tauri/src/database/migrations.rs
+++ b/src-tauri/src/database/migrations.rs
@@ -2,7 +2,7 @@ use rusqlite::Connection;
 
 use super::schema;
 
-const CURRENT_VERSION: i32 = 7;
+pub(crate) const CURRENT_VERSION: i32 = 7;
 
 type MigrationFunction = fn(&Connection) -> Result<(), rusqlite::Error>;
 

--- a/src-tauri/src/database/mod.rs
+++ b/src-tauri/src/database/mod.rs
@@ -3,4 +3,7 @@ pub mod migrations;
 pub mod schema;
 
 #[cfg(test)]
+pub(crate) mod test_helpers;
+
+#[cfg(test)]
 mod tests;

--- a/src-tauri/src/database/test_helpers.rs
+++ b/src-tauri/src/database/test_helpers.rs
@@ -1,0 +1,15 @@
+use rusqlite::Connection;
+
+use super::schema;
+
+/// Shared test helper: creates an in-memory SQLite database with foreign keys enabled
+/// and all tables created via the current schema. Used across multiple test modules
+/// to avoid duplicating setup logic.
+pub(crate) fn setup_test_database() -> Connection {
+    let connection = Connection::open_in_memory().unwrap();
+    connection
+        .execute_batch("PRAGMA foreign_keys = ON;")
+        .unwrap();
+    schema::create_tables(&connection).unwrap();
+    connection
+}

--- a/src-tauri/src/database/tests.rs
+++ b/src-tauri/src/database/tests.rs
@@ -3,16 +3,7 @@ mod tests {
     use rusqlite::Connection;
 
     use crate::database::migrations;
-    use crate::database::schema;
-
-    fn setup_test_database() -> Connection {
-        let connection = Connection::open_in_memory().unwrap();
-        connection
-            .execute_batch("PRAGMA foreign_keys = ON;")
-            .unwrap();
-        schema::create_tables(&connection).unwrap();
-        connection
-    }
+    use crate::database::test_helpers::setup_test_database;
 
     // --- Migration tests ---
 
@@ -22,7 +13,7 @@ mod tests {
         migrations::run_migrations(&connection).unwrap();
 
         let version = migrations::get_schema_version(&connection).unwrap();
-        assert_eq!(version, 7);
+        assert_eq!(version, migrations::CURRENT_VERSION);
     }
 
     #[test]
@@ -32,7 +23,7 @@ mod tests {
         migrations::run_migrations(&connection).unwrap();
 
         let version = migrations::get_schema_version(&connection).unwrap();
-        assert_eq!(version, 7);
+        assert_eq!(version, migrations::CURRENT_VERSION);
     }
 
     // --- Schema tests ---
@@ -696,7 +687,7 @@ mod tests {
         migrations::run_migrations(&connection).unwrap();
 
         let version = migrations::get_schema_version(&connection).unwrap();
-        assert_eq!(version, 7);
+        assert_eq!(version, migrations::CURRENT_VERSION);
 
         // portfolio_dashboard_pointers table exists
         let exists: bool = connection

--- a/src-tauri/src/models/git_status.rs
+++ b/src-tauri/src/models/git_status.rs
@@ -1,10 +1,12 @@
 use serde::{Deserialize, Serialize};
 
+use crate::models::github::PullRequestState;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GitStatusCache {
     pub issue_id: String,
     pub branch_status: Option<String>,
-    pub pr_state: Option<String>,
+    pub pr_state: Option<PullRequestState>,
     pub pr_number: Option<i64>,
     pub pr_url: Option<String>,
     pub github_issue_state: Option<String>,

--- a/src-tauri/src/models/github.rs
+++ b/src-tauri/src/models/github.rs
@@ -1,11 +1,64 @@
+use rusqlite::types::{FromSql, FromSqlError, FromSqlResult, ToSql, ToSqlOutput, ValueRef};
 use serde::{Deserialize, Serialize};
+
+/// PR lifecycle states matching the DB CHECK constraint on `git_status_cache.pr_state`.
+/// Note: Does NOT include `ready-to-merge` — that exists in TypeScript but not in the DB schema.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub enum PullRequestState {
+    Draft,
+    Open,
+    ReviewRequested,
+    ChangesRequested,
+    Approved,
+    Merged,
+    Closed,
+}
+
+impl PullRequestState {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            PullRequestState::Draft => "draft",
+            PullRequestState::Open => "open",
+            PullRequestState::ReviewRequested => "review-requested",
+            PullRequestState::ChangesRequested => "changes-requested",
+            PullRequestState::Approved => "approved",
+            PullRequestState::Merged => "merged",
+            PullRequestState::Closed => "closed",
+        }
+    }
+}
+
+impl FromSql for PullRequestState {
+    fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
+        let text = value.as_str()?;
+        match text {
+            "draft" => Ok(PullRequestState::Draft),
+            "open" => Ok(PullRequestState::Open),
+            "review-requested" => Ok(PullRequestState::ReviewRequested),
+            "changes-requested" => Ok(PullRequestState::ChangesRequested),
+            "approved" => Ok(PullRequestState::Approved),
+            "merged" => Ok(PullRequestState::Merged),
+            "closed" => Ok(PullRequestState::Closed),
+            other => Err(FromSqlError::Other(
+                format!("Unknown PullRequestState: {other}").into(),
+            )),
+        }
+    }
+}
+
+impl ToSql for PullRequestState {
+    fn to_sql(&self) -> rusqlite::Result<ToSqlOutput<'_>> {
+        Ok(ToSqlOutput::from(self.as_str()))
+    }
+}
 
 /// Cached GitHub status for an issue, mirroring the `git_status_cache` table.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GitHubStatusCache {
     pub issue_id: String,
     pub branch_status: Option<String>,
-    pub pr_state: Option<String>,
+    pub pr_state: Option<PullRequestState>,
     pub pr_number: Option<i64>,
     pub pr_url: Option<String>,
     pub github_issue_state: Option<String>,
@@ -76,26 +129,26 @@ pub struct GhReviewOutput {
     pub state: String,
 }
 
-/// Maps gh CLI PR output to our internal state string.
-pub fn resolve_pull_request_state(pr: &GhPullRequestOutput) -> &'static str {
+/// Maps gh CLI PR output to our internal PR state enum.
+pub fn resolve_pull_request_state(pr: &GhPullRequestOutput) -> PullRequestState {
     match pr.state.as_str() {
-        "MERGED" => "merged",
-        "CLOSED" => "closed",
+        "MERGED" => PullRequestState::Merged,
+        "CLOSED" => PullRequestState::Closed,
         _ => {
             // OPEN state with sub-states
             if pr.is_draft {
-                "draft"
+                PullRequestState::Draft
             } else if !pr.review_requests.is_empty() {
-                "review-requested"
+                PullRequestState::ReviewRequested
             // latestReviews is limited to first:1 in both GraphQL and CLI queries
             } else if let Some(review) = pr.latest_reviews.last() {
                 match review.state.as_str() {
-                    "APPROVED" => "approved",
-                    "CHANGES_REQUESTED" => "changes-requested",
-                    _ => "open",
+                    "APPROVED" => PullRequestState::Approved,
+                    "CHANGES_REQUESTED" => PullRequestState::ChangesRequested,
+                    _ => PullRequestState::Open,
                 }
             } else {
-                "open"
+                PullRequestState::Open
             }
         }
     }
@@ -139,7 +192,7 @@ mod tests {
                 state: "APPROVED".to_string(),
             }],
         );
-        assert_eq!(resolve_pull_request_state(&pr), "approved");
+        assert_eq!(resolve_pull_request_state(&pr), PullRequestState::Approved);
     }
 
     #[test]
@@ -152,13 +205,13 @@ mod tests {
                 state: "CHANGES_REQUESTED".to_string(),
             }],
         );
-        assert_eq!(resolve_pull_request_state(&pr), "changes-requested");
+        assert_eq!(resolve_pull_request_state(&pr), PullRequestState::ChangesRequested);
     }
 
     #[test]
     fn resolve_pr_state_draft() {
         let pr = make_pr("OPEN", true, vec![], vec![]);
-        assert_eq!(resolve_pull_request_state(&pr), "draft");
+        assert_eq!(resolve_pull_request_state(&pr), PullRequestState::Draft);
     }
 
     #[test]
@@ -172,18 +225,27 @@ mod tests {
             }],
             vec![],
         );
-        assert_eq!(resolve_pull_request_state(&pr), "review-requested");
+        assert_eq!(resolve_pull_request_state(&pr), PullRequestState::ReviewRequested);
     }
 
     #[test]
     fn resolve_pr_state_merged() {
         let pr = make_pr("MERGED", false, vec![], vec![]);
-        assert_eq!(resolve_pull_request_state(&pr), "merged");
+        assert_eq!(resolve_pull_request_state(&pr), PullRequestState::Merged);
     }
 
     #[test]
     fn resolve_pr_state_open_fallback() {
         let pr = make_pr("OPEN", false, vec![], vec![]);
-        assert_eq!(resolve_pull_request_state(&pr), "open");
+        assert_eq!(resolve_pull_request_state(&pr), PullRequestState::Open);
+    }
+
+    #[test]
+    fn pull_request_state_serde_round_trip() {
+        let json = "\"review-requested\"";
+        let deserialized: PullRequestState = serde_json::from_str(json).unwrap();
+        assert_eq!(deserialized, PullRequestState::ReviewRequested);
+        let serialized = serde_json::to_string(&deserialized).unwrap();
+        assert_eq!(serialized, "\"review-requested\"");
     }
 }

--- a/src-tauri/src/models/session.rs
+++ b/src-tauri/src/models/session.rs
@@ -1,11 +1,141 @@
+use rusqlite::types::{FromSql, FromSqlError, FromSqlResult, ToSql, ToSqlOutput, ValueRef};
 use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub enum SessionState {
+    Running,
+    NeedsInput,
+    NeedsReview,
+    Paused,
+    Finished,
+    Errored,
+}
+
+impl SessionState {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SessionState::Running => "running",
+            SessionState::NeedsInput => "needs-input",
+            SessionState::NeedsReview => "needs-review",
+            SessionState::Paused => "paused",
+            SessionState::Finished => "finished",
+            SessionState::Errored => "errored",
+        }
+    }
+}
+
+impl FromSql for SessionState {
+    fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
+        let text = value.as_str()?;
+        match text {
+            "running" => Ok(SessionState::Running),
+            "needs-input" => Ok(SessionState::NeedsInput),
+            "needs-review" => Ok(SessionState::NeedsReview),
+            "paused" => Ok(SessionState::Paused),
+            "finished" => Ok(SessionState::Finished),
+            "errored" => Ok(SessionState::Errored),
+            other => Err(FromSqlError::Other(
+                format!("Unknown SessionState: {other}").into(),
+            )),
+        }
+    }
+}
+
+impl ToSql for SessionState {
+    fn to_sql(&self) -> rusqlite::Result<ToSqlOutput<'_>> {
+        Ok(ToSqlOutput::from(self.as_str()))
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub enum ExecutionPhase {
+    None,
+    Analyzing,
+    Tdd,
+    Reviewing,
+    Verifying,
+    Committing,
+}
+
+impl ExecutionPhase {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ExecutionPhase::None => "none",
+            ExecutionPhase::Analyzing => "analyzing",
+            ExecutionPhase::Tdd => "tdd",
+            ExecutionPhase::Reviewing => "reviewing",
+            ExecutionPhase::Verifying => "verifying",
+            ExecutionPhase::Committing => "committing",
+        }
+    }
+}
+
+impl FromSql for ExecutionPhase {
+    fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
+        let text = value.as_str()?;
+        match text {
+            "none" => Ok(ExecutionPhase::None),
+            "analyzing" => Ok(ExecutionPhase::Analyzing),
+            "tdd" => Ok(ExecutionPhase::Tdd),
+            "reviewing" => Ok(ExecutionPhase::Reviewing),
+            "verifying" => Ok(ExecutionPhase::Verifying),
+            "committing" => Ok(ExecutionPhase::Committing),
+            other => Err(FromSqlError::Other(
+                format!("Unknown ExecutionPhase: {other}").into(),
+            )),
+        }
+    }
+}
+
+impl ToSql for ExecutionPhase {
+    fn to_sql(&self) -> rusqlite::Result<ToSqlOutput<'_>> {
+        Ok(ToSqlOutput::from(self.as_str()))
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub enum SessionSource {
+    Spawned,
+    Adopted,
+}
+
+impl SessionSource {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SessionSource::Spawned => "spawned",
+            SessionSource::Adopted => "adopted",
+        }
+    }
+}
+
+impl FromSql for SessionSource {
+    fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
+        let text = value.as_str()?;
+        match text {
+            "spawned" => Ok(SessionSource::Spawned),
+            "adopted" => Ok(SessionSource::Adopted),
+            other => Err(FromSqlError::Other(
+                format!("Unknown SessionSource: {other}").into(),
+            )),
+        }
+    }
+}
+
+impl ToSql for SessionSource {
+    fn to_sql(&self) -> rusqlite::Result<ToSqlOutput<'_>> {
+        Ok(ToSqlOutput::from(self.as_str()))
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Session {
     pub id: String,
     pub issue_id: Option<String>,
     pub provider: String,
-    pub state: String,
+    pub state: SessionState,
     pub pid: Option<i64>,
     pub session_file_path: Option<String>,
     pub started_at: String,
@@ -15,8 +145,8 @@ pub struct Session {
     pub original_intent: Option<String>,
     pub last_prompt: Option<String>,
     pub last_response_summary: Option<String>,
-    pub execution_phase: String,
-    pub source: String,
+    pub execution_phase: ExecutionPhase,
+    pub source: SessionSource,
     pub working_directory: Option<String>,
 }
 
@@ -27,4 +157,43 @@ pub struct SpawnSessionRequest {
     pub issue_id: Option<String>,
     pub permission_mode: Option<String>,
     pub model: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn session_state_serde_round_trip() {
+        let json = "\"needs-input\"";
+        let deserialized: SessionState = serde_json::from_str(json).unwrap();
+        assert_eq!(deserialized, SessionState::NeedsInput);
+        let serialized = serde_json::to_string(&deserialized).unwrap();
+        assert_eq!(serialized, "\"needs-input\"");
+    }
+
+    #[test]
+    fn execution_phase_serde_round_trip() {
+        let json = "\"tdd\"";
+        let deserialized: ExecutionPhase = serde_json::from_str(json).unwrap();
+        assert_eq!(deserialized, ExecutionPhase::Tdd);
+        let serialized = serde_json::to_string(&deserialized).unwrap();
+        assert_eq!(serialized, "\"tdd\"");
+    }
+
+    #[test]
+    fn session_source_serde_round_trip() {
+        let json = "\"spawned\"";
+        let deserialized: SessionSource = serde_json::from_str(json).unwrap();
+        assert_eq!(deserialized, SessionSource::Spawned);
+        let serialized = serde_json::to_string(&deserialized).unwrap();
+        assert_eq!(serialized, "\"spawned\"");
+    }
+
+    #[test]
+    fn invalid_session_state_deserialization_returns_error() {
+        let json = "\"invalid-state\"";
+        let result = serde_json::from_str::<SessionState>(json);
+        assert!(result.is_err());
+    }
 }

--- a/src-tauri/src/notification/service.rs
+++ b/src-tauri/src/notification/service.rs
@@ -9,6 +9,7 @@ use crate::models::notification::{
     row_to_notification_config, NotificationConfig, NotificationEventType,
     NOTIFICATION_CONFIG_SELECT_COLUMNS,
 };
+use crate::models::session::SessionState;
 
 use super::sound;
 
@@ -144,17 +145,17 @@ impl NotificationService {
     }
 }
 
-/// Map a session state string (from DB/events) to a notification event type.
-/// Returns None for states that should not trigger notifications (e.g. "running").
+/// Map a SessionState to a notification event type.
+/// Returns None for states that should not trigger notifications (e.g. Running, Paused).
 /// Note: PrReady is not mapped here — it will be triggered by a future GitHub
 /// polling hook, not by session state transitions.
-pub fn session_state_to_event_type(state: &str) -> Option<NotificationEventType> {
+pub fn session_state_to_event_type(state: &SessionState) -> Option<NotificationEventType> {
     match state {
-        "needs-input" => Some(NotificationEventType::NeedsInput),
-        "needs-review" => Some(NotificationEventType::NeedsReview),
-        "finished" => Some(NotificationEventType::Finished),
-        "errored" => Some(NotificationEventType::Errored),
-        _ => None,
+        SessionState::NeedsInput => Some(NotificationEventType::NeedsInput),
+        SessionState::NeedsReview => Some(NotificationEventType::NeedsReview),
+        SessionState::Finished => Some(NotificationEventType::Finished),
+        SessionState::Errored => Some(NotificationEventType::Errored),
+        SessionState::Running | SessionState::Paused => None,
     }
 }
 
@@ -165,35 +166,30 @@ mod tests {
     #[test]
     fn session_state_to_event_type_maps_correctly() {
         assert_eq!(
-            session_state_to_event_type("needs-input"),
+            session_state_to_event_type(&SessionState::NeedsInput),
             Some(NotificationEventType::NeedsInput)
         );
         assert_eq!(
-            session_state_to_event_type("needs-review"),
+            session_state_to_event_type(&SessionState::NeedsReview),
             Some(NotificationEventType::NeedsReview)
         );
         assert_eq!(
-            session_state_to_event_type("finished"),
+            session_state_to_event_type(&SessionState::Finished),
             Some(NotificationEventType::Finished)
         );
         assert_eq!(
-            session_state_to_event_type("errored"),
+            session_state_to_event_type(&SessionState::Errored),
             Some(NotificationEventType::Errored)
         );
     }
 
     #[test]
     fn session_state_to_event_type_ignores_running() {
-        assert_eq!(session_state_to_event_type("running"), None);
+        assert_eq!(session_state_to_event_type(&SessionState::Running), None);
     }
 
     #[test]
     fn session_state_to_event_type_ignores_paused() {
-        assert_eq!(session_state_to_event_type("paused"), None);
-    }
-
-    #[test]
-    fn session_state_to_event_type_ignores_unknown() {
-        assert_eq!(session_state_to_event_type("unknown-state"), None);
+        assert_eq!(session_state_to_event_type(&SessionState::Paused), None);
     }
 }

--- a/src-tauri/src/session/session_actor.rs
+++ b/src-tauri/src/session/session_actor.rs
@@ -8,6 +8,7 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::sync::mpsc;
 
 use super::provider::{ActorCommand, SessionEvent, SessionHandle, SessionProvider};
+use crate::models::session::SessionState;
 use crate::notification::service::{session_state_to_event_type, NotificationService};
 
 /// Payload emitted to the frontend via Tauri events.
@@ -126,7 +127,7 @@ pub async fn run_actor(
                         } else {
                             // Set paused state immediately — the CLI will emit
                             // result(idle) later which transitions to needs-review
-                            update_session_state(&session_id, "paused", &database_connection);
+                            update_session_state(&session_id, &SessionState::Paused, &database_connection);
                             let pause_event = SessionEvent::RunState {
                                 state: "paused".into(),
                                 error: None,
@@ -179,18 +180,18 @@ fn handle_event(
         // Keep in sync with sessions.svelte.ts handle_session_event()
         SessionEvent::RunState { state, error } => {
             let db_state = match state.as_str() {
-                "running" => "running",
-                "idle" => "needs-review",
-                "failed" => "errored",
-                "completed" => "finished",
-                "stopped" => "finished",
+                "running" => SessionState::Running,
+                "idle" => SessionState::NeedsReview,
+                "failed" => SessionState::Errored,
+                "completed" => SessionState::Finished,
+                "stopped" => SessionState::Finished,
                 _ => return,
             };
-            update_session_state(session_id, db_state, database_connection);
+            update_session_state(session_id, &db_state, database_connection);
             fire_notification(
                 session_id,
-                db_state,
-                error.as_deref().unwrap_or(db_state),
+                &db_state,
+                error.as_deref().unwrap_or(db_state.as_str()),
                 app_handle,
                 database_connection,
             );
@@ -218,10 +219,10 @@ fn handle_event(
             update_session_file_path(session_id, cli_session_id, database_connection);
         }
         SessionEvent::PermissionPrompt { .. } | SessionEvent::ElicitationPrompt { .. } => {
-            update_session_state(session_id, "needs-input", database_connection);
+            update_session_state(session_id, &SessionState::NeedsInput, database_connection);
             fire_notification(
                 session_id,
-                "needs-input",
+                &SessionState::NeedsInput,
                 "Session is waiting for your input",
                 app_handle,
                 database_connection,
@@ -233,7 +234,7 @@ fn handle_event(
 
 fn fire_notification(
     session_id: &str,
-    state: &str,
+    state: &SessionState,
     message: &str,
     app_handle: &AppHandle,
     database_connection: &std::sync::Arc<StdMutex<Connection>>,
@@ -249,7 +250,7 @@ fn fire_notification(
 
 fn update_session_state(
     session_id: &str,
-    state: &str,
+    state: &SessionState,
     connection: &std::sync::Arc<StdMutex<Connection>>,
 ) {
     if let Ok(conn) = connection.lock() {


### PR DESCRIPTION
## Description
- Extracted duplicated `setup_test_database()` helper from two test modules into shared `database/test_helpers.rs` module
- Made `CURRENT_VERSION` constant in `migrations.rs` public within crate and replaced hardcoded version literals in tests
- Replaced raw `String` fields with typed enums: `SessionState`, `ExecutionPhase`, `SessionSource`, `PullRequestState`
- All enums have `#[serde(rename_all = "kebab-case")]`, `FromSql`/`ToSql` implementations, and comprehensive test coverage
- All 174 Rust tests pass

## Resolves
Closes #44

## Testing
- [x] All 174 Rust tests passing
- [x] Serde round-trip tests for all enums
- [x] Invalid deserialization rejection tests