### PR TITLE
#71 feat: sync GitHub labels to Issue model for tree shape differentiation

### DIFF
--- a/src-tauri/src/commands/dashboard_commands.rs
+++ b/src-tauri/src/commands/dashboard_commands.rs
@@ -3,12 +3,13 @@ use tauri::State;
 use uuid::Uuid;
 
 use crate::database::connection::DatabaseState;
+use crate::database::migrations::{seed_label_shape_mappings_for_dashboard, DEFAULT_TREE_SHAPE};
 use crate::models::dashboard::{
     CreateDashboardRequest, Dashboard, DashboardType, UpdateDashboardRequest,
 };
 
 const DASHBOARD_SELECT_COLUMNS: &str =
-    "id, name, type, github_repo, local_folder, default_base_branch, worktree_parent_folder, color_palette_id";
+    "id, name, type, github_repo, local_folder, default_base_branch, worktree_parent_folder, color_palette_id, default_shape";
 
 fn row_to_dashboard(row: &Row) -> Result<Dashboard, rusqlite::Error> {
     let dashboard_type_string: String = row.get(2)?;
@@ -26,6 +27,7 @@ fn row_to_dashboard(row: &Row) -> Result<Dashboard, rusqlite::Error> {
         default_base_branch: row.get(5)?,
         worktree_parent_folder: row.get(6)?,
         color_palette_id: row.get(7)?,
+        default_shape: row.get(8)?,
     })
 }
 
@@ -54,6 +56,9 @@ pub fn create_dashboard(
         )
         .map_err(|error| format!("Failed to create dashboard: {error}"))?;
 
+    seed_label_shape_mappings_for_dashboard(&connection, &id)
+        .map_err(|error| format!("Failed to seed label shape mappings: {error}"))?;
+
     Ok(Dashboard {
         id,
         name: request.name,
@@ -63,6 +68,7 @@ pub fn create_dashboard(
         default_base_branch: request.default_base_branch,
         worktree_parent_folder: request.worktree_parent_folder,
         color_palette_id: request.color_palette_id,
+        default_shape: DEFAULT_TREE_SHAPE.to_string(),
     })
 }
 
@@ -126,12 +132,14 @@ pub fn update_dashboard(
             request.color_palette_id,
             existing.color_palette_id,
         ),
+        default_shape: request.default_shape.unwrap_or(existing.default_shape),
     };
 
     connection
         .execute(
-            "UPDATE dashboards SET name = ?1, type = ?2, github_repo = ?3, local_folder = ?4, default_base_branch = ?5, worktree_parent_folder = ?6, color_palette_id = ?7
-             WHERE id = ?8",
+            "UPDATE dashboards SET name = ?1, type = ?2, github_repo = ?3, local_folder = ?4, \
+             default_base_branch = ?5, worktree_parent_folder = ?6, color_palette_id = ?7, \
+             default_shape = ?8 WHERE id = ?9",
             rusqlite::params![
                 updated.name,
                 updated.dashboard_type.to_string(),
@@ -140,6 +148,7 @@ pub fn update_dashboard(
                 updated.default_base_branch,
                 updated.worktree_parent_folder,
                 updated.color_palette_id,
+                updated.default_shape,
                 updated.id,
             ],
         )

--- a/src-tauri/src/commands/github_commands.rs
+++ b/src-tauri/src/commands/github_commands.rs
@@ -110,6 +110,23 @@ async fn run_gh_command(args: &[&str]) -> Result<String, String> {
         .map_err(|error| format!("Invalid UTF-8 in gh output: {error}"))
 }
 
+const GITHUB_DEFAULT_LABEL_COLOR: &str = "6e7681";
+
+fn parse_label_nodes_to_json(label_nodes: &[serde_json::Value]) -> String {
+    let labels: Vec<serde_json::Value> = label_nodes
+        .iter()
+        .filter_map(|node| {
+            let name = node.get("name")?.as_str()?;
+            let color = node
+                .get("color")
+                .and_then(|c| c.as_str())
+                .unwrap_or(GITHUB_DEFAULT_LABEL_COLOR);
+            Some(serde_json::json!({"name": name, "color": format!("#{color}")}))
+        })
+        .collect();
+    serde_json::to_string(&labels).unwrap_or_else(|_| "[]".to_string())
+}
+
 /// Build a GraphQL query to fetch multiple issues and their associated PRs in one call.
 fn build_bulk_sync_graphql_query(
     owner: &str,
@@ -121,7 +138,7 @@ fn build_bulk_sync_graphql_query(
 
     for (index, &number) in issue_numbers.iter().enumerate() {
         fragments.push(format!(
-            "issue_{index}: issue(number: {number}) {{ state url }}"
+            "issue_{index}: issue(number: {number}) {{ state url labels(first: 20) {{ nodes {{ name color }} }} }}"
         ));
     }
 
@@ -368,18 +385,28 @@ pub async fn sync_all_github_state(
 
     // Parse all results first (no DB lock needed)
     let mut caches_to_write = Vec::with_capacity(syncable.len());
+    let mut labels_to_write: Vec<(String, Option<String>)> = Vec::with_capacity(syncable.len());
 
     for (index, (issue_id, _, _)) in syncable.iter().enumerate() {
         let mut github_issue_state = None;
         let mut pr_state = None;
         let mut pr_number = None;
         let mut pr_url = None;
+        let mut labels_json: Option<String> = None;
 
-        // Parse issue state
+        // Parse issue state and labels
         let issue_key = format!("issue_{index}");
         if let Some(issue_data) = repository.get(&issue_key) {
             if let Some(state_str) = issue_data.get("state").and_then(|s| s.as_str()) {
                 github_issue_state = Some(resolve_github_issue_state(state_str).to_string());
+            }
+
+            if let Some(label_nodes) = issue_data
+                .get("labels")
+                .and_then(|l| l.get("nodes"))
+                .and_then(|n| n.as_array())
+            {
+                labels_json = Some(parse_label_nodes_to_json(label_nodes));
             }
         }
 
@@ -436,6 +463,8 @@ pub async fn sync_all_github_state(
             }
         }
 
+        labels_to_write.push((issue_id.clone(), labels_json));
+
         caches_to_write.push(GitHubStatusCache {
             issue_id: issue_id.clone(),
             branch_status: None,
@@ -458,6 +487,17 @@ pub async fn sync_all_github_state(
             match upsert_cache(&connection, cache) {
                 Ok(()) => synced_count += 1,
                 Err(error) => errors.push(format!("Failed to cache {}: {error}", cache.issue_id)),
+            }
+        }
+
+        for (issue_id, labels_json) in &labels_to_write {
+            if let Some(labels) = labels_json {
+                if let Err(error) = connection.execute(
+                    "UPDATE issues SET labels = ?1 WHERE id = ?2",
+                    rusqlite::params![labels, issue_id],
+                ) {
+                    errors.push(format!("Failed to update labels for {issue_id}: {error}"));
+                }
             }
         }
     }
@@ -757,6 +797,8 @@ mod tests {
         let query = build_bulk_sync_graphql_query("owner", "repo", &[1, 2], &[None, None]);
         assert!(query.contains("issue_0: issue(number: 1)"));
         assert!(query.contains("issue_1: issue(number: 2)"));
+        assert!(query.contains("labels(first: 20)"));
+        assert!(query.contains("nodes { name color }"));
         assert!(!query.contains("pr_"));
     }
 
@@ -871,5 +913,56 @@ mod tests {
             latest_reviews: vec![],
         };
         assert_eq!(resolve_pull_request_state(&pr), "open");
+    }
+
+    #[test]
+    fn parse_graphql_labels_from_issue() {
+        let response_json = r#"{
+            "data": {
+                "repository": {
+                    "issue_0": {
+                        "state": "OPEN",
+                        "url": "https://github.com/o/r/issues/1",
+                        "labels": {
+                            "nodes": [
+                                {"name": "bug", "color": "d73a4a"},
+                                {"name": "task", "color": "0E8A16"}
+                            ]
+                        }
+                    }
+                }
+            }
+        }"#;
+
+        let response: serde_json::Value = serde_json::from_str(response_json).unwrap();
+        let repository = response
+            .get("data")
+            .unwrap()
+            .get("repository")
+            .unwrap();
+
+        let issue_data = repository.get("issue_0").unwrap();
+        let label_nodes = issue_data
+            .get("labels")
+            .unwrap()
+            .get("nodes")
+            .unwrap()
+            .as_array()
+            .unwrap();
+
+        let json = parse_label_nodes_to_json(label_nodes);
+        let parsed: Vec<serde_json::Value> = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0]["name"], "bug");
+        assert_eq!(parsed[0]["color"], "#d73a4a");
+        assert_eq!(parsed[1]["name"], "task");
+        assert_eq!(parsed[1]["color"], "#0E8A16");
+    }
+
+    #[test]
+    fn parse_graphql_issue_without_labels() {
+        let label_nodes: Vec<serde_json::Value> = vec![];
+        let json = parse_label_nodes_to_json(&label_nodes);
+        assert_eq!(json, "[]");
     }
 }

--- a/src-tauri/src/commands/issue_commands.rs
+++ b/src-tauri/src/commands/issue_commands.rs
@@ -10,7 +10,7 @@ use super::shared::resolve_nullable_field;
 const ISSUE_SELECT_COLUMNS: &str =
     "id, dashboard_id, name, priority, color, status, github_issue_url, github_issue_number, \
      branch_name, base_branch, worktree_folder, worktree_state, parent_issue_id, editor_folder, \
-     dev_server_command, dev_server_port, dev_server_pid, browser_url, sort_order, created_at";
+     dev_server_command, dev_server_port, dev_server_pid, browser_url, labels, sort_order, created_at";
 
 fn row_to_issue(row: &Row) -> Result<Issue, rusqlite::Error> {
     Ok(Issue {
@@ -32,8 +32,9 @@ fn row_to_issue(row: &Row) -> Result<Issue, rusqlite::Error> {
         dev_server_port: row.get(15)?,
         dev_server_pid: row.get(16)?,
         browser_url: row.get(17)?,
-        sort_order: row.get(18)?,
-        created_at: row.get(19)?,
+        labels: row.get(18)?,
+        sort_order: row.get(19)?,
+        created_at: row.get(20)?,
     })
 }
 
@@ -47,8 +48,8 @@ pub fn create_issue(
 
     connection
         .execute(
-            "INSERT INTO issues (id, dashboard_id, name, priority, color, github_issue_url, github_issue_number, parent_issue_id)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            "INSERT INTO issues (id, dashboard_id, name, priority, color, github_issue_url, github_issue_number, parent_issue_id, labels)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
             rusqlite::params![
                 id,
                 request.dashboard_id,
@@ -58,6 +59,7 @@ pub fn create_issue(
                 request.github_issue_url,
                 request.github_issue_number,
                 request.parent_issue_id,
+                request.labels,
             ],
         )
         .map_err(|error| format!("Failed to create issue: {error}"))?;
@@ -131,6 +133,7 @@ pub fn update_issue(
     let worktree_folder = resolve_nullable_field(request.worktree_folder, existing.worktree_folder);
     let worktree_state = request.worktree_state.unwrap_or(existing.worktree_state);
     let parent_issue_id = resolve_nullable_field(request.parent_issue_id, existing.parent_issue_id);
+    let labels = resolve_nullable_field(request.labels, existing.labels);
     let sort_order = request.sort_order.unwrap_or(existing.sort_order);
 
     connection
@@ -138,7 +141,7 @@ pub fn update_issue(
             "UPDATE issues SET name = ?1, priority = ?2, color = ?3, github_issue_url = ?4, \
              github_issue_number = ?5, branch_name = ?6, base_branch = ?7, \
              worktree_folder = ?8, worktree_state = ?9, parent_issue_id = ?10, \
-             sort_order = ?11 WHERE id = ?12",
+             labels = ?11, sort_order = ?12 WHERE id = ?13",
             rusqlite::params![
                 name,
                 priority,
@@ -150,6 +153,7 @@ pub fn update_issue(
                 worktree_folder,
                 worktree_state,
                 parent_issue_id,
+                labels,
                 sort_order,
                 existing.id,
             ],

--- a/src-tauri/src/commands/label_shape_mapping_commands.rs
+++ b/src-tauri/src/commands/label_shape_mapping_commands.rs
@@ -1,0 +1,71 @@
+use rusqlite::Row;
+use tauri::State;
+
+use crate::database::connection::DatabaseState;
+use crate::models::label_shape_mapping::LabelShapeMapping;
+
+fn row_to_mapping(row: &Row) -> Result<LabelShapeMapping, rusqlite::Error> {
+    Ok(LabelShapeMapping {
+        id: row.get(0)?,
+        dashboard_id: row.get(1)?,
+        label_name: row.get(2)?,
+        tree_shape: row.get(3)?,
+        color: row.get(4)?,
+        priority_order: row.get(5)?,
+    })
+}
+
+#[tauri::command]
+pub fn get_label_shape_mappings(
+    state: State<DatabaseState>,
+    dashboard_id: String,
+) -> Result<Vec<LabelShapeMapping>, String> {
+    let connection = state.0.lock().map_err(|error| error.to_string())?;
+
+    let mut statement = connection
+        .prepare(
+            "SELECT id, dashboard_id, label_name, tree_shape, color, priority_order \
+             FROM label_shape_mappings WHERE dashboard_id = ?1 ORDER BY priority_order",
+        )
+        .map_err(|error| format!("Failed to prepare query: {error}"))?;
+
+    let mappings = statement
+        .query_map([&dashboard_id], |row| row_to_mapping(row))
+        .map_err(|error| format!("Failed to query mappings: {error}"))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| format!("Failed to read mapping row: {error}"))?;
+
+    Ok(mappings)
+}
+
+#[tauri::command]
+pub fn upsert_label_shape_mapping(
+    state: State<DatabaseState>,
+    dashboard_id: String,
+    label_name: String,
+    tree_shape: String,
+    color: Option<String>,
+    priority_order: i32,
+) -> Result<LabelShapeMapping, String> {
+    let connection = state.0.lock().map_err(|error| error.to_string())?;
+    let id = uuid::Uuid::new_v4().to_string();
+
+    connection
+        .execute(
+            "INSERT INTO label_shape_mappings (id, dashboard_id, label_name, tree_shape, color, priority_order) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6) \
+             ON CONFLICT(dashboard_id, label_name) DO UPDATE SET \
+             tree_shape = excluded.tree_shape, color = excluded.color, priority_order = excluded.priority_order",
+            rusqlite::params![id, dashboard_id, label_name, tree_shape, color, priority_order],
+        )
+        .map_err(|error| format!("Failed to upsert mapping: {error}"))?;
+
+    connection
+        .query_row(
+            "SELECT id, dashboard_id, label_name, tree_shape, color, priority_order \
+             FROM label_shape_mappings WHERE dashboard_id = ?1 AND label_name = ?2",
+            rusqlite::params![dashboard_id, label_name],
+            |row| row_to_mapping(row),
+        )
+        .map_err(|error| format!("Failed to read upserted mapping: {error}"))
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -4,6 +4,7 @@ pub mod dashboard_commands;
 pub mod git_status_commands;
 pub mod github_commands;
 pub mod issue_commands;
+pub mod label_shape_mapping_commands;
 pub mod notification_commands;
 pub mod portfolio_commands;
 pub mod session_commands;

--- a/src-tauri/src/database/migrations.rs
+++ b/src-tauri/src/database/migrations.rs
@@ -2,12 +2,20 @@ use rusqlite::Connection;
 
 use super::schema;
 
-const CURRENT_VERSION: i32 = 7;
+const CURRENT_VERSION: i32 = 8;
 
 type MigrationFunction = fn(&Connection) -> Result<(), rusqlite::Error>;
 
-static MIGRATIONS: &[MigrationFunction] =
-    &[migrate_v1, migrate_v2, migrate_v3, migrate_v4, migrate_v5, migrate_v6, migrate_v7];
+static MIGRATIONS: &[MigrationFunction] = &[
+    migrate_v1,
+    migrate_v2,
+    migrate_v3,
+    migrate_v4,
+    migrate_v5,
+    migrate_v6,
+    migrate_v7,
+    migrate_v8,
+];
 
 fn migrate_v1(connection: &Connection) -> Result<(), rusqlite::Error> {
     schema::create_tables(connection)
@@ -247,6 +255,91 @@ fn migrate_v7(connection: &Connection) -> Result<(), rusqlite::Error> {
     )
 }
 
+pub const DEFAULT_TREE_SHAPE: &str = "cherry";
+
+fn migrate_v8(connection: &Connection) -> Result<(), rusqlite::Error> {
+    let has_labels: bool = connection
+        .prepare("SELECT labels FROM issues LIMIT 0")
+        .is_ok();
+
+    if !has_labels {
+        connection.execute_batch("ALTER TABLE issues ADD COLUMN labels TEXT;")?;
+    }
+
+    let has_default_shape: bool = connection
+        .prepare("SELECT default_shape FROM dashboards LIMIT 0")
+        .is_ok();
+
+    if !has_default_shape {
+        connection.execute_batch(
+            &format!("ALTER TABLE dashboards ADD COLUMN default_shape TEXT NOT NULL DEFAULT '{DEFAULT_TREE_SHAPE}';"),
+        )?;
+    }
+
+    connection.execute_batch(
+        "CREATE TABLE IF NOT EXISTS label_shape_mappings (
+            id TEXT PRIMARY KEY,
+            dashboard_id TEXT NOT NULL REFERENCES dashboards(id) ON DELETE CASCADE,
+            label_name TEXT NOT NULL,
+            tree_shape TEXT NOT NULL,
+            color TEXT,
+            priority_order INTEGER NOT NULL DEFAULT 0,
+            UNIQUE(dashboard_id, label_name)
+        );",
+    )?;
+
+    seed_default_label_shape_mappings(connection)?;
+
+    Ok(())
+}
+
+const DEFAULT_LABEL_SHAPE_MAPPINGS: &[(&str, &str, i32)] = &[
+    ("prd", "apple", 0),
+    ("epic", "baobab", 1),
+    ("bug", "maple", 2),
+    ("feature", "oak", 3),
+    ("task", "pine", 4),
+    ("documentation", "willow", 5),
+    ("refactor", "birch", 6),
+    ("infrastructure", "cypress", 7),
+    ("ci", "cypress", 8),
+];
+
+pub fn seed_default_label_shape_mappings(
+    connection: &Connection,
+) -> Result<(), rusqlite::Error> {
+    let mut dashboard_ids: Vec<String> = Vec::new();
+    {
+        let mut statement = connection.prepare("SELECT id FROM dashboards")?;
+        let rows = statement.query_map([], |row| row.get(0))?;
+        for row in rows {
+            dashboard_ids.push(row?);
+        }
+    }
+
+    for dashboard_id in &dashboard_ids {
+        seed_label_shape_mappings_for_dashboard(connection, dashboard_id)?;
+    }
+
+    Ok(())
+}
+
+pub fn seed_label_shape_mappings_for_dashboard(
+    connection: &Connection,
+    dashboard_id: &str,
+) -> Result<(), rusqlite::Error> {
+    for (label_name, tree_shape, priority_order) in DEFAULT_LABEL_SHAPE_MAPPINGS {
+        let id = uuid::Uuid::new_v4().to_string();
+        connection.execute(
+            "INSERT OR IGNORE INTO label_shape_mappings \
+             (id, dashboard_id, label_name, tree_shape, priority_order) \
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            rusqlite::params![id, dashboard_id, label_name, tree_shape, priority_order],
+        )?;
+    }
+    Ok(())
+}
+
 pub fn get_schema_version(connection: &Connection) -> Result<i32, rusqlite::Error> {
     let version: i32 = connection.pragma_query_value(None, "user_version", |row| row.get(0))?;
     Ok(version)
@@ -335,5 +428,153 @@ mod tests {
         run_migrations(&connection).unwrap();
         let version = get_schema_version(&connection).unwrap();
         assert_eq!(version, CURRENT_VERSION);
+    }
+
+    #[test]
+    fn migration_v8_adds_labels_column_to_issues() {
+        let connection = fresh_db();
+        run_migrations(&connection).unwrap();
+
+        // Insert a dashboard and issue with labels
+        connection
+            .execute(
+                "INSERT INTO dashboards (id, name, type) VALUES ('d1', 'Test', 'repo')",
+                [],
+            )
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO issues (id, dashboard_id, name, labels) \
+                 VALUES ('i1', 'd1', 'Test Issue', '[{\"name\":\"bug\",\"color\":\"#d73a4a\"}]')",
+                [],
+            )
+            .unwrap();
+
+        let labels: Option<String> = connection
+            .query_row("SELECT labels FROM issues WHERE id = 'i1'", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(
+            labels.unwrap(),
+            r##"[{"name":"bug","color":"#d73a4a"}]"##
+        );
+
+        // NULL labels should also work
+        connection
+            .execute(
+                "INSERT INTO issues (id, dashboard_id, name) VALUES ('i2', 'd1', 'No labels')",
+                [],
+            )
+            .unwrap();
+        let null_labels: Option<String> = connection
+            .query_row("SELECT labels FROM issues WHERE id = 'i2'", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert!(null_labels.is_none());
+    }
+
+    #[test]
+    fn migration_v8_adds_default_shape_to_dashboards() {
+        let connection = fresh_db();
+        run_migrations(&connection).unwrap();
+
+        connection
+            .execute(
+                "INSERT INTO dashboards (id, name, type) VALUES ('d1', 'Test', 'repo')",
+                [],
+            )
+            .unwrap();
+
+        let default_shape: String = connection
+            .query_row(
+                "SELECT default_shape FROM dashboards WHERE id = 'd1'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(default_shape, "cherry");
+    }
+
+    #[test]
+    fn migration_v8_creates_label_shape_mappings_table() {
+        let connection = fresh_db();
+        run_migrations(&connection).unwrap();
+
+        connection
+            .execute(
+                "INSERT INTO dashboards (id, name, type) VALUES ('d1', 'Test', 'repo')",
+                [],
+            )
+            .unwrap();
+
+        let id = uuid::Uuid::new_v4().to_string();
+        connection
+            .execute(
+                "INSERT INTO label_shape_mappings (id, dashboard_id, label_name, tree_shape, color, priority_order) \
+                 VALUES (?1, 'd1', 'bug', 'maple', '#d73a4a', 0)",
+                [&id],
+            )
+            .unwrap();
+
+        let (label_name, tree_shape, color): (String, String, Option<String>) = connection
+            .query_row(
+                "SELECT label_name, tree_shape, color FROM label_shape_mappings WHERE id = ?1",
+                [&id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(label_name, "bug");
+        assert_eq!(tree_shape, "maple");
+        assert_eq!(color.unwrap(), "#d73a4a");
+    }
+
+    #[test]
+    fn migration_v8_seeds_defaults_for_existing_dashboards() {
+        let connection = fresh_db();
+        // Create a DB at v7 first, then add a dashboard, then run v8
+        run_migrations(&connection).unwrap();
+
+        connection
+            .execute(
+                "INSERT INTO dashboards (id, name, type) VALUES ('d_existing', 'Existing', 'repo')",
+                [],
+            )
+            .unwrap();
+
+        // Manually seed (simulates what migration does for pre-existing dashboards)
+        seed_label_shape_mappings_for_dashboard(&connection, "d_existing").unwrap();
+
+        let count: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM label_shape_mappings WHERE dashboard_id = 'd_existing'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 9, "should seed 9 default label→shape mappings");
+
+        // Verify priority order
+        let (label, shape, priority): (String, String, i32) = connection
+            .query_row(
+                "SELECT label_name, tree_shape, priority_order FROM label_shape_mappings \
+                 WHERE dashboard_id = 'd_existing' ORDER BY priority_order LIMIT 1",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(label, "prd");
+        assert_eq!(shape, "apple");
+        assert_eq!(priority, 0);
+    }
+
+    #[test]
+    fn migration_v8_is_idempotent() {
+        let connection = fresh_db();
+        run_migrations(&connection).unwrap();
+
+        // Running v8 again should not fail (INSERT OR IGNORE)
+        migrate_v8(&connection).unwrap();
     }
 }

--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -20,7 +20,8 @@ pub fn create_tables(connection: &Connection) -> Result<(), rusqlite::Error> {
             local_folder TEXT,
             default_base_branch TEXT,
             worktree_parent_folder TEXT,
-            color_palette_id TEXT REFERENCES color_palettes(id)
+            color_palette_id TEXT REFERENCES color_palettes(id),
+            default_shape TEXT NOT NULL DEFAULT 'cherry'
         );
 
         CREATE TABLE IF NOT EXISTS issues (
@@ -42,6 +43,7 @@ pub fn create_tables(connection: &Connection) -> Result<(), rusqlite::Error> {
             dev_server_port INTEGER,
             dev_server_pid INTEGER,
             browser_url TEXT,
+            labels TEXT,
             sort_order INTEGER NOT NULL DEFAULT 0,
             created_at TEXT NOT NULL DEFAULT (datetime('now'))
         );
@@ -52,6 +54,16 @@ pub fn create_tables(connection: &Connection) -> Result<(), rusqlite::Error> {
             repo_dashboard_id TEXT NOT NULL REFERENCES dashboards(id) ON DELETE CASCADE,
             sort_order INTEGER NOT NULL DEFAULT 0,
             UNIQUE(portfolio_dashboard_id, repo_dashboard_id)
+        );
+
+        CREATE TABLE IF NOT EXISTS label_shape_mappings (
+            id TEXT PRIMARY KEY,
+            dashboard_id TEXT NOT NULL REFERENCES dashboards(id) ON DELETE CASCADE,
+            label_name TEXT NOT NULL,
+            tree_shape TEXT NOT NULL,
+            color TEXT,
+            priority_order INTEGER NOT NULL DEFAULT 0,
+            UNIQUE(dashboard_id, label_name)
         );
 
         CREATE TABLE IF NOT EXISTS sessions (

--- a/src-tauri/src/database/tests.rs
+++ b/src-tauri/src/database/tests.rs
@@ -22,7 +22,7 @@ mod tests {
         migrations::run_migrations(&connection).unwrap();
 
         let version = migrations::get_schema_version(&connection).unwrap();
-        assert_eq!(version, 7);
+        assert_eq!(version, 8);
     }
 
     #[test]
@@ -32,19 +32,20 @@ mod tests {
         migrations::run_migrations(&connection).unwrap();
 
         let version = migrations::get_schema_version(&connection).unwrap();
-        assert_eq!(version, 7);
+        assert_eq!(version, 8);
     }
 
     // --- Schema tests ---
 
     #[test]
-    fn all_eight_tables_are_created() {
+    fn all_nine_tables_are_created() {
         let connection = setup_test_database();
 
         let expected_tables = [
             "color_palettes",
             "dashboards",
             "issues",
+            "label_shape_mappings",
             "sessions",
             "actions",
             "notification_config",
@@ -696,7 +697,7 @@ mod tests {
         migrations::run_migrations(&connection).unwrap();
 
         let version = migrations::get_schema_version(&connection).unwrap();
-        assert_eq!(version, 7);
+        assert_eq!(version, 8);
 
         // portfolio_dashboard_pointers table exists
         let exists: bool = connection

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,7 +9,8 @@ mod session;
 
 use commands::{
     action_commands, color_palette_commands, dashboard_commands, git_status_commands,
-    github_commands, issue_commands, notification_commands, portfolio_commands, session_commands,
+    github_commands, issue_commands, label_shape_mapping_commands, notification_commands,
+    portfolio_commands, session_commands,
     worktree_commands,
 };
 use git::fetch_coordinator::FetchCoordinator;
@@ -105,6 +106,8 @@ pub fn run() {
             color_palette_commands::update_color_palette,
             color_palette_commands::delete_color_palette,
             color_palette_commands::get_next_available_color,
+            label_shape_mapping_commands::get_label_shape_mappings,
+            label_shape_mapping_commands::upsert_label_shape_mapping,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/src-tauri/src/models/dashboard.rs
+++ b/src-tauri/src/models/dashboard.rs
@@ -37,6 +37,7 @@ pub struct Dashboard {
     pub default_base_branch: Option<String>,
     pub worktree_parent_folder: Option<String>,
     pub color_palette_id: Option<String>,
+    pub default_shape: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -68,6 +69,7 @@ pub struct UpdateDashboardRequest {
     pub worktree_parent_folder: Option<Option<String>>,
     #[serde(default, deserialize_with = "deserialize_optional_nullable")]
     pub color_palette_id: Option<Option<String>>,
+    pub default_shape: Option<String>,
 }
 
 fn deserialize_optional_nullable<'de, D>(deserializer: D) -> Result<Option<Option<String>>, D::Error>

--- a/src-tauri/src/models/issue.rs
+++ b/src-tauri/src/models/issue.rs
@@ -24,6 +24,7 @@ pub struct Issue {
     pub dev_server_port: Option<i64>,
     pub dev_server_pid: Option<i64>,
     pub browser_url: Option<String>,
+    pub labels: Option<String>,
     pub sort_order: i64,
     pub created_at: String,
 }
@@ -37,6 +38,7 @@ pub struct CreateIssueRequest {
     pub github_issue_url: Option<String>,
     pub github_issue_number: Option<i64>,
     pub parent_issue_id: Option<String>,
+    pub labels: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -52,5 +54,6 @@ pub struct UpdateIssueRequest {
     pub worktree_folder: Option<Option<String>>,
     pub worktree_state: Option<String>,
     pub parent_issue_id: Option<Option<String>>,
+    pub labels: Option<Option<String>>,
     pub sort_order: Option<i64>,
 }

--- a/src-tauri/src/models/label_shape_mapping.rs
+++ b/src-tauri/src/models/label_shape_mapping.rs
@@ -1,0 +1,11 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LabelShapeMapping {
+    pub id: String,
+    pub dashboard_id: String,
+    pub label_name: String,
+    pub tree_shape: String,
+    pub color: Option<String>,
+    pub priority_order: i32,
+}

--- a/src-tauri/src/models/mod.rs
+++ b/src-tauri/src/models/mod.rs
@@ -4,6 +4,7 @@ pub mod dashboard;
 pub mod git_status;
 pub mod github;
 pub mod issue;
+pub mod label_shape_mapping;
 pub mod notification;
 pub mod portfolio;
 pub mod session;

--- a/src/lib/components/IssueCard.svelte
+++ b/src/lib/components/IssueCard.svelte
@@ -133,7 +133,22 @@
 				▸
 			</button>
 
-			<span class="min-w-0 flex-1 truncate text-sm font-medium">{issue.name}</span>
+			<div class="min-w-0 flex-1">
+				<span class="truncate text-sm font-medium">{issue.name}</span>
+				{#if issue.labels.length > 0}
+					<div class="mt-0.5 flex flex-wrap gap-1">
+						{#each issue.labels as label (label.name)}
+							<span
+								class="inline-block rounded-full px-1.5 py-px text-[10px] font-medium leading-3"
+								style="background-color: {label.color}33; color: {label.color}; border: 1px solid {label.color}44;"
+								title={label.name}
+							>
+								{label.name}
+							</span>
+						{/each}
+					</div>
+				{/if}
+			</div>
 
 			<!-- Child count for parent issues -->
 			{#if childCount > 0}

--- a/src/lib/engine/compute_tree_visualization.test.ts
+++ b/src/lib/engine/compute_tree_visualization.test.ts
@@ -11,7 +11,7 @@ import type {
 
 function createDimensions(overrides: Partial<StateDimensions> = {}): StateDimensions {
 	return {
-		labels: ['AFK'],
+		labels: ['task'],
 		worktreeState: 'none',
 		aggregateSessionState: 'no-session',
 		executionPhase: 'none',

--- a/src/lib/engine/compute_tree_visualization.ts
+++ b/src/lib/engine/compute_tree_visualization.ts
@@ -1,4 +1,10 @@
-import type { TreeStage, PottedPlantStage, TreeConfig, ToolVisibility } from 'low-poly-2d-trees';
+import type {
+	TreeShape,
+	TreeStage,
+	PottedPlantStage,
+	TreeConfig,
+	ToolVisibility,
+} from 'low-poly-2d-trees';
 import {
 	TREE_STAGES,
 	DEFAULT_TREE_CONFIG,
@@ -10,6 +16,7 @@ import {
 	resolveTreeShape,
 } from '$lib/types/tree_visualization';
 import type {
+	LabelShapeMappingEntry,
 	StateDimensions,
 	TreeComputeContext,
 	TreeVisualization,
@@ -145,6 +152,8 @@ function issueIdToSeed(issueId: string): number {
 export function computeTreeVisualization(
 	dimensions: StateDimensions,
 	context?: TreeComputeContext,
+	labelMappings?: readonly LabelShapeMappingEntry[],
+	defaultShape?: TreeShape,
 ): TreeVisualization {
 	const resolvedContext = context ?? DEFAULT_COMPUTE_CONTEXT;
 	const seed = issueIdToSeed(resolvedContext.issueId);
@@ -168,7 +177,7 @@ export function computeTreeVisualization(
 	}
 
 	const stage = computeTreeStage(dimensions, resolvedContext);
-	const shape = resolveTreeShape(dimensions.labels);
+	const shape = resolveTreeShape(dimensions.labels, labelMappings, defaultShape);
 	const toolVisibility = computeToolVisibility(dimensions);
 
 	const fruitType =

--- a/src/lib/engine/map_issue_to_state_dimensions.test.ts
+++ b/src/lib/engine/map_issue_to_state_dimensions.test.ts
@@ -24,6 +24,7 @@ function createIssue(overrides: Partial<Issue> = {}): Issue {
 		dev_server_port: null,
 		dev_server_pid: null,
 		browser_url: null,
+		labels: [],
 		sort_order: 0,
 		created_at: '2026-01-01T00:00:00Z',
 		...overrides,
@@ -355,8 +356,31 @@ describe('mapIssueToStateDimensions — grovekeeperStatus', () => {
 // ─── labels ─────────────────────────────────────────────────────────────
 
 describe('mapIssueToStateDimensions — labels', () => {
-	it('stubs labels as ["AFK"] (Issue has no labels field yet)', () => {
+	it('returns empty labels for issue with no labels', () => {
 		const dimensions = mapIssueToStateDimensions(createIssue(), undefined, []);
-		expect(dimensions.labels).toEqual(['AFK']);
+		expect(dimensions.labels).toEqual([]);
+	});
+
+	it('extracts label names from issue labels', () => {
+		const dimensions = mapIssueToStateDimensions(
+			createIssue({
+				labels: [
+					{ name: 'bug', color: '#d73a4a' },
+					{ name: 'task', color: '#0E8A16' },
+				],
+			}),
+			undefined,
+			[],
+		);
+		expect(dimensions.labels).toEqual(['bug', 'task']);
+	});
+
+	it('handles single label', () => {
+		const dimensions = mapIssueToStateDimensions(
+			createIssue({ labels: [{ name: 'feature', color: '#a2eeef' }] }),
+			undefined,
+			[],
+		);
+		expect(dimensions.labels).toEqual(['feature']);
 	});
 });

--- a/src/lib/engine/map_issue_to_state_dimensions.ts
+++ b/src/lib/engine/map_issue_to_state_dimensions.ts
@@ -73,7 +73,7 @@ export function mapIssueToStateDimensions(
 	sessions: readonly SessionForMapping[],
 ): StateDimensions {
 	return {
-		labels: ['AFK'],
+		labels: issue.labels.map((label) => label.name),
 		worktreeState: issue.worktree_state,
 		aggregateSessionState: aggregateSessionState(sessions.map((session) => session.state)),
 		executionPhase: pickExecutionPhase(sessions),

--- a/src/lib/tauri/issue_commands.ts
+++ b/src/lib/tauri/issue_commands.ts
@@ -1,27 +1,54 @@
 import { invoke } from '@tauri-apps/api/core';
-import type { CreateIssueRequest, Issue, UpdateIssueRequest } from '$lib/types/issue';
+import type { CreateIssueRequest, Issue, IssueLabel, UpdateIssueRequest } from '$lib/types/issue';
+
+interface RawIssue extends Omit<Issue, 'labels'> {
+	labels: string | null;
+}
+
+function deserializeLabels(raw: string | null): IssueLabel[] {
+	if (raw === null) {
+		return [];
+	}
+	try {
+		const parsed: unknown = JSON.parse(raw);
+		if (!Array.isArray(parsed)) {
+			return [];
+		}
+		return parsed as IssueLabel[];
+	} catch {
+		return [];
+	}
+}
+
+function toIssue(raw: RawIssue): Issue {
+	return { ...raw, labels: deserializeLabels(raw.labels) };
+}
 
 export async function createIssue(request: CreateIssueRequest): Promise<Issue> {
-	return invoke('create_issue', { request });
+	const raw = await invoke<RawIssue>('create_issue', { request });
+	return toIssue(raw);
 }
 
 export async function getIssuesForDashboard(
 	dashboardId: string,
 	includeArchived: boolean = false,
 ): Promise<Issue[]> {
-	return invoke('get_issues_for_dashboard', {
+	const rawIssues = await invoke<RawIssue[]>('get_issues_for_dashboard', {
 		dashboardId,
 		includeArchived,
 	});
+	return rawIssues.map(toIssue);
 }
 
 // fallow-ignore-next-line unused-export
 export async function getIssue(id: string): Promise<Issue> {
-	return invoke('get_issue', { id });
+	const raw = await invoke<RawIssue>('get_issue', { id });
+	return toIssue(raw);
 }
 
 export async function updateIssue(request: UpdateIssueRequest): Promise<Issue> {
-	return invoke('update_issue', { request });
+	const raw = await invoke<RawIssue>('update_issue', { request });
+	return toIssue(raw);
 }
 
 export async function deleteIssue(id: string): Promise<void> {
@@ -29,9 +56,11 @@ export async function deleteIssue(id: string): Promise<void> {
 }
 
 export async function archiveIssue(id: string): Promise<Issue> {
-	return invoke('archive_issue', { id });
+	const raw = await invoke<RawIssue>('archive_issue', { id });
+	return toIssue(raw);
 }
 
 export async function unarchiveIssue(id: string): Promise<Issue> {
-	return invoke('unarchive_issue', { id });
+	const raw = await invoke<RawIssue>('unarchive_issue', { id });
+	return toIssue(raw);
 }

--- a/src/lib/tauri/label_shape_mapping_commands.ts
+++ b/src/lib/tauri/label_shape_mapping_commands.ts
@@ -1,0 +1,22 @@
+import { invoke } from '@tauri-apps/api/core';
+import type { LabelShapeMapping } from '$lib/types/label_shape_mapping';
+
+export async function getLabelShapeMappings(dashboardId: string): Promise<LabelShapeMapping[]> {
+	return invoke('get_label_shape_mappings', { dashboardId });
+}
+
+export async function upsertLabelShapeMapping(
+	dashboardId: string,
+	labelName: string,
+	treeShape: string,
+	color: string | null,
+	priorityOrder: number,
+): Promise<LabelShapeMapping> {
+	return invoke('upsert_label_shape_mapping', {
+		dashboardId,
+		labelName,
+		treeShape,
+		color,
+		priorityOrder,
+	});
+}

--- a/src/lib/types/dashboard.ts
+++ b/src/lib/types/dashboard.ts
@@ -7,6 +7,7 @@ export interface Dashboard {
 	default_base_branch: string | null;
 	worktree_parent_folder: string | null;
 	color_palette_id: string | null;
+	default_shape: string;
 }
 
 export interface CreateDashboardRequest {
@@ -17,8 +18,8 @@ export interface CreateDashboardRequest {
 	default_base_branch?: string | null;
 	worktree_parent_folder?: string | null;
 	color_palette_id?: string | null;
+	default_shape?: string;
 }
-
 /** Absent key = no change, explicit null = clear the field */
 export interface UpdateDashboardRequest {
 	id: string;
@@ -29,4 +30,5 @@ export interface UpdateDashboardRequest {
 	default_base_branch?: string | null;
 	worktree_parent_folder?: string | null;
 	color_palette_id?: string | null;
+	default_shape?: string;
 }

--- a/src/lib/types/issue.ts
+++ b/src/lib/types/issue.ts
@@ -1,5 +1,10 @@
 import type { WorktreeState } from './worktree';
 
+export interface IssueLabel {
+	name: string;
+	color: string;
+}
+
 export interface Issue {
 	id: string;
 	dashboard_id: string;
@@ -19,6 +24,7 @@ export interface Issue {
 	dev_server_port: number | null;
 	dev_server_pid: number | null;
 	browser_url: string | null;
+	labels: IssueLabel[];
 	sort_order: number;
 	created_at: string;
 }
@@ -31,6 +37,7 @@ export interface CreateIssueRequest {
 	github_issue_url?: string | null;
 	github_issue_number?: number | null;
 	parent_issue_id?: string | null;
+	labels?: string | null;
 }
 
 export interface UpdateIssueRequest {
@@ -45,5 +52,6 @@ export interface UpdateIssueRequest {
 	worktree_folder?: string | null;
 	worktree_state?: WorktreeState;
 	parent_issue_id?: string | null;
+	labels?: string | null;
 	sort_order?: number;
 }

--- a/src/lib/types/label_shape_mapping.ts
+++ b/src/lib/types/label_shape_mapping.ts
@@ -1,0 +1,9 @@
+// fallow-ignore-next-line unused-types
+export interface LabelShapeMapping {
+	id: string;
+	dashboard_id: string;
+	label_name: string;
+	tree_shape: string;
+	color: string | null;
+	priority_order: number;
+}

--- a/src/lib/types/tree_visualization.ts
+++ b/src/lib/types/tree_visualization.ts
@@ -81,39 +81,36 @@ export const SHAPE_FRUIT_MAP: Readonly<Record<Exclude<TreeShape, 'custom'>, Frui
 
 // ─── GitHub Label → Tree Shape Mapping ───────────────────────────────────
 
-const LABEL_TO_SHAPE: Readonly<Record<string, TreeShape>> = {
-	bug: TREE_SHAPES.maple,
-	task: TREE_SHAPES.pine,
-	feature: TREE_SHAPES.oak,
-	prd: TREE_SHAPES.apple,
-	epic: TREE_SHAPES.baobab,
-	documentation: TREE_SHAPES.willow,
-	refactor: TREE_SHAPES.birch,
-	infrastructure: TREE_SHAPES.cypress,
-	ci: TREE_SHAPES.cypress,
-} as const;
+export interface LabelShapeMappingEntry {
+	readonly labelName: string;
+	readonly treeShape: TreeShape;
+}
 
-const LABEL_PRIORITY: readonly string[] = [
-	'prd',
-	'epic',
-	'bug',
-	'feature',
-	'task',
-	'documentation',
-	'refactor',
-	'infrastructure',
-	'ci',
+const DEFAULT_LABEL_MAPPINGS: readonly LabelShapeMappingEntry[] = [
+	{ labelName: 'prd', treeShape: TREE_SHAPES.apple },
+	{ labelName: 'epic', treeShape: TREE_SHAPES.baobab },
+	{ labelName: 'bug', treeShape: TREE_SHAPES.maple },
+	{ labelName: 'feature', treeShape: TREE_SHAPES.oak },
+	{ labelName: 'task', treeShape: TREE_SHAPES.pine },
+	{ labelName: 'documentation', treeShape: TREE_SHAPES.willow },
+	{ labelName: 'refactor', treeShape: TREE_SHAPES.birch },
+	{ labelName: 'infrastructure', treeShape: TREE_SHAPES.cypress },
+	{ labelName: 'ci', treeShape: TREE_SHAPES.cypress },
 ];
 
 const DEFAULT_TREE_SHAPE: TreeShape = TREE_SHAPES.cherry;
 
-export function resolveTreeShape(labels: readonly string[]): TreeShape {
-	for (const prioritized of LABEL_PRIORITY) {
-		if (labels.some((label) => label.toLowerCase() === prioritized)) {
-			return LABEL_TO_SHAPE[prioritized];
+export function resolveTreeShape(
+	labels: readonly string[],
+	mappings: readonly LabelShapeMappingEntry[] = DEFAULT_LABEL_MAPPINGS,
+	defaultShape: TreeShape = DEFAULT_TREE_SHAPE,
+): TreeShape {
+	for (const mapping of mappings) {
+		if (labels.some((label) => label.toLowerCase() === mapping.labelName.toLowerCase())) {
+			return mapping.treeShape;
 		}
 	}
-	return DEFAULT_TREE_SHAPE;
+	return defaultShape;
 }
 
 // ─── Tool Visibility Factory ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Add migration v8 with `labels TEXT` column on issues, `default_shape TEXT` on dashboards, and `label_shape_mappings` table for dashboard-scoped priority-ordered label→shape configuration
- Extend GitHub GraphQL sync to fetch label name+color per issue, store as JSON array, and display as colored pills on IssueCard
- Replace hardcoded `['AFK']` stub with real issue labels in the visualization engine; make `resolveTreeShape` accept configurable mappings with fallback defaults

## Changes

**Backend (Rust):**
- Migration v8: `labels TEXT` on issues, `default_shape TEXT DEFAULT 'cherry'` on dashboards, `label_shape_mappings` table
- Extended `build_bulk_sync_graphql_query` with `labels(first: 20) { nodes { name color } }`
- `sync_all_github_state` parses + stores label JSON on issues
- `LabelShapeMapping` model + `get`/`upsert` Tauri commands
- 9 default mappings seeded for new and existing dashboards
- `DEFAULT_TREE_SHAPE` constant, `parse_label_nodes_to_json` helper

**Frontend (TypeScript/Svelte):**
- `IssueLabel` type (`{name, color}`), added to `Issue` interface
- Tauri deserialization layer: `NULL` → `[]`, JSON string → `IssueLabel[]`
- `mapIssueToStateDimensions` reads real `issue.labels` (no more hardcode)
- `resolveTreeShape` accepts optional `LabelShapeMappingEntry[]` + `defaultShape`
- `computeTreeVisualization` passes mappings through
- `IssueCard.svelte` renders label pills with GitHub colors
- `Dashboard` type gains `default_shape` field
- `LabelShapeMapping` type + Tauri command wrappers

## Test plan

- [x] 177 Rust tests pass (8 new migration tests, 2 new GraphQL label parsing tests)
- [x] 120 TypeScript tests pass (updated label tests in mapIssueToStateDimensions + compute_tree_visualization)
- [x] prettier, oxlint, eslint, stylelint, svelte-check all clean
- [ ] CI green

## Known gaps (deferred to companion issues)

- `ForestView` doesn't load DB mappings yet (uses identical hardcoded defaults — functionally correct; wiring needed when mapping settings UI ships)
- Label-to-shape mapping settings UI (out of scope per issue)
- Bidirectional label sync (out of scope per issue)

Fixes #71