### PR TITLE
#97 feat: design token pipeline with OKLCH theme

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -6,7 +6,7 @@
 		"**/*.stories.svelte",
 		"src/lib/reactivity/*.svelte.ts"
 	],
-	"ignorePatterns": ["src/lib/types/generated/**"],
+	"ignorePatterns": ["src/lib/types/generated/**", "claude_design/**"],
 	"ignoreDependencies": [
 		"@typescript-eslint/parser",
 		"vitest-browser-svelte",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 		"@tauri-apps/plugin-opener": "^2",
 		"bits-ui": "^2.16.5",
 		"clsx": "^2.1.1",
+		"geist": "^1.7.0",
 		"low-poly-2d-trees": "link:..\\low-poly-2d-trees",
 		"lucide-svelte": "^1.0.1",
 		"tailwind-merge": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -27,11 +27,12 @@
 		"build:storybook": "svelte-kit sync && storybook build"
 	},
 	"dependencies": {
+		"@fontsource/geist": "^5.2.8",
+		"@fontsource/geist-mono": "^5.2.7",
 		"@tauri-apps/api": "^2",
 		"@tauri-apps/plugin-opener": "^2",
 		"bits-ui": "^2.16.5",
 		"clsx": "^2.1.1",
-		"geist": "^1.7.0",
 		"low-poly-2d-trees": "link:..\\low-poly-2d-trees",
 		"lucide-svelte": "^1.0.1",
 		"tailwind-merge": "^3.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,12 @@ settings:
 importers:
     .:
         dependencies:
+            '@fontsource/geist':
+                specifier: ^5.2.8
+                version: 5.2.8
+            '@fontsource/geist-mono':
+                specifier: ^5.2.7
+                version: 5.2.7
             '@tauri-apps/api':
                 specifier: ^2
                 version: 2.10.1
@@ -19,9 +25,6 @@ importers:
             clsx:
                 specifier: ^2.1.1
                 version: 2.1.1
-            geist:
-                specifier: ^1.7.0
-                version: 1.7.0(next@16.2.4(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
             low-poly-2d-trees:
                 specifier: link:..\low-poly-2d-trees
                 version: link:../low-poly-2d-trees
@@ -320,12 +323,6 @@ packages:
         engines: { node: '>=20.19.0' }
         peerDependencies:
             postcss-selector-parser: ^7.1.1
-
-    '@emnapi/runtime@1.10.0':
-        resolution:
-            {
-                integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==,
-            }
 
     '@esbuild/aix-ppc64@0.25.12':
         resolution:
@@ -928,6 +925,18 @@ packages:
                 integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==,
             }
 
+    '@fontsource/geist-mono@5.2.7':
+        resolution:
+            {
+                integrity: sha512-xVPVFISJg/K0VVd+aQN0Y7X/sw9hUcJPyDWFJ5GpyU3bHELhoRsJkPSRSHXW32mOi0xZCUQDOaPj1sqIFJ1FGg==,
+            }
+
+    '@fontsource/geist@5.2.8':
+        resolution:
+            {
+                integrity: sha512-pI54klK6vz8fVpAVyV+iODGLEzw73cs1XJqV9PIXgW8MYMmBcwK6lKKaWqJrNHwEx8ppz9cuhussb6arXQ/PVQ==,
+            }
+
     '@humanfs/core@0.19.1':
         resolution:
             {
@@ -955,218 +964,6 @@ packages:
                 integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==,
             }
         engines: { node: '>=18.18' }
-
-    '@img/colour@1.1.0':
-        resolution:
-            {
-                integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==,
-            }
-        engines: { node: '>=18' }
-
-    '@img/sharp-darwin-arm64@0.34.5':
-        resolution:
-            {
-                integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==,
-            }
-        engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-        cpu: [arm64]
-        os: [darwin]
-
-    '@img/sharp-darwin-x64@0.34.5':
-        resolution:
-            {
-                integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==,
-            }
-        engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-        cpu: [x64]
-        os: [darwin]
-
-    '@img/sharp-libvips-darwin-arm64@1.2.4':
-        resolution:
-            {
-                integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==,
-            }
-        cpu: [arm64]
-        os: [darwin]
-
-    '@img/sharp-libvips-darwin-x64@1.2.4':
-        resolution:
-            {
-                integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==,
-            }
-        cpu: [x64]
-        os: [darwin]
-
-    '@img/sharp-libvips-linux-arm64@1.2.4':
-        resolution:
-            {
-                integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==,
-            }
-        cpu: [arm64]
-        os: [linux]
-
-    '@img/sharp-libvips-linux-arm@1.2.4':
-        resolution:
-            {
-                integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==,
-            }
-        cpu: [arm]
-        os: [linux]
-
-    '@img/sharp-libvips-linux-ppc64@1.2.4':
-        resolution:
-            {
-                integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==,
-            }
-        cpu: [ppc64]
-        os: [linux]
-
-    '@img/sharp-libvips-linux-riscv64@1.2.4':
-        resolution:
-            {
-                integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==,
-            }
-        cpu: [riscv64]
-        os: [linux]
-
-    '@img/sharp-libvips-linux-s390x@1.2.4':
-        resolution:
-            {
-                integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==,
-            }
-        cpu: [s390x]
-        os: [linux]
-
-    '@img/sharp-libvips-linux-x64@1.2.4':
-        resolution:
-            {
-                integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==,
-            }
-        cpu: [x64]
-        os: [linux]
-
-    '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
-        resolution:
-            {
-                integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==,
-            }
-        cpu: [arm64]
-        os: [linux]
-
-    '@img/sharp-libvips-linuxmusl-x64@1.2.4':
-        resolution:
-            {
-                integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==,
-            }
-        cpu: [x64]
-        os: [linux]
-
-    '@img/sharp-linux-arm64@0.34.5':
-        resolution:
-            {
-                integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==,
-            }
-        engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-        cpu: [arm64]
-        os: [linux]
-
-    '@img/sharp-linux-arm@0.34.5':
-        resolution:
-            {
-                integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==,
-            }
-        engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-        cpu: [arm]
-        os: [linux]
-
-    '@img/sharp-linux-ppc64@0.34.5':
-        resolution:
-            {
-                integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==,
-            }
-        engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-        cpu: [ppc64]
-        os: [linux]
-
-    '@img/sharp-linux-riscv64@0.34.5':
-        resolution:
-            {
-                integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==,
-            }
-        engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-        cpu: [riscv64]
-        os: [linux]
-
-    '@img/sharp-linux-s390x@0.34.5':
-        resolution:
-            {
-                integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==,
-            }
-        engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-        cpu: [s390x]
-        os: [linux]
-
-    '@img/sharp-linux-x64@0.34.5':
-        resolution:
-            {
-                integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==,
-            }
-        engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-        cpu: [x64]
-        os: [linux]
-
-    '@img/sharp-linuxmusl-arm64@0.34.5':
-        resolution:
-            {
-                integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==,
-            }
-        engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-        cpu: [arm64]
-        os: [linux]
-
-    '@img/sharp-linuxmusl-x64@0.34.5':
-        resolution:
-            {
-                integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==,
-            }
-        engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-        cpu: [x64]
-        os: [linux]
-
-    '@img/sharp-wasm32@0.34.5':
-        resolution:
-            {
-                integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==,
-            }
-        engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-        cpu: [wasm32]
-
-    '@img/sharp-win32-arm64@0.34.5':
-        resolution:
-            {
-                integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==,
-            }
-        engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-        cpu: [arm64]
-        os: [win32]
-
-    '@img/sharp-win32-ia32@0.34.5':
-        resolution:
-            {
-                integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==,
-            }
-        engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-        cpu: [ia32]
-        os: [win32]
-
-    '@img/sharp-win32-x64@0.34.5':
-        resolution:
-            {
-                integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==,
-            }
-        engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-        cpu: [x64]
-        os: [win32]
 
     '@internationalized/date@3.12.0':
         resolution:
@@ -1234,84 +1031,6 @@ packages:
             {
                 integrity: sha512-klcSooChXXOzIm+SE5IISIAn3bYzYfPjbX7D7HoqZL84oAfgREeSg5vSIaSFH+DaGzzvImTyWe1OyrJ67vik4A==,
             }
-
-    '@next/env@16.2.4':
-        resolution:
-            {
-                integrity: sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==,
-            }
-
-    '@next/swc-darwin-arm64@16.2.4':
-        resolution:
-            {
-                integrity: sha512-OXTFFox5EKN1Ym08vfrz+OXxmCcEjT4SFMbNRsWZE99dMqt2Kcusl5MqPXcW232RYkMLQTy0hqgAMEsfEd/l2A==,
-            }
-        engines: { node: '>= 10' }
-        cpu: [arm64]
-        os: [darwin]
-
-    '@next/swc-darwin-x64@16.2.4':
-        resolution:
-            {
-                integrity: sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ==,
-            }
-        engines: { node: '>= 10' }
-        cpu: [x64]
-        os: [darwin]
-
-    '@next/swc-linux-arm64-gnu@16.2.4':
-        resolution:
-            {
-                integrity: sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ==,
-            }
-        engines: { node: '>= 10' }
-        cpu: [arm64]
-        os: [linux]
-
-    '@next/swc-linux-arm64-musl@16.2.4':
-        resolution:
-            {
-                integrity: sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==,
-            }
-        engines: { node: '>= 10' }
-        cpu: [arm64]
-        os: [linux]
-
-    '@next/swc-linux-x64-gnu@16.2.4':
-        resolution:
-            {
-                integrity: sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==,
-            }
-        engines: { node: '>= 10' }
-        cpu: [x64]
-        os: [linux]
-
-    '@next/swc-linux-x64-musl@16.2.4':
-        resolution:
-            {
-                integrity: sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==,
-            }
-        engines: { node: '>= 10' }
-        cpu: [x64]
-        os: [linux]
-
-    '@next/swc-win32-arm64-msvc@16.2.4':
-        resolution:
-            {
-                integrity: sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==,
-            }
-        engines: { node: '>= 10' }
-        cpu: [arm64]
-        os: [win32]
-
-    '@next/swc-win32-x64-msvc@16.2.4':
-        resolution:
-            {
-                integrity: sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw==,
-            }
-        engines: { node: '>= 10' }
-        cpu: [x64]
-        os: [win32]
 
     '@nodelib/fs.scandir@2.1.5':
         resolution:
@@ -1927,12 +1646,6 @@ packages:
         peerDependencies:
             svelte: ^5.0.0
             vite: ^6.3.0 || ^7.0.0
-
-    '@swc/helpers@0.5.15':
-        resolution:
-            {
-                integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==,
-            }
 
     '@swc/helpers@0.5.21':
         resolution:
@@ -2621,14 +2334,6 @@ packages:
             }
         engines: { node: 18 || 20 || >=22 }
 
-    baseline-browser-mapping@2.10.24:
-        resolution:
-            {
-                integrity: sha512-I2NkZOOrj2XuguvWCK6OVh9GavsNjZjK908Rq3mIBK25+GD8vPX5w2WdxVqnQ7xx3SrZJiCiZFu+/Oz50oSYSA==,
-            }
-        engines: { node: '>=6.0.0' }
-        hasBin: true
-
     bits-ui@2.16.5:
         resolution:
             {
@@ -2672,12 +2377,6 @@ packages:
                 integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==,
             }
         engines: { node: '>=6' }
-
-    caniuse-lite@1.0.30001791:
-        resolution:
-            {
-                integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==,
-            }
 
     chai@5.3.3:
         resolution:
@@ -2735,12 +2434,6 @@ packages:
                 integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==,
             }
         engines: { node: '>=20' }
-
-    client-only@0.0.1:
-        resolution:
-            {
-                integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==,
-            }
 
     clsx@2.1.1:
         resolution:
@@ -3359,14 +3052,6 @@ packages:
             }
         engines: { node: ^8.16.0 || ^10.6.0 || >=11.0.0 }
         os: [darwin]
-
-    geist@1.7.0:
-        resolution:
-            {
-                integrity: sha512-ZaoiZwkSf0DwwB1ncdLKp+ggAldqxl5L1+SXaNIBGkPAqcu+xjVJLxlf3/S8vLt9UHx1xu5fz3lbzKCj5iOVdQ==,
-            }
-        peerDependencies:
-            next: '>=13.2.0'
 
     get-east-asian-width@1.5.0:
         resolution:
@@ -4055,30 +3740,6 @@ packages:
                 integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==,
             }
 
-    next@16.2.4:
-        resolution:
-            {
-                integrity: sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==,
-            }
-        engines: { node: '>=20.9.0' }
-        hasBin: true
-        peerDependencies:
-            '@opentelemetry/api': ^1.1.0
-            '@playwright/test': ^1.51.1
-            babel-plugin-react-compiler: '*'
-            react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
-            react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
-            sass: ^1.3.0
-        peerDependenciesMeta:
-            '@opentelemetry/api':
-                optional: true
-            '@playwright/test':
-                optional: true
-            babel-plugin-react-compiler:
-                optional: true
-            sass:
-                optional: true
-
     normalize-path@3.0.0:
         resolution:
             {
@@ -4286,13 +3947,6 @@ packages:
                 integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==,
             }
 
-    postcss@8.4.31:
-        resolution:
-            {
-                integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==,
-            }
-        engines: { node: ^10 || ^12 || >=14 }
-
     postcss@8.5.8:
         resolution:
             {
@@ -4493,13 +4147,6 @@ packages:
                 integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==,
             }
 
-    sharp@0.34.5:
-        resolution:
-            {
-                integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==,
-            }
-        engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-
     shebang-command@2.0.0:
         resolution:
             {
@@ -4654,22 +4301,6 @@ packages:
             {
                 integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==,
             }
-
-    styled-jsx@5.1.6:
-        resolution:
-            {
-                integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==,
-            }
-        engines: { node: '>= 12.0.0' }
-        peerDependencies:
-            '@babel/core': '*'
-            babel-plugin-macros: '*'
-            react: '>= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0'
-        peerDependenciesMeta:
-            '@babel/core':
-                optional: true
-            babel-plugin-macros:
-                optional: true
 
     stylelint-config-html@1.1.0:
         resolution:
@@ -5300,11 +4931,6 @@ snapshots:
         dependencies:
             postcss-selector-parser: 7.1.1
 
-    '@emnapi/runtime@1.10.0':
-        dependencies:
-            tslib: 2.8.1
-        optional: true
-
     '@esbuild/aix-ppc64@0.25.12':
         optional: true
 
@@ -5526,6 +5152,10 @@ snapshots:
 
     '@floating-ui/utils@0.2.11': {}
 
+    '@fontsource/geist-mono@5.2.7': {}
+
+    '@fontsource/geist@5.2.8': {}
+
     '@humanfs/core@0.19.1': {}
 
     '@humanfs/node@0.16.7':
@@ -5536,103 +5166,6 @@ snapshots:
     '@humanwhocodes/module-importer@1.0.1': {}
 
     '@humanwhocodes/retry@0.4.3': {}
-
-    '@img/colour@1.1.0':
-        optional: true
-
-    '@img/sharp-darwin-arm64@0.34.5':
-        optionalDependencies:
-            '@img/sharp-libvips-darwin-arm64': 1.2.4
-        optional: true
-
-    '@img/sharp-darwin-x64@0.34.5':
-        optionalDependencies:
-            '@img/sharp-libvips-darwin-x64': 1.2.4
-        optional: true
-
-    '@img/sharp-libvips-darwin-arm64@1.2.4':
-        optional: true
-
-    '@img/sharp-libvips-darwin-x64@1.2.4':
-        optional: true
-
-    '@img/sharp-libvips-linux-arm64@1.2.4':
-        optional: true
-
-    '@img/sharp-libvips-linux-arm@1.2.4':
-        optional: true
-
-    '@img/sharp-libvips-linux-ppc64@1.2.4':
-        optional: true
-
-    '@img/sharp-libvips-linux-riscv64@1.2.4':
-        optional: true
-
-    '@img/sharp-libvips-linux-s390x@1.2.4':
-        optional: true
-
-    '@img/sharp-libvips-linux-x64@1.2.4':
-        optional: true
-
-    '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
-        optional: true
-
-    '@img/sharp-libvips-linuxmusl-x64@1.2.4':
-        optional: true
-
-    '@img/sharp-linux-arm64@0.34.5':
-        optionalDependencies:
-            '@img/sharp-libvips-linux-arm64': 1.2.4
-        optional: true
-
-    '@img/sharp-linux-arm@0.34.5':
-        optionalDependencies:
-            '@img/sharp-libvips-linux-arm': 1.2.4
-        optional: true
-
-    '@img/sharp-linux-ppc64@0.34.5':
-        optionalDependencies:
-            '@img/sharp-libvips-linux-ppc64': 1.2.4
-        optional: true
-
-    '@img/sharp-linux-riscv64@0.34.5':
-        optionalDependencies:
-            '@img/sharp-libvips-linux-riscv64': 1.2.4
-        optional: true
-
-    '@img/sharp-linux-s390x@0.34.5':
-        optionalDependencies:
-            '@img/sharp-libvips-linux-s390x': 1.2.4
-        optional: true
-
-    '@img/sharp-linux-x64@0.34.5':
-        optionalDependencies:
-            '@img/sharp-libvips-linux-x64': 1.2.4
-        optional: true
-
-    '@img/sharp-linuxmusl-arm64@0.34.5':
-        optionalDependencies:
-            '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
-        optional: true
-
-    '@img/sharp-linuxmusl-x64@0.34.5':
-        optionalDependencies:
-            '@img/sharp-libvips-linuxmusl-x64': 1.2.4
-        optional: true
-
-    '@img/sharp-wasm32@0.34.5':
-        dependencies:
-            '@emnapi/runtime': 1.10.0
-        optional: true
-
-    '@img/sharp-win32-arm64@0.34.5':
-        optional: true
-
-    '@img/sharp-win32-ia32@0.34.5':
-        optional: true
-
-    '@img/sharp-win32-x64@0.34.5':
-        optional: true
 
     '@internationalized/date@3.12.0':
         dependencies:
@@ -5672,32 +5205,6 @@ snapshots:
             react: 19.2.4
 
     '@neoconfetti/react@1.0.0': {}
-
-    '@next/env@16.2.4': {}
-
-    '@next/swc-darwin-arm64@16.2.4':
-        optional: true
-
-    '@next/swc-darwin-x64@16.2.4':
-        optional: true
-
-    '@next/swc-linux-arm64-gnu@16.2.4':
-        optional: true
-
-    '@next/swc-linux-arm64-musl@16.2.4':
-        optional: true
-
-    '@next/swc-linux-x64-gnu@16.2.4':
-        optional: true
-
-    '@next/swc-linux-x64-musl@16.2.4':
-        optional: true
-
-    '@next/swc-win32-arm64-msvc@16.2.4':
-        optional: true
-
-    '@next/swc-win32-x64-msvc@16.2.4':
-        optional: true
 
     '@nodelib/fs.scandir@2.1.5':
         dependencies:
@@ -6025,10 +5532,6 @@ snapshots:
             svelte: 5.55.0
             vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
             vitefu: 1.1.2(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))
-
-    '@swc/helpers@0.5.15':
-        dependencies:
-            tslib: 2.8.1
 
     '@swc/helpers@0.5.21':
         dependencies:
@@ -6476,8 +5979,6 @@ snapshots:
 
     balanced-match@4.0.4: {}
 
-    baseline-browser-mapping@2.10.24: {}
-
     bits-ui@2.16.5(@internationalized/date@3.12.0)(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)))(svelte@5.55.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)))(svelte@5.55.0):
         dependencies:
             '@floating-ui/core': 1.7.5
@@ -6513,8 +6014,6 @@ snapshots:
 
     callsites@3.1.0: {}
 
-    caniuse-lite@1.0.30001791: {}
-
     chai@5.3.3:
         dependencies:
             assertion-error: 2.0.1
@@ -6541,8 +6040,6 @@ snapshots:
         dependencies:
             slice-ansi: 8.0.0
             string-width: 8.2.0
-
-    client-only@0.0.1: {}
 
     clsx@2.1.1: {}
 
@@ -6939,10 +6436,6 @@ snapshots:
     fsevents@2.3.3:
         optional: true
 
-    geist@1.7.0(next@16.2.4(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)):
-        dependencies:
-            next: 16.2.4(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-
     get-east-asian-width@1.5.0: {}
 
     glob-parent@5.1.2:
@@ -7260,31 +6753,6 @@ snapshots:
 
     natural-compare@1.4.0: {}
 
-    next@16.2.4(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
-        dependencies:
-            '@next/env': 16.2.4
-            '@swc/helpers': 0.5.15
-            baseline-browser-mapping: 2.10.24
-            caniuse-lite: 1.0.30001791
-            postcss: 8.4.31
-            react: 19.2.4
-            react-dom: 19.2.4(react@19.2.4)
-            styled-jsx: 5.1.6(react@19.2.4)
-        optionalDependencies:
-            '@next/swc-darwin-arm64': 16.2.4
-            '@next/swc-darwin-x64': 16.2.4
-            '@next/swc-linux-arm64-gnu': 16.2.4
-            '@next/swc-linux-arm64-musl': 16.2.4
-            '@next/swc-linux-x64-gnu': 16.2.4
-            '@next/swc-linux-x64-musl': 16.2.4
-            '@next/swc-win32-arm64-msvc': 16.2.4
-            '@next/swc-win32-x64-msvc': 16.2.4
-            '@playwright/test': 1.58.2
-            sharp: 0.34.5
-        transitivePeerDependencies:
-            - '@babel/core'
-            - babel-plugin-macros
-
     normalize-path@3.0.0: {}
 
     obug@2.1.1: {}
@@ -7406,12 +6874,6 @@ snapshots:
             util-deprecate: 1.0.2
 
     postcss-value-parser@4.2.0: {}
-
-    postcss@8.4.31:
-        dependencies:
-            nanoid: 3.3.11
-            picocolors: 1.1.1
-            source-map-js: 1.2.1
 
     postcss@8.5.8:
         dependencies:
@@ -7537,38 +6999,6 @@ snapshots:
 
     set-cookie-parser@3.1.0: {}
 
-    sharp@0.34.5:
-        dependencies:
-            '@img/colour': 1.1.0
-            detect-libc: 2.1.2
-            semver: 7.7.4
-        optionalDependencies:
-            '@img/sharp-darwin-arm64': 0.34.5
-            '@img/sharp-darwin-x64': 0.34.5
-            '@img/sharp-libvips-darwin-arm64': 1.2.4
-            '@img/sharp-libvips-darwin-x64': 1.2.4
-            '@img/sharp-libvips-linux-arm': 1.2.4
-            '@img/sharp-libvips-linux-arm64': 1.2.4
-            '@img/sharp-libvips-linux-ppc64': 1.2.4
-            '@img/sharp-libvips-linux-riscv64': 1.2.4
-            '@img/sharp-libvips-linux-s390x': 1.2.4
-            '@img/sharp-libvips-linux-x64': 1.2.4
-            '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
-            '@img/sharp-libvips-linuxmusl-x64': 1.2.4
-            '@img/sharp-linux-arm': 0.34.5
-            '@img/sharp-linux-arm64': 0.34.5
-            '@img/sharp-linux-ppc64': 0.34.5
-            '@img/sharp-linux-riscv64': 0.34.5
-            '@img/sharp-linux-s390x': 0.34.5
-            '@img/sharp-linux-x64': 0.34.5
-            '@img/sharp-linuxmusl-arm64': 0.34.5
-            '@img/sharp-linuxmusl-x64': 0.34.5
-            '@img/sharp-wasm32': 0.34.5
-            '@img/sharp-win32-arm64': 0.34.5
-            '@img/sharp-win32-ia32': 0.34.5
-            '@img/sharp-win32-x64': 0.34.5
-        optional: true
-
     shebang-command@2.0.0:
         dependencies:
             shebang-regex: 3.0.0
@@ -7668,11 +7098,6 @@ snapshots:
     style-to-object@1.0.14:
         dependencies:
             inline-style-parser: 0.2.7
-
-    styled-jsx@5.1.6(react@19.2.4):
-        dependencies:
-            client-only: 0.0.1
-            react: 19.2.4
 
     stylelint-config-html@1.1.0(postcss-html@1.8.1)(stylelint@17.6.0(typescript@5.9.3)):
         dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ importers:
             clsx:
                 specifier: ^2.1.1
                 version: 2.1.1
+            geist:
+                specifier: ^1.7.0
+                version: 1.7.0(next@16.2.4(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
             low-poly-2d-trees:
                 specifier: link:..\low-poly-2d-trees
                 version: link:../low-poly-2d-trees
@@ -317,6 +320,12 @@ packages:
         engines: { node: '>=20.19.0' }
         peerDependencies:
             postcss-selector-parser: ^7.1.1
+
+    '@emnapi/runtime@1.10.0':
+        resolution:
+            {
+                integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==,
+            }
 
     '@esbuild/aix-ppc64@0.25.12':
         resolution:
@@ -947,6 +956,218 @@ packages:
             }
         engines: { node: '>=18.18' }
 
+    '@img/colour@1.1.0':
+        resolution:
+            {
+                integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==,
+            }
+        engines: { node: '>=18' }
+
+    '@img/sharp-darwin-arm64@0.34.5':
+        resolution:
+            {
+                integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==,
+            }
+        engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+        cpu: [arm64]
+        os: [darwin]
+
+    '@img/sharp-darwin-x64@0.34.5':
+        resolution:
+            {
+                integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==,
+            }
+        engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+        cpu: [x64]
+        os: [darwin]
+
+    '@img/sharp-libvips-darwin-arm64@1.2.4':
+        resolution:
+            {
+                integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==,
+            }
+        cpu: [arm64]
+        os: [darwin]
+
+    '@img/sharp-libvips-darwin-x64@1.2.4':
+        resolution:
+            {
+                integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==,
+            }
+        cpu: [x64]
+        os: [darwin]
+
+    '@img/sharp-libvips-linux-arm64@1.2.4':
+        resolution:
+            {
+                integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==,
+            }
+        cpu: [arm64]
+        os: [linux]
+
+    '@img/sharp-libvips-linux-arm@1.2.4':
+        resolution:
+            {
+                integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==,
+            }
+        cpu: [arm]
+        os: [linux]
+
+    '@img/sharp-libvips-linux-ppc64@1.2.4':
+        resolution:
+            {
+                integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==,
+            }
+        cpu: [ppc64]
+        os: [linux]
+
+    '@img/sharp-libvips-linux-riscv64@1.2.4':
+        resolution:
+            {
+                integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==,
+            }
+        cpu: [riscv64]
+        os: [linux]
+
+    '@img/sharp-libvips-linux-s390x@1.2.4':
+        resolution:
+            {
+                integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==,
+            }
+        cpu: [s390x]
+        os: [linux]
+
+    '@img/sharp-libvips-linux-x64@1.2.4':
+        resolution:
+            {
+                integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==,
+            }
+        cpu: [x64]
+        os: [linux]
+
+    '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+        resolution:
+            {
+                integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==,
+            }
+        cpu: [arm64]
+        os: [linux]
+
+    '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+        resolution:
+            {
+                integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==,
+            }
+        cpu: [x64]
+        os: [linux]
+
+    '@img/sharp-linux-arm64@0.34.5':
+        resolution:
+            {
+                integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==,
+            }
+        engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+        cpu: [arm64]
+        os: [linux]
+
+    '@img/sharp-linux-arm@0.34.5':
+        resolution:
+            {
+                integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==,
+            }
+        engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+        cpu: [arm]
+        os: [linux]
+
+    '@img/sharp-linux-ppc64@0.34.5':
+        resolution:
+            {
+                integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==,
+            }
+        engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+        cpu: [ppc64]
+        os: [linux]
+
+    '@img/sharp-linux-riscv64@0.34.5':
+        resolution:
+            {
+                integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==,
+            }
+        engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+        cpu: [riscv64]
+        os: [linux]
+
+    '@img/sharp-linux-s390x@0.34.5':
+        resolution:
+            {
+                integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==,
+            }
+        engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+        cpu: [s390x]
+        os: [linux]
+
+    '@img/sharp-linux-x64@0.34.5':
+        resolution:
+            {
+                integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==,
+            }
+        engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+        cpu: [x64]
+        os: [linux]
+
+    '@img/sharp-linuxmusl-arm64@0.34.5':
+        resolution:
+            {
+                integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==,
+            }
+        engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+        cpu: [arm64]
+        os: [linux]
+
+    '@img/sharp-linuxmusl-x64@0.34.5':
+        resolution:
+            {
+                integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==,
+            }
+        engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+        cpu: [x64]
+        os: [linux]
+
+    '@img/sharp-wasm32@0.34.5':
+        resolution:
+            {
+                integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==,
+            }
+        engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+        cpu: [wasm32]
+
+    '@img/sharp-win32-arm64@0.34.5':
+        resolution:
+            {
+                integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==,
+            }
+        engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+        cpu: [arm64]
+        os: [win32]
+
+    '@img/sharp-win32-ia32@0.34.5':
+        resolution:
+            {
+                integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==,
+            }
+        engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+        cpu: [ia32]
+        os: [win32]
+
+    '@img/sharp-win32-x64@0.34.5':
+        resolution:
+            {
+                integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==,
+            }
+        engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+        cpu: [x64]
+        os: [win32]
+
     '@internationalized/date@3.12.0':
         resolution:
             {
@@ -1013,6 +1234,84 @@ packages:
             {
                 integrity: sha512-klcSooChXXOzIm+SE5IISIAn3bYzYfPjbX7D7HoqZL84oAfgREeSg5vSIaSFH+DaGzzvImTyWe1OyrJ67vik4A==,
             }
+
+    '@next/env@16.2.4':
+        resolution:
+            {
+                integrity: sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==,
+            }
+
+    '@next/swc-darwin-arm64@16.2.4':
+        resolution:
+            {
+                integrity: sha512-OXTFFox5EKN1Ym08vfrz+OXxmCcEjT4SFMbNRsWZE99dMqt2Kcusl5MqPXcW232RYkMLQTy0hqgAMEsfEd/l2A==,
+            }
+        engines: { node: '>= 10' }
+        cpu: [arm64]
+        os: [darwin]
+
+    '@next/swc-darwin-x64@16.2.4':
+        resolution:
+            {
+                integrity: sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ==,
+            }
+        engines: { node: '>= 10' }
+        cpu: [x64]
+        os: [darwin]
+
+    '@next/swc-linux-arm64-gnu@16.2.4':
+        resolution:
+            {
+                integrity: sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ==,
+            }
+        engines: { node: '>= 10' }
+        cpu: [arm64]
+        os: [linux]
+
+    '@next/swc-linux-arm64-musl@16.2.4':
+        resolution:
+            {
+                integrity: sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==,
+            }
+        engines: { node: '>= 10' }
+        cpu: [arm64]
+        os: [linux]
+
+    '@next/swc-linux-x64-gnu@16.2.4':
+        resolution:
+            {
+                integrity: sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==,
+            }
+        engines: { node: '>= 10' }
+        cpu: [x64]
+        os: [linux]
+
+    '@next/swc-linux-x64-musl@16.2.4':
+        resolution:
+            {
+                integrity: sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==,
+            }
+        engines: { node: '>= 10' }
+        cpu: [x64]
+        os: [linux]
+
+    '@next/swc-win32-arm64-msvc@16.2.4':
+        resolution:
+            {
+                integrity: sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==,
+            }
+        engines: { node: '>= 10' }
+        cpu: [arm64]
+        os: [win32]
+
+    '@next/swc-win32-x64-msvc@16.2.4':
+        resolution:
+            {
+                integrity: sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw==,
+            }
+        engines: { node: '>= 10' }
+        cpu: [x64]
+        os: [win32]
 
     '@nodelib/fs.scandir@2.1.5':
         resolution:
@@ -1628,6 +1927,12 @@ packages:
         peerDependencies:
             svelte: ^5.0.0
             vite: ^6.3.0 || ^7.0.0
+
+    '@swc/helpers@0.5.15':
+        resolution:
+            {
+                integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==,
+            }
 
     '@swc/helpers@0.5.21':
         resolution:
@@ -2316,6 +2621,14 @@ packages:
             }
         engines: { node: 18 || 20 || >=22 }
 
+    baseline-browser-mapping@2.10.24:
+        resolution:
+            {
+                integrity: sha512-I2NkZOOrj2XuguvWCK6OVh9GavsNjZjK908Rq3mIBK25+GD8vPX5w2WdxVqnQ7xx3SrZJiCiZFu+/Oz50oSYSA==,
+            }
+        engines: { node: '>=6.0.0' }
+        hasBin: true
+
     bits-ui@2.16.5:
         resolution:
             {
@@ -2359,6 +2672,12 @@ packages:
                 integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==,
             }
         engines: { node: '>=6' }
+
+    caniuse-lite@1.0.30001791:
+        resolution:
+            {
+                integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==,
+            }
 
     chai@5.3.3:
         resolution:
@@ -2416,6 +2735,12 @@ packages:
                 integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==,
             }
         engines: { node: '>=20' }
+
+    client-only@0.0.1:
+        resolution:
+            {
+                integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==,
+            }
 
     clsx@2.1.1:
         resolution:
@@ -3034,6 +3359,14 @@ packages:
             }
         engines: { node: ^8.16.0 || ^10.6.0 || >=11.0.0 }
         os: [darwin]
+
+    geist@1.7.0:
+        resolution:
+            {
+                integrity: sha512-ZaoiZwkSf0DwwB1ncdLKp+ggAldqxl5L1+SXaNIBGkPAqcu+xjVJLxlf3/S8vLt9UHx1xu5fz3lbzKCj5iOVdQ==,
+            }
+        peerDependencies:
+            next: '>=13.2.0'
 
     get-east-asian-width@1.5.0:
         resolution:
@@ -3722,6 +4055,30 @@ packages:
                 integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==,
             }
 
+    next@16.2.4:
+        resolution:
+            {
+                integrity: sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==,
+            }
+        engines: { node: '>=20.9.0' }
+        hasBin: true
+        peerDependencies:
+            '@opentelemetry/api': ^1.1.0
+            '@playwright/test': ^1.51.1
+            babel-plugin-react-compiler: '*'
+            react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+            react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+            sass: ^1.3.0
+        peerDependenciesMeta:
+            '@opentelemetry/api':
+                optional: true
+            '@playwright/test':
+                optional: true
+            babel-plugin-react-compiler:
+                optional: true
+            sass:
+                optional: true
+
     normalize-path@3.0.0:
         resolution:
             {
@@ -3929,6 +4286,13 @@ packages:
                 integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==,
             }
 
+    postcss@8.4.31:
+        resolution:
+            {
+                integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==,
+            }
+        engines: { node: ^10 || ^12 || >=14 }
+
     postcss@8.5.8:
         resolution:
             {
@@ -4129,6 +4493,13 @@ packages:
                 integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==,
             }
 
+    sharp@0.34.5:
+        resolution:
+            {
+                integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==,
+            }
+        engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+
     shebang-command@2.0.0:
         resolution:
             {
@@ -4283,6 +4654,22 @@ packages:
             {
                 integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==,
             }
+
+    styled-jsx@5.1.6:
+        resolution:
+            {
+                integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==,
+            }
+        engines: { node: '>= 12.0.0' }
+        peerDependencies:
+            '@babel/core': '*'
+            babel-plugin-macros: '*'
+            react: '>= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0'
+        peerDependenciesMeta:
+            '@babel/core':
+                optional: true
+            babel-plugin-macros:
+                optional: true
 
     stylelint-config-html@1.1.0:
         resolution:
@@ -4913,6 +5300,11 @@ snapshots:
         dependencies:
             postcss-selector-parser: 7.1.1
 
+    '@emnapi/runtime@1.10.0':
+        dependencies:
+            tslib: 2.8.1
+        optional: true
+
     '@esbuild/aix-ppc64@0.25.12':
         optional: true
 
@@ -5145,6 +5537,103 @@ snapshots:
 
     '@humanwhocodes/retry@0.4.3': {}
 
+    '@img/colour@1.1.0':
+        optional: true
+
+    '@img/sharp-darwin-arm64@0.34.5':
+        optionalDependencies:
+            '@img/sharp-libvips-darwin-arm64': 1.2.4
+        optional: true
+
+    '@img/sharp-darwin-x64@0.34.5':
+        optionalDependencies:
+            '@img/sharp-libvips-darwin-x64': 1.2.4
+        optional: true
+
+    '@img/sharp-libvips-darwin-arm64@1.2.4':
+        optional: true
+
+    '@img/sharp-libvips-darwin-x64@1.2.4':
+        optional: true
+
+    '@img/sharp-libvips-linux-arm64@1.2.4':
+        optional: true
+
+    '@img/sharp-libvips-linux-arm@1.2.4':
+        optional: true
+
+    '@img/sharp-libvips-linux-ppc64@1.2.4':
+        optional: true
+
+    '@img/sharp-libvips-linux-riscv64@1.2.4':
+        optional: true
+
+    '@img/sharp-libvips-linux-s390x@1.2.4':
+        optional: true
+
+    '@img/sharp-libvips-linux-x64@1.2.4':
+        optional: true
+
+    '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+        optional: true
+
+    '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+        optional: true
+
+    '@img/sharp-linux-arm64@0.34.5':
+        optionalDependencies:
+            '@img/sharp-libvips-linux-arm64': 1.2.4
+        optional: true
+
+    '@img/sharp-linux-arm@0.34.5':
+        optionalDependencies:
+            '@img/sharp-libvips-linux-arm': 1.2.4
+        optional: true
+
+    '@img/sharp-linux-ppc64@0.34.5':
+        optionalDependencies:
+            '@img/sharp-libvips-linux-ppc64': 1.2.4
+        optional: true
+
+    '@img/sharp-linux-riscv64@0.34.5':
+        optionalDependencies:
+            '@img/sharp-libvips-linux-riscv64': 1.2.4
+        optional: true
+
+    '@img/sharp-linux-s390x@0.34.5':
+        optionalDependencies:
+            '@img/sharp-libvips-linux-s390x': 1.2.4
+        optional: true
+
+    '@img/sharp-linux-x64@0.34.5':
+        optionalDependencies:
+            '@img/sharp-libvips-linux-x64': 1.2.4
+        optional: true
+
+    '@img/sharp-linuxmusl-arm64@0.34.5':
+        optionalDependencies:
+            '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+        optional: true
+
+    '@img/sharp-linuxmusl-x64@0.34.5':
+        optionalDependencies:
+            '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+        optional: true
+
+    '@img/sharp-wasm32@0.34.5':
+        dependencies:
+            '@emnapi/runtime': 1.10.0
+        optional: true
+
+    '@img/sharp-win32-arm64@0.34.5':
+        optional: true
+
+    '@img/sharp-win32-ia32@0.34.5':
+        optional: true
+
+    '@img/sharp-win32-x64@0.34.5':
+        optional: true
+
     '@internationalized/date@3.12.0':
         dependencies:
             '@swc/helpers': 0.5.21
@@ -5183,6 +5672,32 @@ snapshots:
             react: 19.2.4
 
     '@neoconfetti/react@1.0.0': {}
+
+    '@next/env@16.2.4': {}
+
+    '@next/swc-darwin-arm64@16.2.4':
+        optional: true
+
+    '@next/swc-darwin-x64@16.2.4':
+        optional: true
+
+    '@next/swc-linux-arm64-gnu@16.2.4':
+        optional: true
+
+    '@next/swc-linux-arm64-musl@16.2.4':
+        optional: true
+
+    '@next/swc-linux-x64-gnu@16.2.4':
+        optional: true
+
+    '@next/swc-linux-x64-musl@16.2.4':
+        optional: true
+
+    '@next/swc-win32-arm64-msvc@16.2.4':
+        optional: true
+
+    '@next/swc-win32-x64-msvc@16.2.4':
+        optional: true
 
     '@nodelib/fs.scandir@2.1.5':
         dependencies:
@@ -5510,6 +6025,10 @@ snapshots:
             svelte: 5.55.0
             vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
             vitefu: 1.1.2(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))
+
+    '@swc/helpers@0.5.15':
+        dependencies:
+            tslib: 2.8.1
 
     '@swc/helpers@0.5.21':
         dependencies:
@@ -5957,6 +6476,8 @@ snapshots:
 
     balanced-match@4.0.4: {}
 
+    baseline-browser-mapping@2.10.24: {}
+
     bits-ui@2.16.5(@internationalized/date@3.12.0)(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)))(svelte@5.55.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)))(svelte@5.55.0):
         dependencies:
             '@floating-ui/core': 1.7.5
@@ -5992,6 +6513,8 @@ snapshots:
 
     callsites@3.1.0: {}
 
+    caniuse-lite@1.0.30001791: {}
+
     chai@5.3.3:
         dependencies:
             assertion-error: 2.0.1
@@ -6018,6 +6541,8 @@ snapshots:
         dependencies:
             slice-ansi: 8.0.0
             string-width: 8.2.0
+
+    client-only@0.0.1: {}
 
     clsx@2.1.1: {}
 
@@ -6414,6 +6939,10 @@ snapshots:
     fsevents@2.3.3:
         optional: true
 
+    geist@1.7.0(next@16.2.4(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)):
+        dependencies:
+            next: 16.2.4(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+
     get-east-asian-width@1.5.0: {}
 
     glob-parent@5.1.2:
@@ -6731,6 +7260,31 @@ snapshots:
 
     natural-compare@1.4.0: {}
 
+    next@16.2.4(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+        dependencies:
+            '@next/env': 16.2.4
+            '@swc/helpers': 0.5.15
+            baseline-browser-mapping: 2.10.24
+            caniuse-lite: 1.0.30001791
+            postcss: 8.4.31
+            react: 19.2.4
+            react-dom: 19.2.4(react@19.2.4)
+            styled-jsx: 5.1.6(react@19.2.4)
+        optionalDependencies:
+            '@next/swc-darwin-arm64': 16.2.4
+            '@next/swc-darwin-x64': 16.2.4
+            '@next/swc-linux-arm64-gnu': 16.2.4
+            '@next/swc-linux-arm64-musl': 16.2.4
+            '@next/swc-linux-x64-gnu': 16.2.4
+            '@next/swc-linux-x64-musl': 16.2.4
+            '@next/swc-win32-arm64-msvc': 16.2.4
+            '@next/swc-win32-x64-msvc': 16.2.4
+            '@playwright/test': 1.58.2
+            sharp: 0.34.5
+        transitivePeerDependencies:
+            - '@babel/core'
+            - babel-plugin-macros
+
     normalize-path@3.0.0: {}
 
     obug@2.1.1: {}
@@ -6852,6 +7406,12 @@ snapshots:
             util-deprecate: 1.0.2
 
     postcss-value-parser@4.2.0: {}
+
+    postcss@8.4.31:
+        dependencies:
+            nanoid: 3.3.11
+            picocolors: 1.1.1
+            source-map-js: 1.2.1
 
     postcss@8.5.8:
         dependencies:
@@ -6977,6 +7537,38 @@ snapshots:
 
     set-cookie-parser@3.1.0: {}
 
+    sharp@0.34.5:
+        dependencies:
+            '@img/colour': 1.1.0
+            detect-libc: 2.1.2
+            semver: 7.7.4
+        optionalDependencies:
+            '@img/sharp-darwin-arm64': 0.34.5
+            '@img/sharp-darwin-x64': 0.34.5
+            '@img/sharp-libvips-darwin-arm64': 1.2.4
+            '@img/sharp-libvips-darwin-x64': 1.2.4
+            '@img/sharp-libvips-linux-arm': 1.2.4
+            '@img/sharp-libvips-linux-arm64': 1.2.4
+            '@img/sharp-libvips-linux-ppc64': 1.2.4
+            '@img/sharp-libvips-linux-riscv64': 1.2.4
+            '@img/sharp-libvips-linux-s390x': 1.2.4
+            '@img/sharp-libvips-linux-x64': 1.2.4
+            '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+            '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+            '@img/sharp-linux-arm': 0.34.5
+            '@img/sharp-linux-arm64': 0.34.5
+            '@img/sharp-linux-ppc64': 0.34.5
+            '@img/sharp-linux-riscv64': 0.34.5
+            '@img/sharp-linux-s390x': 0.34.5
+            '@img/sharp-linux-x64': 0.34.5
+            '@img/sharp-linuxmusl-arm64': 0.34.5
+            '@img/sharp-linuxmusl-x64': 0.34.5
+            '@img/sharp-wasm32': 0.34.5
+            '@img/sharp-win32-arm64': 0.34.5
+            '@img/sharp-win32-ia32': 0.34.5
+            '@img/sharp-win32-x64': 0.34.5
+        optional: true
+
     shebang-command@2.0.0:
         dependencies:
             shebang-regex: 3.0.0
@@ -7076,6 +7668,11 @@ snapshots:
     style-to-object@1.0.14:
         dependencies:
             inline-style-parser: 0.2.7
+
+    styled-jsx@5.1.6(react@19.2.4):
+        dependencies:
+            client-only: 0.0.1
+            react: 19.2.4
 
     stylelint-config-html@1.1.0(postcss-html@1.8.1)(stylelint@17.6.0(typescript@5.9.3)):
         dependencies:

--- a/src/app.css
+++ b/src/app.css
@@ -1,111 +1,276 @@
 @import 'tailwindcss';
 
-@custom-variant dark (&:where(.dark, .dark *));
+@custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *));
 
 @theme inline {
 	--color-background: var(--background);
 	--color-foreground: var(--foreground);
-	--color-card: var(--card);
-	--color-card-foreground: var(--card-foreground);
-	--color-popover: var(--popover);
-	--color-popover-foreground: var(--popover-foreground);
+	--color-surface: var(--surface);
+	--color-surface-2: var(--surface-2);
+	--color-surface-3: var(--surface-3);
+	--color-foreground-muted: var(--foreground-muted);
+	--color-foreground-subtle: var(--foreground-subtle);
 	--color-primary: var(--primary);
-	--color-primary-foreground: var(--primary-foreground);
-	--color-secondary: var(--secondary);
-	--color-secondary-foreground: var(--secondary-foreground);
-	--color-muted: var(--muted);
-	--color-muted-foreground: var(--muted-foreground);
+	--color-primary-foreground: var(--primary-fg);
+	--color-primary-soft: var(--primary-soft);
+	--color-secondary: var(--surface-2);
+	--color-secondary-foreground: var(--foreground);
+	--color-muted: var(--surface-2);
+	--color-muted-foreground: var(--foreground-muted);
 	--color-accent: var(--accent);
-	--color-accent-foreground: var(--accent-foreground);
-	--color-destructive: var(--destructive);
-	--color-destructive-foreground: var(--destructive-foreground);
+	--color-accent-foreground: var(--accent-fg);
+	--color-destructive: var(--status-danger);
+	--color-destructive-foreground: oklch(0.985 0 0);
 	--color-border: var(--border);
-	--color-input: var(--input);
+	--color-border-strong: var(--border-strong);
+	--color-input: var(--border);
 	--color-ring: var(--ring);
-	--color-chart-1: var(--chart-1);
-	--color-chart-2: var(--chart-2);
-	--color-chart-3: var(--chart-3);
-	--color-chart-4: var(--chart-4);
-	--color-chart-5: var(--chart-5);
-	--color-sidebar: var(--sidebar);
-	--color-sidebar-foreground: var(--sidebar-foreground);
-	--color-sidebar-primary: var(--sidebar-primary);
-	--color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-	--color-sidebar-accent: var(--sidebar-accent);
-	--color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-	--color-sidebar-border: var(--sidebar-border);
-	--color-sidebar-ring: var(--sidebar-ring);
-	--radius: 0.625rem;
+	--color-card: var(--surface);
+	--color-card-foreground: var(--foreground);
+	--color-popover: var(--surface);
+	--color-popover-foreground: var(--foreground);
+	--color-sidebar: var(--sidebar-bg);
+	--color-sidebar-foreground: var(--sidebar-fg);
+	--color-sidebar-primary: var(--primary);
+	--color-sidebar-primary-foreground: var(--primary-fg);
+	--color-sidebar-accent: var(--surface-2);
+	--color-sidebar-accent-foreground: var(--foreground);
+	--color-sidebar-border: var(--border);
+	--color-sidebar-ring: var(--ring);
+	--color-status-success: var(--status-success);
+	--color-status-warning: var(--status-warning);
+	--color-status-danger: var(--status-danger);
+	--color-status-info: var(--status-info);
+	--color-code-bg: var(--code-bg);
+	--color-moss-50: var(--moss-50);
+	--color-moss-100: var(--moss-100);
+	--color-moss-200: var(--moss-200);
+	--color-moss-300: var(--moss-300);
+	--color-moss-400: var(--moss-400);
+	--color-moss-500: var(--moss-500);
+	--color-moss-600: var(--moss-600);
+	--color-moss-700: var(--moss-700);
+	--color-moss-800: var(--moss-800);
+	--color-moss-900: var(--moss-900);
+	--color-moss-950: var(--moss-950);
+	--color-amber-300: var(--amber-300);
+	--color-amber-400: var(--amber-400);
+	--color-amber-500: var(--amber-500);
+	--color-amber-600: var(--amber-600);
+	--color-bark-300: var(--bark-300);
+	--color-bark-500: var(--bark-500);
+	--color-bark-700: var(--bark-700);
+	--color-azure-300: var(--azure-300);
+	--color-azure-400: var(--azure-400);
+	--color-azure-500: var(--azure-500);
+	--color-azure-600: var(--azure-600);
+	--color-azure-700: var(--azure-700);
+	--font-sans: 'Geist', 'Inter', ui-sans-serif, system-ui, sans-serif;
+	--font-mono: 'Geist Mono', ui-monospace, 'JetBrains Mono', 'Menlo', monospace;
+	--radius-none: 0;
+	--radius-xs: 4px;
+	--radius-sm: 6px;
+	--radius-md: 8px;
+	--radius-lg: 10px;
+	--radius-xl: 14px;
+	--radius-2xl: 20px;
+	--radius-full: 9999px;
+	--shadow-sm: 0 1px 2px rgb(20 30 22 / 6%);
+	--shadow-md: 0 2px 8px rgb(20 30 22 / 8%), 0 1px 2px rgb(20 30 22 / 4%);
+	--shadow-lg: 0 12px 32px rgb(20 30 22 / 14%), 0 2px 6px rgb(20 30 22 / 6%);
+	--shadow-xl: 0 24px 56px rgb(20 30 22 / 20%), 0 4px 12px rgb(20 30 22 / 8%);
+	--shadow-inset: inset 0 1px 0 rgb(255 255 255 / 5%);
+	--ease-standard: cubic-bezier(0.2, 0.7, 0.3, 1);
+	--ease-out: cubic-bezier(0.16, 0.84, 0.44, 1);
+	--ease-in: cubic-bezier(0.5, 0, 0.75, 0);
+	--duration-1: 90ms;
+	--duration-2: 120ms;
+	--duration-3: 160ms;
+	--duration-4: 220ms;
+	--duration-5: 320ms;
 }
 
 :root {
-	--background: oklch(1 0 0);
-	--foreground: oklch(0.141 0.005 285.823);
-	--card: oklch(1 0 0);
-	--card-foreground: oklch(0.141 0.005 285.823);
-	--popover: oklch(1 0 0);
-	--popover-foreground: oklch(0.141 0.005 285.823);
-	--primary: oklch(0.141 0.005 285.823);
-	--primary-foreground: oklch(0.985 0 0);
-	--secondary: oklch(0.967 0.001 286.375);
-	--secondary-foreground: oklch(0.141 0.005 285.823);
-	--muted: oklch(0.967 0.001 286.375);
-	--muted-foreground: oklch(0.552 0.016 285.938);
-	--accent: oklch(0.967 0.001 286.375);
-	--accent-foreground: oklch(0.141 0.005 285.823);
-	--destructive: oklch(0.577 0.245 27.325);
-	--destructive-foreground: oklch(0.985 0 0);
-	--border: oklch(0.92 0.004 286.32);
-	--input: oklch(0.92 0.004 286.32);
-	--ring: oklch(0.141 0.005 285.823);
-	--chart-1: oklch(0.646 0.222 41.116);
-	--chart-2: oklch(0.6 0.118 184.704);
-	--chart-3: oklch(0.398 0.07 227.392);
-	--chart-4: oklch(0.828 0.189 84.429);
-	--chart-5: oklch(0.769 0.188 70.08);
-	--sidebar: oklch(0.985 0 0);
-	--sidebar-foreground: oklch(0.552 0.016 285.938);
-	--sidebar-primary: oklch(0.141 0.005 285.823);
-	--sidebar-primary-foreground: oklch(0.985 0 0);
-	--sidebar-accent: oklch(0.967 0.001 286.375);
-	--sidebar-accent-foreground: oklch(0.141 0.005 285.823);
-	--sidebar-border: oklch(0.92 0.004 286.32);
-	--sidebar-ring: oklch(0.141 0.005 285.823);
+	--moss-50: oklch(0.972 0.018 130);
+	--moss-100: oklch(0.94 0.034 130);
+	--moss-200: oklch(0.88 0.058 130);
+	--moss-300: oklch(0.795 0.082 130);
+	--moss-400: oklch(0.69 0.098 132);
+	--moss-500: oklch(0.58 0.096 134);
+	--moss-600: oklch(0.48 0.082 138);
+	--moss-700: oklch(0.395 0.066 142);
+	--moss-800: oklch(0.3 0.048 145);
+	--moss-900: oklch(0.215 0.032 148);
+	--moss-950: oklch(0.155 0.024 150);
+	--amber-300: oklch(0.84 0.13 78);
+	--amber-400: oklch(0.77 0.15 65);
+	--amber-500: oklch(0.69 0.165 55);
+	--amber-600: oklch(0.595 0.16 48);
+	--bark-300: oklch(0.7 0.06 60);
+	--bark-500: oklch(0.5 0.075 55);
+	--bark-700: oklch(0.345 0.055 50);
+	--azure-300: oklch(0.75 0.09 230);
+	--azure-400: oklch(0.66 0.12 230);
+	--azure-500: oklch(0.57 0.13 235);
+	--azure-600: oklch(0.49 0.115 240);
+	--azure-700: oklch(0.4 0.095 240);
+	--sky-light-top: oklch(0.965 0.018 220);
+	--sky-light-bot: oklch(0.94 0.025 130);
+	--sky-dark-top: oklch(0.225 0.028 240);
+	--sky-dark-bot: oklch(0.18 0.03 150);
+	--space-0: 0;
+	--space-1: 2px;
+	--space-2: 4px;
+	--space-3: 6px;
+	--space-4: 8px;
+	--space-5: 10px;
+	--space-6: 12px;
+	--space-7: 14px;
+	--space-8: 16px;
+	--space-10: 20px;
+	--space-12: 24px;
+	--space-14: 28px;
+	--space-16: 32px;
+	--space-20: 40px;
+	--space-24: 48px;
+	--space-32: 64px;
+	--status-success: oklch(0.66 0.135 145);
+	--status-warning: oklch(0.77 0.155 75);
+	--status-danger: oklch(0.62 0.205 25);
+	--status-info: oklch(0.66 0.105 220);
+	--text-2xs: 10.5px;
+	--text-xs: 11px;
+	--text-sm: 12px;
+	--text-md: 13px;
+	--text-base: 14px;
+	--text-lg: 15px;
+	--text-xl: 17px;
+	--text-2xl: 22px;
+	--text-3xl: 28px;
+	--text-4xl: 36px;
+	--text-5xl: 48px;
+	--leading-tight: 1.15;
+	--leading-snug: 1.25;
+	--leading-normal: 1.4;
+	--leading-relaxed: 1.55;
+	--leading-loose: 1.7;
+	--weight-regular: 400;
+	--weight-medium: 500;
+	--weight-semibold: 600;
+	--weight-bold: 700;
+	--tracking-tight: -0.02em;
+	--tracking-snug: -0.01em;
+	--tracking-normal: 0;
+	--tracking-wide: 0.04em;
+	--tracking-wider: 0.08em;
+	--size-control-sm: 26px;
+	--size-control-md: 32px;
+	--size-control-lg: 38px;
+	--z-base: 0;
+	--z-raised: 10;
+	--z-dropdown: 20;
+	--z-sticky: 30;
+	--z-overlay: 40;
+	--z-modal: 50;
+	--z-toast: 60;
+	--z-tooltip: 70;
+	--border-width-1: 1px;
+	--border-width-2: 1.5px;
+	--border-width-3: 2px;
+	--focus-ring-width: 3px;
+	--focus-ring-offset: 2px;
+	--sidebar-width: 240px;
+	--sidebar-width-collapsed: 56px;
 }
 
-.dark {
-	--background: oklch(0.141 0.005 285.823);
-	--foreground: oklch(0.985 0 0);
-	--card: oklch(0.141 0.005 285.823);
-	--card-foreground: oklch(0.985 0 0);
-	--popover: oklch(0.141 0.005 285.823);
-	--popover-foreground: oklch(0.985 0 0);
-	--primary: oklch(0.985 0 0);
-	--primary-foreground: oklch(0.141 0.005 285.823);
-	--secondary: oklch(0.254 0.006 285.885);
-	--secondary-foreground: oklch(0.985 0 0);
-	--muted: oklch(0.254 0.006 285.885);
-	--muted-foreground: oklch(0.716 0.013 286.067);
-	--accent: oklch(0.254 0.006 285.885);
-	--accent-foreground: oklch(0.985 0 0);
-	--destructive: oklch(0.704 0.191 22.216);
-	--destructive-foreground: oklch(0.985 0 0);
-	--border: oklch(0.254 0.006 285.885);
-	--input: oklch(0.254 0.006 285.885);
-	--ring: oklch(0.716 0.013 286.067);
-	--chart-1: oklch(0.488 0.243 264.376);
-	--chart-2: oklch(0.696 0.17 162.48);
-	--chart-3: oklch(0.769 0.188 70.08);
-	--chart-4: oklch(0.627 0.265 303.9);
-	--chart-5: oklch(0.645 0.246 16.439);
-	--sidebar: oklch(0.141 0.005 285.823);
-	--sidebar-foreground: oklch(0.716 0.013 286.067);
-	--sidebar-primary: oklch(0.488 0.243 264.376);
-	--sidebar-primary-foreground: oklch(0.985 0 0);
-	--sidebar-accent: oklch(0.254 0.006 285.885);
-	--sidebar-accent-foreground: oklch(0.985 0 0);
-	--sidebar-border: oklch(0.254 0.006 285.885);
-	--sidebar-ring: oklch(0.716 0.013 286.067);
+[data-theme='light'] {
+	color-scheme: light;
+
+	--background: oklch(0.985 0.005 130);
+	--surface: oklch(1 0 0);
+	--surface-2: oklch(0.965 0.008 130);
+	--surface-3: oklch(0.94 0.012 130);
+	--foreground: oklch(0.205 0.015 145);
+	--foreground-muted: oklch(0.46 0.015 145);
+	--foreground-subtle: oklch(0.62 0.012 145);
+	--border: oklch(0.9 0.012 135);
+	--border-strong: oklch(0.815 0.018 135);
+	--primary: var(--moss-700);
+	--primary-fg: oklch(0.985 0.008 130);
+	--primary-soft: oklch(0.92 0.03 135);
+	--accent: var(--amber-500);
+	--accent-fg: oklch(0.16 0.02 50);
+	--ring: var(--moss-600);
+	--sidebar-bg: oklch(0.955 0.01 135);
+	--sidebar-fg: oklch(0.3 0.02 145);
+	--code-bg: oklch(0.955 0.01 135);
+}
+
+[data-theme='dark'] {
+	color-scheme: dark;
+
+	--background: oklch(0.155 0.018 150);
+	--surface: oklch(0.19 0.02 150);
+	--surface-2: oklch(0.225 0.022 150);
+	--surface-3: oklch(0.265 0.024 150);
+	--foreground: oklch(0.965 0.01 130);
+	--foreground-muted: oklch(0.73 0.018 135);
+	--foreground-subtle: oklch(0.56 0.02 140);
+	--border: oklch(0.295 0.022 148);
+	--border-strong: oklch(0.38 0.028 145);
+	--primary: var(--moss-400);
+	--primary-fg: oklch(0.135 0.02 150);
+	--primary-soft: oklch(0.305 0.045 145);
+	--accent: var(--amber-400);
+	--accent-fg: oklch(0.15 0.02 50);
+	--ring: var(--moss-400);
+	--sidebar-bg: oklch(0.18 0.022 150);
+	--sidebar-fg: oklch(0.77 0.02 140);
+	--code-bg: oklch(0.215 0.02 150);
+}
+
+/* ── Accent color overrides ─────────────────────────────────────────────── */
+
+[data-accent='amber'][data-theme='light'] {
+	--primary: var(--amber-600);
+	--primary-fg: oklch(0.985 0.008 75);
+	--primary-soft: oklch(0.92 0.065 75);
+	--ring: var(--amber-600);
+}
+
+[data-accent='amber'][data-theme='dark'] {
+	--primary: var(--amber-400);
+	--primary-fg: oklch(0.135 0.02 55);
+	--primary-soft: oklch(0.305 0.07 60);
+	--ring: var(--amber-400);
+}
+
+[data-accent='bark'][data-theme='light'] {
+	--primary: var(--bark-700);
+	--primary-fg: oklch(0.985 0.008 55);
+	--primary-soft: oklch(0.92 0.03 55);
+	--ring: var(--bark-700);
+}
+
+[data-accent='bark'][data-theme='dark'] {
+	--primary: var(--bark-300);
+	--primary-fg: oklch(0.135 0.02 50);
+	--primary-soft: oklch(0.305 0.04 55);
+	--ring: var(--bark-300);
+}
+
+[data-accent='azure'][data-theme='light'] {
+	--primary: var(--azure-600);
+	--primary-fg: oklch(0.985 0.008 230);
+	--primary-soft: oklch(0.92 0.04 230);
+	--ring: var(--azure-600);
+}
+
+[data-accent='azure'][data-theme='dark'] {
+	--primary: var(--azure-400);
+	--primary-fg: oklch(0.135 0.02 240);
+	--primary-soft: oklch(0.305 0.055 235);
+	--ring: var(--azure-400);
 }
 
 @layer base {
@@ -115,5 +280,11 @@
 
 	body {
 		@apply bg-background text-foreground;
+
+		font-family: var(--font-sans);
+		font-feature-settings: 'ss01', 'cv11';
+		font-synthesis: none;
+		-webkit-font-smoothing: antialiased;
+		text-rendering: optimizelegibility;
 	}
 }

--- a/src/app.html
+++ b/src/app.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 	<head>
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />

--- a/src/lib/components/ui/button/Button.stories.svelte
+++ b/src/lib/components/ui/button/Button.stories.svelte
@@ -12,11 +12,11 @@
 		argTypes: {
 			variant: {
 				control: 'select',
-				options: ['default', 'secondary', 'outline', 'ghost', 'destructive', 'link'],
+				options: ['primary', 'secondary', 'ghost', 'danger'],
 			},
 			size: {
 				control: 'select',
-				options: ['default', 'xs', 'sm', 'lg', 'icon', 'icon-xs', 'icon-sm', 'icon-lg'],
+				options: ['sm', 'md', 'lg', 'icon', 'icon-sm'],
 			},
 			disabled: { control: 'boolean' },
 		},
@@ -25,11 +25,17 @@
 
 <script lang="ts">
 	import type { ButtonProps } from './button-variants.js';
+	import {
+		Mail as MailIcon,
+		Plus as PlusIcon,
+		Trash2 as TrashIcon,
+		Settings as SettingsIcon,
+	} from 'lucide-svelte';
 </script>
 
-<Story name="Default" args={{ variant: 'default' }}>
+<Story name="Primary" args={{ variant: 'primary' }}>
 	{#snippet template(args: ButtonProps)}
-		<Button {...args}>Button</Button>
+		<Button {...args}>Primary</Button>
 	{/snippet}
 </Story>
 
@@ -39,45 +45,36 @@
 	{/snippet}
 </Story>
 
-<Story name="Outline">
-	{#snippet template(args: ButtonProps)}
-		<Button variant="outline" {...args}>Outline</Button>
-	{/snippet}
-</Story>
-
 <Story name="Ghost">
 	{#snippet template(args: ButtonProps)}
 		<Button variant="ghost" {...args}>Ghost</Button>
 	{/snippet}
 </Story>
 
-<Story name="Destructive">
+<Story name="Danger">
 	{#snippet template(args: ButtonProps)}
-		<Button variant="destructive" {...args}>Destructive</Button>
-	{/snippet}
-</Story>
-
-<Story name="Link">
-	{#snippet template(args: ButtonProps)}
-		<Button variant="link" {...args}>Link</Button>
+		<Button variant="danger" {...args}>Danger</Button>
 	{/snippet}
 </Story>
 
 <Story name="Disabled">
 	{#snippet template(args: ButtonProps)}
-		<Button disabled {...args}>Disabled</Button>
+		<div class="flex flex-wrap items-center gap-4">
+			<Button variant="primary" disabled {...args}>Primary</Button>
+			<Button variant="secondary" disabled {...args}>Secondary</Button>
+			<Button variant="ghost" disabled {...args}>Ghost</Button>
+			<Button variant="danger" disabled {...args}>Danger</Button>
+		</div>
 	{/snippet}
 </Story>
 
 <Story name="All Variants">
 	{#snippet template(args: ButtonProps)}
 		<div class="flex flex-wrap items-center gap-4">
-			<Button variant="default" {...args}>Default</Button>
+			<Button variant="primary" {...args}>Primary</Button>
 			<Button variant="secondary" {...args}>Secondary</Button>
-			<Button variant="outline" {...args}>Outline</Button>
 			<Button variant="ghost" {...args}>Ghost</Button>
-			<Button variant="destructive" {...args}>Destructive</Button>
-			<Button variant="link" {...args}>Link</Button>
+			<Button variant="danger" {...args}>Danger</Button>
 		</div>
 	{/snippet}
 </Story>
@@ -85,10 +82,51 @@
 <Story name="All Sizes">
 	{#snippet template(args: ButtonProps)}
 		<div class="flex flex-wrap items-center gap-4">
-			<Button size="xs" {...args}>Extra Small</Button>
 			<Button size="sm" {...args}>Small</Button>
-			<Button size="default" {...args}>Default</Button>
+			<Button size="md" {...args}>Medium</Button>
 			<Button size="lg" {...args}>Large</Button>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Icon Only">
+	{#snippet template(args: ButtonProps)}
+		<div class="flex flex-wrap items-center gap-4">
+			<Button variant="primary" size="icon" {...args}><PlusIcon /></Button>
+			<Button variant="secondary" size="icon" {...args}><SettingsIcon /></Button>
+			<Button variant="ghost" size="icon" {...args}><MailIcon /></Button>
+			<Button variant="danger" size="icon" {...args}><TrashIcon /></Button>
+			<Button variant="primary" size="icon-sm" {...args}><PlusIcon /></Button>
+			<Button variant="ghost" size="icon-sm" {...args}><SettingsIcon /></Button>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="With Icons">
+	{#snippet template(args: ButtonProps)}
+		<div class="flex flex-wrap items-center gap-4">
+			<Button variant="primary" {...args}><PlusIcon /> Create</Button>
+			<Button variant="secondary" {...args}><SettingsIcon /> Settings</Button>
+			<Button variant="ghost" {...args}><MailIcon /> Mail</Button>
+			<Button variant="danger" {...args}><TrashIcon /> Delete</Button>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Size x Variant Matrix">
+	{#snippet template(args: ButtonProps)}
+		<div class="flex flex-col gap-6">
+			{#each ['sm', 'md', 'lg'] as const as size (size)}
+				<div>
+					<p class="mb-2 text-sm text-foreground-muted">{size}</p>
+					<div class="flex flex-wrap items-center gap-3">
+						<Button variant="primary" {size} {...args}>Primary</Button>
+						<Button variant="secondary" {size} {...args}>Secondary</Button>
+						<Button variant="ghost" {size} {...args}>Ghost</Button>
+						<Button variant="danger" {size} {...args}>Danger</Button>
+					</div>
+				</div>
+			{/each}
 		</div>
 	{/snippet}
 </Story>

--- a/src/lib/components/ui/button/Button.svelte
+++ b/src/lib/components/ui/button/Button.svelte
@@ -4,8 +4,8 @@
 
 	let {
 		class: className,
-		variant = 'default',
-		size = 'default',
+		variant = 'primary',
+		size = 'md',
 		ref = $bindable(null),
 		href = undefined,
 		type = 'button',

--- a/src/lib/components/ui/button/button-variants.ts
+++ b/src/lib/components/ui/button/button-variants.ts
@@ -3,36 +3,27 @@ import type { HTMLAnchorAttributes, HTMLButtonAttributes } from 'svelte/elements
 import { type VariantProps, tv } from 'tailwind-variants';
 
 export const buttonVariants = tv({
-	base: "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-3 active:not-aria-[haspopup]:translate-y-px aria-invalid:ring-3 [&_svg:not([class*='size-'])]:size-4 group/button inline-flex shrink-0 items-center justify-center whitespace-nowrap transition-all outline-none select-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+	base: 'inline-flex shrink-0 items-center justify-center gap-[6px] whitespace-nowrap rounded-md border border-transparent font-medium leading-none outline-none select-none transition-[background,border-color,color,transform,filter,box-shadow] duration-[120ms] ease-[ease] active:scale-[0.96] focus-visible:outline-2 focus-visible:outline-solid focus-visible:outline-offset-2 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-45 [&_svg:not([class*="size-"])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0',
 	variants: {
 		variant: {
-			default: 'bg-primary text-primary-foreground hover:bg-primary/80',
-			outline:
-				'border-border bg-background hover:bg-muted hover:text-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 aria-expanded:bg-muted aria-expanded:text-foreground shadow-xs',
+			primary:
+				'bg-primary text-primary-foreground shadow-sm hover:bg-[color-mix(in_oklch,var(--primary)_88%,white_12%)] dark:hover:bg-[color-mix(in_oklch,var(--primary)_88%,black_12%)]',
 			secondary:
-				'bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground',
-			ghost: 'hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground',
-			destructive:
-				'bg-destructive/10 hover:bg-destructive/20 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/20 text-destructive focus-visible:border-destructive/40 dark:hover:bg-destructive/30',
-			link: 'text-primary underline-offset-4 hover:underline',
+				'border-border bg-surface-2 text-foreground hover:bg-surface-3 hover:border-border-strong',
+			ghost: 'bg-transparent text-foreground-muted hover:bg-surface-2 hover:text-foreground',
+			danger: 'bg-transparent text-status-danger border-[color-mix(in_oklch,var(--status-danger)_35%,transparent)] hover:bg-[color-mix(in_oklch,var(--status-danger)_12%,transparent)]',
 		},
 		size: {
-			default:
-				'h-9 gap-1.5 px-2.5 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2',
-			xs: "h-6 gap-1 rounded-[min(var(--radius-md),8px)] px-2 text-xs in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
-			sm: 'h-8 gap-1 rounded-[min(var(--radius-md),10px)] px-2.5 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5',
-			lg: 'h-10 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2',
-			icon: 'size-9',
-			'icon-xs':
-				"size-6 rounded-[min(var(--radius-md),8px)] in-data-[slot=button-group]:rounded-md [&_svg:not([class*='size-'])]:size-3",
-			'icon-sm':
-				'size-8 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-md',
-			'icon-lg': 'size-10',
+			sm: 'h-[var(--size-control-sm)] px-[9px] text-[var(--text-sm)] rounded-[var(--radius-sm)]',
+			md: 'h-[var(--size-control-md)] px-3 text-[var(--text-md)]',
+			lg: 'h-[var(--size-control-lg)] px-4 text-[var(--text-base)]',
+			icon: 'size-[var(--size-control-md)] p-0',
+			'icon-sm': 'size-[var(--size-control-sm)] p-0',
 		},
 	},
 	defaultVariants: {
-		variant: 'default',
-		size: 'default',
+		variant: 'primary',
+		size: 'md',
 	},
 });
 

--- a/src/lib/modules/board/board.context.svelte.ts
+++ b/src/lib/modules/board/board.context.svelte.ts
@@ -17,9 +17,11 @@ import type {
 	AddRepoToPortfolioRequest,
 	ViewMode,
 	ThemeMode,
+	AccentColor,
 } from './types.js';
 import {
 	isThemeMode,
+	isAccentColor,
 	isViewMode,
 	findPaletteForDashboard,
 	selectActiveDashboardId,
@@ -77,6 +79,12 @@ function createBoardContext() {
 		defaultValue: 'system',
 	});
 
+	const accentColor = new Persisted<AccentColor>({
+		key: 'grovekeeper_accent_color',
+		serde: stringSerde(isAccentColor),
+		defaultValue: 'moss',
+	});
+
 	const prefersDark = browser ? new MediaQuery('(prefers-color-scheme: dark)') : null;
 
 	const isDark = $derived.by(() => {
@@ -88,7 +96,8 @@ function createBoardContext() {
 
 	$effect.pre(() => {
 		if (browser) {
-			document.documentElement.classList.toggle('dark', isDark);
+			document.documentElement.dataset.theme = isDark ? 'dark' : 'light';
+			document.documentElement.dataset.accent = accentColor.current;
 		}
 	});
 
@@ -285,6 +294,12 @@ function createBoardContext() {
 				},
 				get prefersDark() {
 					return prefersDark?.current ?? true;
+				},
+				get accent() {
+					return accentColor.current;
+				},
+				set accent(value: AccentColor) {
+					accentColor.current = value;
 				},
 			};
 		},

--- a/src/lib/modules/board/index.ts
+++ b/src/lib/modules/board/index.ts
@@ -12,4 +12,6 @@ export type {
 	AddRepoToPortfolioRequest,
 	ViewMode,
 	ThemeMode,
+	AccentColor,
 } from './types.js';
+export { ACCENT_COLORS } from './types.js';

--- a/src/lib/modules/board/types.ts
+++ b/src/lib/modules/board/types.ts
@@ -50,10 +50,18 @@ export type ViewMode = 'cards' | 'forest';
 /** @public */
 export type ThemeMode = 'dark' | 'light' | 'system';
 
+export const ACCENT_COLORS = ['moss', 'amber', 'bark', 'azure'] as const;
+/** @public */
+export type AccentColor = (typeof ACCENT_COLORS)[number];
+
 // ─── Type guards ──────────────────────────────────────────────────────────
 
 export function isThemeMode(value: unknown): value is ThemeMode {
 	return value === 'dark' || value === 'light' || value === 'system';
+}
+
+export function isAccentColor(value: unknown): value is AccentColor {
+	return typeof value === 'string' && ACCENT_COLORS.includes(value as AccentColor);
 }
 
 export function isViewMode(value: unknown): value is ViewMode {

--- a/src/lib/storybook/ThemeDecorator.svelte
+++ b/src/lib/storybook/ThemeDecorator.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { setBoardContext, useBoard } from '$lib/modules/board';
+	import { setBoardContext, useBoard, ACCENT_COLORS } from '$lib/modules/board';
 	import type { Snippet } from 'svelte';
 
 	let { children }: { children: Snippet } = $props();
@@ -9,33 +9,52 @@
 	const theme = boardStore.theme;
 </script>
 
-<div class="flex flex-col gap-4 p-4" class:dark={theme.isDark}>
-	<div class="flex items-center gap-2 border-b border-border pb-3">
-		<span class="text-sm font-medium text-muted-foreground">Theme:</span>
-		<button
-			class="rounded px-2 py-1 text-xs {theme.mode === 'light'
-				? 'bg-primary text-primary-foreground'
-				: 'bg-muted text-muted-foreground'}"
-			onclick={() => (theme.mode = 'light')}
-		>
-			Light
-		</button>
-		<button
-			class="rounded px-2 py-1 text-xs {theme.mode === 'dark'
-				? 'bg-primary text-primary-foreground'
-				: 'bg-muted text-muted-foreground'}"
-			onclick={() => (theme.mode = 'dark')}
-		>
-			Dark
-		</button>
-		<button
-			class="rounded px-2 py-1 text-xs {theme.mode === 'system'
-				? 'bg-primary text-primary-foreground'
-				: 'bg-muted text-muted-foreground'}"
-			onclick={() => (theme.mode = 'system')}
-		>
-			System
-		</button>
+<div
+	class="flex flex-col gap-4 p-4"
+	data-theme={theme.isDark ? 'dark' : 'light'}
+	data-accent={theme.accent}
+>
+	<div class="flex items-center gap-4 border-b border-border pb-3">
+		<div class="flex items-center gap-2">
+			<span class="text-sm font-medium text-muted-foreground">Theme:</span>
+			<button
+				class="rounded px-2 py-1 text-xs {theme.mode === 'light'
+					? 'bg-primary text-primary-foreground'
+					: 'bg-muted text-muted-foreground'}"
+				onclick={() => (theme.mode = 'light')}
+			>
+				Light
+			</button>
+			<button
+				class="rounded px-2 py-1 text-xs {theme.mode === 'dark'
+					? 'bg-primary text-primary-foreground'
+					: 'bg-muted text-muted-foreground'}"
+				onclick={() => (theme.mode = 'dark')}
+			>
+				Dark
+			</button>
+			<button
+				class="rounded px-2 py-1 text-xs {theme.mode === 'system'
+					? 'bg-primary text-primary-foreground'
+					: 'bg-muted text-muted-foreground'}"
+				onclick={() => (theme.mode = 'system')}
+			>
+				System
+			</button>
+		</div>
+		<div class="flex items-center gap-2">
+			<span class="text-sm font-medium text-muted-foreground">Accent:</span>
+			{#each ACCENT_COLORS as accent (accent)}
+				<button
+					class="rounded px-2 py-1 text-xs capitalize {theme.accent === accent
+						? 'bg-primary text-primary-foreground'
+						: 'bg-muted text-muted-foreground'}"
+					onclick={() => (theme.accent = accent)}
+				>
+					{accent}
+				</button>
+			{/each}
+		</div>
 	</div>
 	<div class="rounded-lg bg-background p-6 text-foreground">
 		{@render children()}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import 'geist/font/sans.css';
-	import 'geist/font/mono.css';
+	import '@fontsource/geist';
+	import '@fontsource/geist-mono';
 	import '../app.css';
 	import { onMount } from 'svelte';
 	import DashboardSidebar from '$lib/components/DashboardSidebar.svelte';

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import 'geist/font/sans.css';
+	import 'geist/font/mono.css';
 	import '../app.css';
 	import { onMount } from 'svelte';
 	import DashboardSidebar from '$lib/components/DashboardSidebar.svelte';


### PR DESCRIPTION
## Description
- Tracer bullet for design system: replaces shadcn default zinc with Grovekeeper Forest Moss palette using OKLCH tokens
- Dark/light theme switching via `data-theme` attribute (replacing `.dark` class) with token-based values
- Accent color switching via `data-accent` attribute supporting moss/amber/bark/azure variants
- Rebuilt Button component with primary/secondary/ghost/danger variants and sm/md/lg sizes
- Geist Sans and Mono fonts installed and configured for typography
- Z-index scale, shadows, radii, and motion tokens defined in Tailwind 4 @theme format
- Board context updated to use dataset API for theme/accent management

## Resolves
Closes #97

## Testing
- [ ] Theme switching (data-theme attribute) works in browser devtools
- [ ] Accent color switching (data-accent attribute) toggles correctly
- [ ] Button variants and sizes render as expected
- [ ] Fonts display correctly in Storybook