### PR TITLE
#98 feat: add form components with Storybook stories

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
 	},
 	"devDependencies": {
 		"@chromatic-com/storybook": "^5.1.1",
+		"@lucide/svelte": "^1.14.0",
 		"@playwright/test": "^1.58.2",
 		"@storybook/addon-a11y": "^10.3.3",
 		"@storybook/addon-docs": "^10.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
             '@chromatic-com/storybook':
                 specifier: ^5.1.1
                 version: 5.1.1(storybook@10.3.3(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+            '@lucide/svelte':
+                specifier: ^1.14.0
+                version: 1.14.0(svelte@5.55.0)
             '@playwright/test':
                 specifier: ^1.58.2
                 version: 1.58.2
@@ -1016,6 +1019,14 @@ packages:
             {
                 integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==,
             }
+
+    '@lucide/svelte@1.14.0':
+        resolution:
+            {
+                integrity: sha512-MVuP5VRCBQa2OaIpaRbuEV4k5OV2dy9MyxA6Tf4Sz/IN0v3zzUU72ObHc9r2Zn/wSMXDg6lLrHrczqI7w7gCzQ==,
+            }
+        peerDependencies:
+            svelte: ^5
 
     '@mdx-js/react@3.1.1':
         resolution:
@@ -5197,6 +5208,10 @@ snapshots:
             keyv: 5.6.0
 
     '@keyv/serialize@1.1.1': {}
+
+    '@lucide/svelte@1.14.0(svelte@5.55.0)':
+        dependencies:
+            svelte: 5.55.0
 
     '@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4)':
         dependencies:

--- a/src/app.css
+++ b/src/app.css
@@ -88,6 +88,7 @@
 	--duration-3: 160ms;
 	--duration-4: 220ms;
 	--duration-5: 320ms;
+	--animate-shimmer: shimmer 1.4s linear infinite;
 }
 
 :root {
@@ -271,6 +272,15 @@
 	--primary-fg: oklch(0.135 0.02 240);
 	--primary-soft: oklch(0.305 0.055 235);
 	--ring: var(--azure-400);
+}
+
+@keyframes shimmer {
+	from {
+		background-position: 200% 0;
+	}
+	to {
+		background-position: -200% 0;
+	}
 }
 
 @layer base {

--- a/src/app.css
+++ b/src/app.css
@@ -278,6 +278,7 @@
 	from {
 		background-position: 200% 0;
 	}
+
 	to {
 		background-position: -200% 0;
 	}

--- a/src/lib/components/ui/checkbox/Checkbox.stories.svelte
+++ b/src/lib/components/ui/checkbox/Checkbox.stories.svelte
@@ -1,0 +1,99 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import { Checkbox } from './index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import ThemeDecorator from '$lib/storybook/ThemeDecorator.svelte';
+
+	const { Story } = defineMeta({
+		title: 'UI/Checkbox',
+		component: Checkbox,
+		// @ts-expect-error — Storybook decorator typing doesn't match Svelte 5 Component type
+		decorators: [() => ThemeDecorator],
+		tags: ['autodocs'],
+		argTypes: {
+			checked: { control: 'boolean' },
+			indeterminate: { control: 'boolean' },
+			disabled: { control: 'boolean' },
+		},
+	});
+</script>
+
+<script lang="ts">
+	import type { CheckboxProps } from './checkbox-variants.js';
+</script>
+
+<Story name="Unchecked">
+	{#snippet template(args: CheckboxProps)}
+		<Checkbox {...args} />
+	{/snippet}
+</Story>
+
+<Story name="Checked">
+	{#snippet template(args: CheckboxProps)}
+		<Checkbox checked {...args} />
+	{/snippet}
+</Story>
+
+<Story name="Indeterminate">
+	{#snippet template(args: CheckboxProps)}
+		<Checkbox indeterminate {...args} />
+	{/snippet}
+</Story>
+
+<Story name="Disabled">
+	{#snippet template(args: CheckboxProps)}
+		<div class="flex items-center gap-4">
+			<Checkbox disabled {...args} />
+			<Checkbox disabled checked {...args} />
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="With Label">
+	{#snippet template(args: CheckboxProps)}
+		<div class="flex items-center gap-2">
+			<Checkbox id="worktree" checked {...args} />
+			<Label for="worktree" class="mb-0 cursor-pointer text-[length:var(--text-md)]"
+				>Auto-create worktree</Label
+			>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="All States">
+	{#snippet template(_args: CheckboxProps)}
+		<div class="grid grid-cols-4 gap-6">
+			<div class="flex flex-col items-center gap-2">
+				<span class="text-xs text-foreground-subtle">Unchecked</span>
+				<Checkbox />
+			</div>
+			<div class="flex flex-col items-center gap-2">
+				<span class="text-xs text-foreground-subtle">Checked</span>
+				<Checkbox checked />
+			</div>
+			<div class="flex flex-col items-center gap-2">
+				<span class="text-xs text-foreground-subtle">Indeterminate</span>
+				<Checkbox indeterminate />
+			</div>
+			<div class="flex flex-col items-center gap-2">
+				<span class="text-xs text-foreground-subtle">Disabled</span>
+				<Checkbox disabled />
+			</div>
+			<div class="flex flex-col items-center gap-2">
+				<span class="text-xs text-foreground-subtle">Disabled + Checked</span>
+				<Checkbox disabled checked />
+			</div>
+			<div class="col-span-3 flex flex-col gap-2">
+				<span class="text-xs text-foreground-subtle">With label</span>
+				<div class="flex items-center gap-2">
+					<Checkbox id="cb-label-demo" checked />
+					<Label
+						for="cb-label-demo"
+						class="mb-0 cursor-pointer text-[length:var(--text-md)]"
+						>Auto-create worktree</Label
+					>
+				</div>
+			</div>
+		</div>
+	{/snippet}
+</Story>

--- a/src/lib/components/ui/checkbox/Checkbox.stories.svelte
+++ b/src/lib/components/ui/checkbox/Checkbox.stories.svelte
@@ -61,11 +61,11 @@
 </Story>
 
 <Story name="All States">
-	{#snippet template(_args: CheckboxProps)}
+	{#snippet template(args: CheckboxProps)}
 		<div class="grid grid-cols-4 gap-6">
 			<div class="flex flex-col items-center gap-2">
 				<span class="text-xs text-foreground-subtle">Unchecked</span>
-				<Checkbox />
+				<Checkbox {...args} />
 			</div>
 			<div class="flex flex-col items-center gap-2">
 				<span class="text-xs text-foreground-subtle">Checked</span>

--- a/src/lib/components/ui/checkbox/Checkbox.svelte
+++ b/src/lib/components/ui/checkbox/Checkbox.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+	import { Checkbox as CheckboxPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+	import CheckIcon from '@lucide/svelte/icons/check';
+	import MinusIcon from '@lucide/svelte/icons/minus';
+	import type { CheckboxProps } from './checkbox-variants.js';
+
+	let {
+		ref = $bindable(null),
+		checked = $bindable(false),
+		indeterminate = $bindable(false),
+		class: className,
+		...restProps
+	}: CheckboxProps = $props();
+</script>
+
+<CheckboxPrimitive.Root
+	bind:ref
+	data-slot="checkbox"
+	class={cn(
+		'flex size-4 shrink-0 cursor-pointer items-center justify-center rounded-[4px] border-[1.5px] border-border-strong bg-surface outline-none transition-[background,border-color] duration-[120ms] ease-[ease] hover:border-ring focus-visible:outline-2 focus-visible:outline-ring focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-40 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground',
+		className,
+	)}
+	bind:checked
+	bind:indeterminate
+	{...restProps}
+>
+	{#snippet children({ checked, indeterminate })}
+		<div
+			data-slot="checkbox-indicator"
+			class="grid place-content-center text-current [&>svg]:size-3"
+		>
+			{#if indeterminate}
+				<MinusIcon />
+			{:else if checked}
+				<CheckIcon />
+			{/if}
+		</div>
+	{/snippet}
+</CheckboxPrimitive.Root>

--- a/src/lib/components/ui/checkbox/checkbox-variants.ts
+++ b/src/lib/components/ui/checkbox/checkbox-variants.ts
@@ -1,0 +1,4 @@
+import type { Checkbox as CheckboxPrimitive } from 'bits-ui';
+import type { WithoutChildrenOrChild } from '$lib/utils.js';
+
+export type CheckboxProps = WithoutChildrenOrChild<CheckboxPrimitive.RootProps>;

--- a/src/lib/components/ui/checkbox/index.ts
+++ b/src/lib/components/ui/checkbox/index.ts
@@ -1,0 +1,5 @@
+import Root from './Checkbox.svelte';
+
+export { Root, Root as Checkbox };
+export { type CheckboxProps } from './checkbox-variants.js';
+export type { CheckboxProps as Props } from './checkbox-variants.js';

--- a/src/lib/components/ui/help-text/HelpText.svelte
+++ b/src/lib/components/ui/help-text/HelpText.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+	import { helpTextVariants, type HelpTextProps } from './help-text-variants.js';
+
+	let {
+		ref = $bindable(null),
+		status = 'default',
+		class: className,
+		children,
+		...restProps
+	}: HelpTextProps = $props();
+</script>
+
+<p
+	bind:this={ref}
+	data-slot="help-text"
+	data-status={status}
+	class={cn(helpTextVariants({ status }), className)}
+	{...restProps}
+>
+	{@render children?.()}
+</p>

--- a/src/lib/components/ui/help-text/help-text-variants.ts
+++ b/src/lib/components/ui/help-text/help-text-variants.ts
@@ -1,0 +1,29 @@
+import type { WithElementRef } from '$lib/utils.js';
+import type { HTMLAttributes } from 'svelte/elements';
+import { tv } from 'tailwind-variants';
+
+export const HELP_TEXT_STATUS = {
+	default: 'default',
+	error: 'error',
+	success: 'success',
+} as const;
+
+export type HelpTextStatus = (typeof HELP_TEXT_STATUS)[keyof typeof HELP_TEXT_STATUS];
+
+export const helpTextVariants = tv({
+	base: 'mt-1 text-[11px] text-foreground-subtle',
+	variants: {
+		status: {
+			default: '',
+			error: 'text-status-danger',
+			success: 'text-status-success',
+		},
+	},
+	defaultVariants: {
+		status: 'default',
+	},
+});
+
+export type HelpTextProps = WithElementRef<HTMLAttributes<HTMLParagraphElement>> & {
+	status?: HelpTextStatus;
+};

--- a/src/lib/components/ui/help-text/index.ts
+++ b/src/lib/components/ui/help-text/index.ts
@@ -1,0 +1,10 @@
+import Root from './HelpText.svelte';
+
+export { Root, Root as HelpText };
+export {
+	HELP_TEXT_STATUS,
+	helpTextVariants,
+	type HelpTextProps,
+	type HelpTextStatus,
+} from './help-text-variants.js';
+export type { HelpTextProps as Props } from './help-text-variants.js';

--- a/src/lib/components/ui/input/Input.stories.svelte
+++ b/src/lib/components/ui/input/Input.stories.svelte
@@ -87,11 +87,11 @@
 </Story>
 
 <Story name="All States">
-	{#snippet template(_args: InputProps)}
+	{#snippet template(args: InputProps)}
 		<div class="grid max-w-2xl grid-cols-3 gap-4">
 			<div>
 				<Label>Default</Label>
-				<Input placeholder="Branch name" />
+				<Input placeholder="Branch name" {...args} />
 			</div>
 			<div>
 				<Label>Filled</Label>

--- a/src/lib/components/ui/input/Input.stories.svelte
+++ b/src/lib/components/ui/input/Input.stories.svelte
@@ -1,0 +1,128 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import { Input } from './index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import { HelpText } from '$lib/components/ui/help-text/index.js';
+	import ThemeDecorator from '$lib/storybook/ThemeDecorator.svelte';
+
+	const { Story } = defineMeta({
+		title: 'UI/Input',
+		component: Input,
+		// @ts-expect-error — Storybook decorator typing doesn't match Svelte 5 Component type
+		decorators: [() => ThemeDecorator],
+		tags: ['autodocs'],
+		argTypes: {
+			state: {
+				control: 'select',
+				options: ['default', 'success', 'error', 'loading'],
+			},
+			disabled: { control: 'boolean' },
+			readonly: { control: 'boolean' },
+		},
+	});
+</script>
+
+<script lang="ts">
+	import type { InputProps } from './input-variants.js';
+</script>
+
+<Story name="Default" args={{ state: 'default' }}>
+	{#snippet template(args: InputProps)}
+		<div class="max-w-xs">
+			<Input placeholder="Branch name" {...args} />
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Filled">
+	{#snippet template(args: InputProps)}
+		<div class="max-w-xs">
+			<Input value="feat/forest-overlays" {...args} />
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Success">
+	{#snippet template(args: InputProps)}
+		<div class="max-w-xs">
+			<Label for="success-demo">Branch name</Label>
+			<Input id="success-demo" state="success" value="feat/valid-name" {...args} />
+			<HelpText status="success">Branch is available.</HelpText>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Error">
+	{#snippet template(args: InputProps)}
+		<div class="max-w-xs">
+			<Label for="error-demo">Branch name</Label>
+			<Input id="error-demo" state="error" value="feat/forest overlays" {...args} />
+			<HelpText status="error">Branch names cannot contain spaces.</HelpText>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Disabled">
+	{#snippet template(args: InputProps)}
+		<div class="max-w-xs">
+			<Input disabled value="feat/locked-branch" {...args} />
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Read Only">
+	{#snippet template(args: InputProps)}
+		<div class="max-w-xs">
+			<Input readonly value="main" {...args} />
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Loading">
+	{#snippet template(args: InputProps)}
+		<div class="max-w-xs">
+			<Input state="loading" value="resolving…" {...args} />
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="All States">
+	{#snippet template(_args: InputProps)}
+		<div class="grid max-w-2xl grid-cols-3 gap-4">
+			<div>
+				<Label>Default</Label>
+				<Input placeholder="Branch name" />
+			</div>
+			<div>
+				<Label>Filled</Label>
+				<Input value="feat/forest-overlays" />
+			</div>
+			<div>
+				<Label>Focus (interact)</Label>
+				<Input value="feat/forest-overlays" />
+			</div>
+			<div>
+				<Label>Success</Label>
+				<Input state="success" value="feat/valid-name" />
+				<HelpText status="success">Branch is available.</HelpText>
+			</div>
+			<div>
+				<Label>Error</Label>
+				<Input state="error" value="feat/forest overlays" />
+				<HelpText status="error">Branch names cannot contain spaces.</HelpText>
+			</div>
+			<div>
+				<Label>Disabled</Label>
+				<Input disabled value="feat/locked-branch" />
+			</div>
+			<div>
+				<Label>Read-only</Label>
+				<Input readonly value="main" />
+			</div>
+			<div>
+				<Label>Loading</Label>
+				<Input state="loading" value="resolving…" />
+			</div>
+		</div>
+	{/snippet}
+</Story>

--- a/src/lib/components/ui/input/Input.svelte
+++ b/src/lib/components/ui/input/Input.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+	import { inputVariants, type InputProps } from './input-variants.js';
+
+	let {
+		ref = $bindable(null),
+		value = $bindable(),
+		state = 'default',
+		class: className,
+		...restProps
+	}: InputProps = $props();
+</script>
+
+<input
+	bind:this={ref}
+	bind:value
+	data-slot="input"
+	data-state={state}
+	aria-invalid={state === 'error' ? true : undefined}
+	class={cn(inputVariants({ state }), className)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/input/index.ts
+++ b/src/lib/components/ui/input/index.ts
@@ -1,0 +1,5 @@
+import Root from './Input.svelte';
+
+export { Root, Root as Input };
+export { type InputProps, type InputState, inputVariants } from './input-variants.js';
+export type { InputProps as Props } from './input-variants.js';

--- a/src/lib/components/ui/input/input-variants.ts
+++ b/src/lib/components/ui/input/input-variants.ts
@@ -1,0 +1,33 @@
+import type { WithElementRef, WithoutChildren } from '$lib/utils.js';
+import type { HTMLInputAttributes } from 'svelte/elements';
+import { tv } from 'tailwind-variants';
+
+const INPUT_STATE = {
+	default: 'default',
+	success: 'success',
+	error: 'error',
+	loading: 'loading',
+} as const;
+
+export type InputState = (typeof INPUT_STATE)[keyof typeof INPUT_STATE];
+
+export const inputVariants = tv({
+	base: 'h-[var(--size-control-md)] w-full rounded-[var(--radius-md)] border border-border bg-surface px-2.5 font-sans text-[length:var(--text-md)] text-foreground outline-none transition-[border-color,box-shadow] duration-[120ms] ease-[ease] placeholder:text-foreground-subtle hover:border-border-strong disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-surface-2 disabled:text-foreground-subtle disabled:opacity-70 read-only:bg-surface-2 read-only:text-foreground-muted focus-visible:border-ring focus-visible:shadow-[0_0_0_3px_color-mix(in_oklch,var(--ring)_22%,transparent)]',
+	variants: {
+		state: {
+			default: '',
+			success:
+				'border-status-success shadow-[0_0_0_3px_color-mix(in_oklch,var(--status-success)_18%,transparent)]',
+			error: 'border-status-danger shadow-[0_0_0_3px_color-mix(in_oklch,var(--status-danger)_18%,transparent)]',
+			loading:
+				'animate-shimmer bg-[length:200%_100%] bg-[linear-gradient(90deg,transparent_0%,color-mix(in_oklch,var(--primary)_12%,transparent)_50%,transparent_100%)]',
+		},
+	},
+	defaultVariants: {
+		state: 'default',
+	},
+});
+
+export type InputProps = WithoutChildren<WithElementRef<HTMLInputAttributes>> & {
+	state?: InputState;
+};

--- a/src/lib/components/ui/input/input-variants.ts
+++ b/src/lib/components/ui/input/input-variants.ts
@@ -2,14 +2,7 @@ import type { WithElementRef, WithoutChildren } from '$lib/utils.js';
 import type { HTMLInputAttributes } from 'svelte/elements';
 import { tv } from 'tailwind-variants';
 
-const INPUT_STATE = {
-	default: 'default',
-	success: 'success',
-	error: 'error',
-	loading: 'loading',
-} as const;
-
-export type InputState = (typeof INPUT_STATE)[keyof typeof INPUT_STATE];
+export type InputState = 'default' | 'success' | 'error' | 'loading';
 
 export const inputVariants = tv({
 	base: 'h-[var(--size-control-md)] w-full rounded-[var(--radius-md)] border border-border bg-surface px-2.5 font-sans text-[length:var(--text-md)] text-foreground outline-none transition-[border-color,box-shadow] duration-[120ms] ease-[ease] placeholder:text-foreground-subtle hover:border-border-strong disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-surface-2 disabled:text-foreground-subtle disabled:opacity-70 read-only:bg-surface-2 read-only:text-foreground-muted focus-visible:border-ring focus-visible:shadow-[0_0_0_3px_color-mix(in_oklch,var(--ring)_22%,transparent)]',

--- a/src/lib/components/ui/label/Label.stories.svelte
+++ b/src/lib/components/ui/label/Label.stories.svelte
@@ -1,0 +1,64 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import { Label } from './index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { HelpText } from '$lib/components/ui/help-text/index.js';
+	import ThemeDecorator from '$lib/storybook/ThemeDecorator.svelte';
+
+	const { Story } = defineMeta({
+		title: 'UI/Label',
+		component: Label,
+		// @ts-expect-error — Storybook decorator typing doesn't match Svelte 5 Component type
+		decorators: [() => ThemeDecorator],
+		tags: ['autodocs'],
+	});
+</script>
+
+<script lang="ts">
+	import type { LabelProps } from './label-variants.js';
+</script>
+
+<Story name="Default">
+	{#snippet template(args: LabelProps)}
+		<Label {...args}>Issue title</Label>
+	{/snippet}
+</Story>
+
+<Story name="With Input">
+	{#snippet template(args: LabelProps)}
+		<div class="max-w-xs">
+			<Label for="demo-input" {...args}>Branch name</Label>
+			<Input id="demo-input" placeholder="feat/my-feature" />
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="With HelpText Success">
+	{#snippet template(args: LabelProps)}
+		<div class="max-w-xs">
+			<Label for="success-input" {...args}>Branch name</Label>
+			<Input id="success-input" state="success" value="feat/valid-name" />
+			<HelpText status="success">Branch is available.</HelpText>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="With HelpText Error">
+	{#snippet template(args: LabelProps)}
+		<div class="max-w-xs">
+			<Label for="error-input" {...args}>Branch name</Label>
+			<Input id="error-input" state="error" value="feat/forest overlays" />
+			<HelpText status="error">Branch names cannot contain spaces.</HelpText>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="HelpText Variants">
+	{#snippet template(_args: LabelProps)}
+		<div class="flex flex-col gap-4">
+			<HelpText>Default help text with additional guidance.</HelpText>
+			<HelpText status="success">Branch is available.</HelpText>
+			<HelpText status="error">Branch names cannot contain spaces.</HelpText>
+		</div>
+	{/snippet}
+</Story>

--- a/src/lib/components/ui/label/Label.stories.svelte
+++ b/src/lib/components/ui/label/Label.stories.svelte
@@ -53,8 +53,9 @@
 	{/snippet}
 </Story>
 
+<!-- eslint-disable @typescript-eslint/no-unused-vars -->
 <Story name="HelpText Variants">
-	{#snippet template(_args: LabelProps)}
+	{#snippet template(args: LabelProps)}
 		<div class="flex flex-col gap-4">
 			<HelpText>Default help text with additional guidance.</HelpText>
 			<HelpText status="success">Branch is available.</HelpText>

--- a/src/lib/components/ui/label/Label.svelte
+++ b/src/lib/components/ui/label/Label.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { Label as LabelPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+	import type { LabelProps } from './label-variants.js';
+
+	let { ref = $bindable(null), class: className, ...restProps }: LabelProps = $props();
+</script>
+
+<LabelPrimitive.Root
+	bind:ref
+	data-slot="label"
+	class={cn(
+		'mb-1.5 block text-[length:var(--text-sm)] font-medium leading-none tracking-[0.01em] text-foreground-muted select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50',
+		className,
+	)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/label/index.ts
+++ b/src/lib/components/ui/label/index.ts
@@ -1,0 +1,5 @@
+import Root from './Label.svelte';
+
+export { Root, Root as Label };
+export { type LabelProps } from './label-variants.js';
+export type { LabelProps as Props } from './label-variants.js';

--- a/src/lib/components/ui/label/label-variants.ts
+++ b/src/lib/components/ui/label/label-variants.ts
@@ -1,0 +1,3 @@
+import type { Label as LabelPrimitive } from 'bits-ui';
+
+export type LabelProps = LabelPrimitive.RootProps;

--- a/src/lib/components/ui/radio-group/RadioGroup.stories.svelte
+++ b/src/lib/components/ui/radio-group/RadioGroup.stories.svelte
@@ -87,11 +87,11 @@
 </Story>
 
 <Story name="All States">
-	{#snippet template(_args: RadioGroupProps)}
+	{#snippet template(args: RadioGroupProps)}
 		<div class="grid grid-cols-4 gap-6">
 			<div class="flex flex-col items-center gap-2">
 				<span class="text-xs text-foreground-subtle">Rest</span>
-				<RadioGroup>
+				<RadioGroup {...args}>
 					<RadioGroupItem value="x" />
 				</RadioGroup>
 			</div>

--- a/src/lib/components/ui/radio-group/RadioGroup.stories.svelte
+++ b/src/lib/components/ui/radio-group/RadioGroup.stories.svelte
@@ -1,0 +1,144 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import { RadioGroup, RadioGroupItem } from './index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import ThemeDecorator from '$lib/storybook/ThemeDecorator.svelte';
+
+	const { Story } = defineMeta({
+		title: 'UI/RadioGroup',
+		component: RadioGroup,
+		// @ts-expect-error — Storybook decorator typing doesn't match Svelte 5 Component type
+		decorators: [() => ThemeDecorator],
+		tags: ['autodocs'],
+	});
+</script>
+
+<script lang="ts">
+	import type { RadioGroupProps } from './radio-group-variants.js';
+</script>
+
+<Story name="Default">
+	{#snippet template(args: RadioGroupProps)}
+		<RadioGroup value="claude" {...args}>
+			<div class="flex items-center gap-2">
+				<RadioGroupItem value="claude" id="r-claude" />
+				<Label for="r-claude" class="mb-0 cursor-pointer text-[length:var(--text-md)]"
+					>Claude</Label
+				>
+			</div>
+			<div class="flex items-center gap-2">
+				<RadioGroupItem value="codex" id="r-codex" />
+				<Label for="r-codex" class="mb-0 cursor-pointer text-[length:var(--text-md)]"
+					>Codex</Label
+				>
+			</div>
+			<div class="flex items-center gap-2">
+				<RadioGroupItem value="cursor" id="r-cursor" />
+				<Label for="r-cursor" class="mb-0 cursor-pointer text-[length:var(--text-md)]"
+					>Cursor</Label
+				>
+			</div>
+		</RadioGroup>
+	{/snippet}
+</Story>
+
+<Story name="Horizontal">
+	{#snippet template(args: RadioGroupProps)}
+		<RadioGroup value="claude" class="flex flex-row gap-4" {...args}>
+			<div class="flex items-center gap-1.5">
+				<RadioGroupItem value="claude" id="rh-claude" />
+				<Label for="rh-claude" class="mb-0 cursor-pointer text-[length:var(--text-md)]"
+					>Claude</Label
+				>
+			</div>
+			<div class="flex items-center gap-1.5">
+				<RadioGroupItem value="codex" id="rh-codex" />
+				<Label for="rh-codex" class="mb-0 cursor-pointer text-[length:var(--text-md)]"
+					>Codex</Label
+				>
+			</div>
+			<div class="flex items-center gap-1.5">
+				<RadioGroupItem value="cursor" id="rh-cursor" />
+				<Label for="rh-cursor" class="mb-0 cursor-pointer text-[length:var(--text-md)]"
+					>Cursor</Label
+				>
+			</div>
+		</RadioGroup>
+	{/snippet}
+</Story>
+
+<Story name="Disabled">
+	{#snippet template(args: RadioGroupProps)}
+		<RadioGroup value="claude" disabled {...args}>
+			<div class="flex items-center gap-2">
+				<RadioGroupItem value="claude" id="rd-claude" />
+				<Label for="rd-claude" class="mb-0 text-[length:var(--text-md)] opacity-40"
+					>Claude</Label
+				>
+			</div>
+			<div class="flex items-center gap-2">
+				<RadioGroupItem value="codex" id="rd-codex" />
+				<Label for="rd-codex" class="mb-0 text-[length:var(--text-md)] opacity-40"
+					>Codex</Label
+				>
+			</div>
+		</RadioGroup>
+	{/snippet}
+</Story>
+
+<Story name="All States">
+	{#snippet template(_args: RadioGroupProps)}
+		<div class="grid grid-cols-4 gap-6">
+			<div class="flex flex-col items-center gap-2">
+				<span class="text-xs text-foreground-subtle">Rest</span>
+				<RadioGroup>
+					<RadioGroupItem value="x" />
+				</RadioGroup>
+			</div>
+			<div class="flex flex-col items-center gap-2">
+				<span class="text-xs text-foreground-subtle">Selected</span>
+				<RadioGroup value="x">
+					<RadioGroupItem value="x" />
+				</RadioGroup>
+			</div>
+			<div class="flex flex-col items-center gap-2">
+				<span class="text-xs text-foreground-subtle">Disabled</span>
+				<RadioGroup disabled>
+					<RadioGroupItem value="x" />
+				</RadioGroup>
+			</div>
+			<div class="flex flex-col items-center gap-2">
+				<span class="text-xs text-foreground-subtle">Disabled + Selected</span>
+				<RadioGroup value="x" disabled>
+					<RadioGroupItem value="x" />
+				</RadioGroup>
+			</div>
+			<div class="col-span-4 flex flex-col gap-2">
+				<span class="text-xs text-foreground-subtle">Group</span>
+				<RadioGroup value="claude" class="flex flex-row gap-4">
+					<div class="flex items-center gap-1.5">
+						<RadioGroupItem value="claude" id="rs-claude" />
+						<Label
+							for="rs-claude"
+							class="mb-0 cursor-pointer text-[length:var(--text-md)]">Claude</Label
+						>
+					</div>
+					<div class="flex items-center gap-1.5">
+						<RadioGroupItem value="codex" id="rs-codex" />
+						<Label
+							for="rs-codex"
+							class="mb-0 cursor-pointer text-[length:var(--text-md)]">Codex</Label
+						>
+					</div>
+					<div class="flex items-center gap-1.5">
+						<RadioGroupItem value="cursor" id="rs-cursor" />
+						<Label
+							for="rs-cursor"
+							class="mb-0 cursor-pointer text-[length:var(--text-md)]">Cursor</Label
+						>
+					</div>
+				</RadioGroup>
+			</div>
+		</div>
+	{/snippet}
+</Story>

--- a/src/lib/components/ui/radio-group/RadioGroup.svelte
+++ b/src/lib/components/ui/radio-group/RadioGroup.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		value = $bindable(undefined),
+		value = $bindable(''),
 		class: className,
 		children,
 		...restProps

--- a/src/lib/components/ui/radio-group/RadioGroup.svelte
+++ b/src/lib/components/ui/radio-group/RadioGroup.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import { RadioGroup as RadioGroupPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+	import type { RadioGroupProps } from './radio-group-variants.js';
+
+	let {
+		ref = $bindable(null),
+		value = $bindable(undefined),
+		class: className,
+		children,
+		...restProps
+	}: RadioGroupProps = $props();
+</script>
+
+<RadioGroupPrimitive.Root
+	bind:ref
+	bind:value
+	data-slot="radio-group"
+	class={cn('flex flex-col gap-3', className)}
+	{...restProps}
+>
+	{@render children?.()}
+</RadioGroupPrimitive.Root>

--- a/src/lib/components/ui/radio-group/RadioGroupItem.svelte
+++ b/src/lib/components/ui/radio-group/RadioGroupItem.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import { RadioGroup as RadioGroupPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+	import type { RadioGroupItemProps } from './radio-group-variants.js';
+
+	let {
+		ref = $bindable(null),
+		value,
+		class: className,
+		...restProps
+	}: RadioGroupItemProps = $props();
+</script>
+
+<RadioGroupPrimitive.Item
+	bind:ref
+	{value}
+	data-slot="radio-group-item"
+	class={cn(
+		'relative size-4 shrink-0 cursor-pointer rounded-full border-[1.5px] border-border-strong bg-surface outline-none transition-[border-color] duration-[120ms] after:absolute after:inset-[3px] after:rounded-full after:bg-primary after:opacity-0 after:transition-opacity after:duration-[120ms] hover:border-ring focus-visible:outline-2 focus-visible:outline-ring focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-40 data-checked:border-primary data-checked:after:opacity-100',
+		className,
+	)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/radio-group/index.ts
+++ b/src/lib/components/ui/radio-group/index.ts
@@ -1,0 +1,5 @@
+import Root from './RadioGroup.svelte';
+import Item from './RadioGroupItem.svelte';
+
+export { Root, Root as RadioGroup, Item, Item as RadioGroupItem };
+export { type RadioGroupProps, type RadioGroupItemProps } from './radio-group-variants.js';

--- a/src/lib/components/ui/radio-group/radio-group-variants.ts
+++ b/src/lib/components/ui/radio-group/radio-group-variants.ts
@@ -1,0 +1,6 @@
+import type { RadioGroup as RadioGroupPrimitive } from 'bits-ui';
+import type { WithoutChildrenOrChild } from '$lib/utils.js';
+
+export type RadioGroupProps = RadioGroupPrimitive.RootProps;
+
+export type RadioGroupItemProps = WithoutChildrenOrChild<RadioGroupPrimitive.ItemProps>;

--- a/src/lib/components/ui/search-field/SearchField.stories.svelte
+++ b/src/lib/components/ui/search-field/SearchField.stories.svelte
@@ -1,0 +1,135 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import { SearchField } from './index.js';
+	import ThemeDecorator from '$lib/storybook/ThemeDecorator.svelte';
+
+	const { Story } = defineMeta({
+		title: 'UI/SearchField',
+		component: SearchField,
+		// @ts-expect-error — Storybook decorator typing doesn't match Svelte 5 Component type
+		decorators: [() => ThemeDecorator],
+		tags: ['autodocs'],
+	});
+</script>
+
+<script lang="ts">
+	import type { SearchFieldProps } from './search-field-variants.js';
+	import TreesIcon from '@lucide/svelte/icons/trees';
+	import GitBranchIcon from '@lucide/svelte/icons/git-branch';
+</script>
+
+<Story name="Rest">
+	{#snippet template(args: SearchFieldProps)}
+		<div class="max-w-xs">
+			<SearchField placeholder="Search issues, branches…" {...args} />
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Typing With Results">
+	{#snippet template(_args: SearchFieldProps)}
+		<div class="max-w-xs">
+			<SearchField value="forest">
+				<div
+					class="mt-1.5 max-h-[320px] overflow-auto rounded-[var(--radius-md)] border border-border bg-surface p-1.5 shadow-lg"
+				>
+					<div
+						class="px-2 py-1.5 text-[10.5px] font-semibold uppercase tracking-[0.06em] text-foreground-subtle"
+					>
+						Issues
+					</div>
+					<div
+						class="flex cursor-pointer items-center gap-2 rounded-[4px] bg-primary-soft px-2 py-1.5 text-[12.5px] text-foreground"
+					>
+						<TreesIcon class="size-3" />
+						#118 · Forest view overlays
+						<span
+							class="ml-auto inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-[4px] border border-border bg-surface-2 px-[5px] font-mono text-[10.5px] text-foreground-muted"
+							>↵</span
+						>
+					</div>
+					<div
+						class="flex cursor-pointer items-center gap-2 rounded-[4px] px-2 py-1.5 text-[12.5px] text-foreground hover:bg-surface-2"
+					>
+						<TreesIcon class="size-3" />
+						#128 · Forest tag centering
+					</div>
+					<div
+						class="px-2 py-1.5 text-[10.5px] font-semibold uppercase tracking-[0.06em] text-foreground-subtle"
+					>
+						Branches
+					</div>
+					<div
+						class="flex cursor-pointer items-center gap-2 rounded-[4px] px-2 py-1.5 text-[12.5px] text-foreground hover:bg-surface-2"
+					>
+						<GitBranchIcon class="size-3" />
+						feat/forest-overlays
+					</div>
+				</div>
+			</SearchField>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="No Results">
+	{#snippet template(_args: SearchFieldProps)}
+		<div class="max-w-xs">
+			<SearchField value="qqzzqz">
+				<div
+					class="mt-1.5 rounded-[var(--radius-md)] border border-border bg-surface p-[18px] text-center shadow-lg"
+				>
+					<span class="text-[11px] text-foreground-subtle">No matches for "qqzzqz".</span>
+				</div>
+			</SearchField>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="All States">
+	{#snippet template(_args: SearchFieldProps)}
+		<div class="grid max-w-2xl grid-cols-3 items-start gap-4">
+			<div>
+				<span class="mb-2 block text-xs text-foreground-subtle">Rest</span>
+				<SearchField placeholder="Search issues, branches…" />
+			</div>
+			<div>
+				<span class="mb-2 block text-xs text-foreground-subtle">Typing + results</span>
+				<SearchField value="forest">
+					<div
+						class="mt-1.5 max-h-[320px] overflow-auto rounded-[var(--radius-md)] border border-border bg-surface p-1.5 shadow-lg"
+					>
+						<div
+							class="px-2 py-1.5 text-[10.5px] font-semibold uppercase tracking-[0.06em] text-foreground-subtle"
+						>
+							Issues
+						</div>
+						<div
+							class="flex cursor-pointer items-center gap-2 rounded-[4px] bg-primary-soft px-2 py-1.5 text-[12.5px] text-foreground"
+						>
+							<TreesIcon class="size-3" />
+							#118 · Forest view overlays
+						</div>
+						<div
+							class="flex cursor-pointer items-center gap-2 rounded-[4px] px-2 py-1.5 text-[12.5px] text-foreground hover:bg-surface-2"
+						>
+							<TreesIcon class="size-3" />
+							#128 · Forest tag centering
+						</div>
+					</div>
+				</SearchField>
+			</div>
+			<div>
+				<span class="mb-2 block text-xs text-foreground-subtle">No results</span>
+				<SearchField value="qqzzqz">
+					<div
+						class="mt-1.5 rounded-[var(--radius-md)] border border-border bg-surface p-[18px] text-center shadow-lg"
+					>
+						<span class="text-[11px] text-foreground-subtle"
+							>No matches for "qqzzqz".</span
+						>
+					</div>
+				</SearchField>
+			</div>
+		</div>
+	{/snippet}
+</Story>

--- a/src/lib/components/ui/search-field/SearchField.stories.svelte
+++ b/src/lib/components/ui/search-field/SearchField.stories.svelte
@@ -27,9 +27,9 @@
 </Story>
 
 <Story name="Typing With Results">
-	{#snippet template(_args: SearchFieldProps)}
+	{#snippet template(args: SearchFieldProps)}
 		<div class="max-w-xs">
-			<SearchField value="forest">
+			<SearchField value="forest" {...args}>
 				<div
 					class="mt-1.5 max-h-[320px] overflow-auto rounded-[var(--radius-md)] border border-border bg-surface p-1.5 shadow-lg"
 				>
@@ -72,9 +72,9 @@
 </Story>
 
 <Story name="No Results">
-	{#snippet template(_args: SearchFieldProps)}
+	{#snippet template(args: SearchFieldProps)}
 		<div class="max-w-xs">
-			<SearchField value="qqzzqz">
+			<SearchField value="qqzzqz" {...args}>
 				<div
 					class="mt-1.5 rounded-[var(--radius-md)] border border-border bg-surface p-[18px] text-center shadow-lg"
 				>
@@ -86,11 +86,11 @@
 </Story>
 
 <Story name="All States">
-	{#snippet template(_args: SearchFieldProps)}
+	{#snippet template(args: SearchFieldProps)}
 		<div class="grid max-w-2xl grid-cols-3 items-start gap-4">
 			<div>
 				<span class="mb-2 block text-xs text-foreground-subtle">Rest</span>
-				<SearchField placeholder="Search issues, branches…" />
+				<SearchField placeholder="Search issues, branches…" {...args} />
 			</div>
 			<div>
 				<span class="mb-2 block text-xs text-foreground-subtle">Typing + results</span>

--- a/src/lib/components/ui/search-field/SearchField.svelte
+++ b/src/lib/components/ui/search-field/SearchField.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+	import { inputVariants } from '$lib/components/ui/input/input-variants.js';
+	import SearchIcon from '@lucide/svelte/icons/search';
+	import type { SearchFieldProps } from './search-field-variants.js';
+
+	let {
+		ref = $bindable(null),
+		value = $bindable(),
+		children,
+		class: className,
+		...restProps
+	}: SearchFieldProps = $props();
+</script>
+
+<div class="relative" data-slot="search-field">
+	<SearchIcon
+		class="pointer-events-none absolute left-2.5 top-[9px] size-[13px] text-foreground-subtle"
+	/>
+	<input
+		bind:this={ref}
+		bind:value
+		data-slot="search-field-input"
+		class={cn(inputVariants(), 'pl-[30px]', className)}
+		type="search"
+		{...restProps}
+	/>
+	{#if children}
+		{@render children()}
+	{/if}
+</div>

--- a/src/lib/components/ui/search-field/index.ts
+++ b/src/lib/components/ui/search-field/index.ts
@@ -1,0 +1,5 @@
+import Root from './SearchField.svelte';
+
+export { Root, Root as SearchField };
+export { type SearchFieldProps } from './search-field-variants.js';
+export type { SearchFieldProps as Props } from './search-field-variants.js';

--- a/src/lib/components/ui/search-field/search-field-variants.ts
+++ b/src/lib/components/ui/search-field/search-field-variants.ts
@@ -1,0 +1,9 @@
+import type { WithElementRef } from '$lib/utils.js';
+import type { HTMLInputAttributes } from 'svelte/elements';
+import type { Snippet } from 'svelte';
+
+type InputWithoutResults = Omit<HTMLInputAttributes, 'results'>;
+
+export type SearchFieldProps = WithElementRef<InputWithoutResults> & {
+	children?: Snippet;
+};

--- a/src/lib/components/ui/select/Select.stories.svelte
+++ b/src/lib/components/ui/select/Select.stories.svelte
@@ -77,8 +77,9 @@
 	{/snippet}
 </Story>
 
+<!-- eslint-disable @typescript-eslint/no-unused-vars -->
 <Story name="Custom Open Dropdown">
-	{#snippet template(_args: SelectProps)}
+	{#snippet template(args: SelectProps)}
 		<div class="relative max-w-[280px]">
 			<Label>Provider</Label>
 			<button
@@ -120,11 +121,11 @@
 </Story>
 
 <Story name="All States">
-	{#snippet template(_args: SelectProps)}
+	{#snippet template(args: SelectProps)}
 		<div class="grid max-w-2xl grid-cols-3 gap-4">
 			<div>
 				<Label>Default</Label>
-				<Select>
+				<Select {...args}>
 					<option>Choose provider…</option>
 				</Select>
 			</div>

--- a/src/lib/components/ui/select/Select.stories.svelte
+++ b/src/lib/components/ui/select/Select.stories.svelte
@@ -1,0 +1,158 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import { Select } from './index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import { HelpText } from '$lib/components/ui/help-text/index.js';
+	import ThemeDecorator from '$lib/storybook/ThemeDecorator.svelte';
+
+	const { Story } = defineMeta({
+		title: 'UI/Select',
+		component: Select,
+		// @ts-expect-error — Storybook decorator typing doesn't match Svelte 5 Component type
+		decorators: [() => ThemeDecorator],
+		tags: ['autodocs'],
+		argTypes: {
+			state: {
+				control: 'select',
+				options: ['default', 'error'],
+			},
+			disabled: { control: 'boolean' },
+		},
+	});
+</script>
+
+<script lang="ts">
+	import type { SelectProps } from './select-variants.js';
+	import CheckIcon from '@lucide/svelte/icons/check';
+	import ChevronDownIcon from '@lucide/svelte/icons/chevron-down';
+</script>
+
+<Story name="Default">
+	{#snippet template(args: SelectProps)}
+		<div class="max-w-xs">
+			<Label for="prov">Provider</Label>
+			<Select id="prov" {...args}>
+				<option value="">Choose provider…</option>
+				<option value="claude">Claude · Sonnet 4.5</option>
+				<option value="codex">Codex · gpt-5</option>
+				<option value="cursor">Cursor · auto</option>
+			</Select>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="With Value">
+	{#snippet template(args: SelectProps)}
+		<div class="max-w-xs">
+			<Label for="val">Provider</Label>
+			<Select id="val" value="claude" {...args}>
+				<option value="claude">Claude · Sonnet 4.5</option>
+				<option value="codex">Codex · gpt-5</option>
+				<option value="cursor">Cursor · auto</option>
+			</Select>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Error">
+	{#snippet template(args: SelectProps)}
+		<div class="max-w-xs">
+			<Label for="err-sel">Provider</Label>
+			<Select id="err-sel" state="error" value="" {...args}>
+				<option value="">No provider configured</option>
+			</Select>
+			<HelpText status="error">Add a provider in Settings.</HelpText>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Disabled">
+	{#snippet template(args: SelectProps)}
+		<div class="max-w-xs">
+			<Label for="dis-sel">Provider</Label>
+			<Select id="dis-sel" disabled value="claude" {...args}>
+				<option value="claude">Claude · Sonnet 4.5</option>
+			</Select>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Custom Open Dropdown">
+	{#snippet template(_args: SelectProps)}
+		<div class="relative max-w-[280px]">
+			<Label>Provider</Label>
+			<button
+				class="flex h-[var(--size-control-md)] w-full cursor-default items-center justify-between rounded-[var(--radius-md)] border border-ring bg-surface px-2.5 text-left font-sans text-[length:var(--text-md)] text-foreground shadow-[0_0_0_3px_color-mix(in_oklch,var(--ring)_22%,transparent)] outline-none"
+			>
+				<span>Claude · Sonnet 4.5</span>
+				<ChevronDownIcon class="size-3.5 text-foreground-subtle" />
+			</button>
+			<div
+				class="mt-1.5 rounded-[var(--radius-lg)] border border-border bg-surface p-2 shadow-lg"
+			>
+				<div
+					class="flex cursor-pointer items-center gap-2 rounded-[6px] bg-primary-soft px-2 py-1.5 text-[length:var(--text-md)] text-foreground"
+				>
+					<CheckIcon class="size-[11px]" />
+					Claude · Sonnet 4.5
+				</div>
+				<div
+					class="flex cursor-pointer items-center gap-2 rounded-[6px] px-2 py-1.5 text-[length:var(--text-md)] text-foreground hover:bg-surface-2"
+				>
+					<span class="inline-block w-[11px]"></span>
+					Claude · Haiku 4.5
+				</div>
+				<div
+					class="flex cursor-pointer items-center gap-2 rounded-[6px] px-2 py-1.5 text-[length:var(--text-md)] text-foreground hover:bg-surface-2"
+				>
+					<span class="inline-block w-[11px]"></span>
+					Codex · gpt-5
+				</div>
+				<div
+					class="flex cursor-pointer items-center gap-2 rounded-[6px] px-2 py-1.5 text-[length:var(--text-md)] text-foreground hover:bg-surface-2"
+				>
+					<span class="inline-block w-[11px]"></span>
+					Cursor · auto
+				</div>
+			</div>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="All States">
+	{#snippet template(_args: SelectProps)}
+		<div class="grid max-w-2xl grid-cols-3 gap-4">
+			<div>
+				<Label>Default</Label>
+				<Select>
+					<option>Choose provider…</option>
+				</Select>
+			</div>
+			<div>
+				<Label>Value</Label>
+				<Select value="claude">
+					<option value="claude">Claude · Sonnet 4.5</option>
+				</Select>
+			</div>
+			<div>
+				<Label>Focus (interact)</Label>
+				<Select value="claude">
+					<option value="claude">Claude · Sonnet 4.5</option>
+				</Select>
+			</div>
+			<div>
+				<Label>Disabled</Label>
+				<Select disabled value="claude">
+					<option value="claude">Claude · Sonnet 4.5</option>
+				</Select>
+			</div>
+			<div>
+				<Label>Error</Label>
+				<Select state="error" value="">
+					<option value="">No provider configured</option>
+				</Select>
+				<HelpText status="error">Add a provider in Settings.</HelpText>
+			</div>
+		</div>
+	{/snippet}
+</Story>

--- a/src/lib/components/ui/select/Select.svelte
+++ b/src/lib/components/ui/select/Select.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+	import { selectVariants, type SelectProps } from './select-variants.js';
+
+	let {
+		ref = $bindable(null),
+		value = $bindable(),
+		state = 'default',
+		class: className,
+		children,
+		...restProps
+	}: SelectProps = $props();
+</script>
+
+<select
+	bind:this={ref}
+	bind:value
+	data-slot="select"
+	data-state={state}
+	aria-invalid={state === 'error' ? true : undefined}
+	class={cn(selectVariants({ state }), className)}
+	{...restProps}
+>
+	{@render children?.()}
+</select>

--- a/src/lib/components/ui/select/index.ts
+++ b/src/lib/components/ui/select/index.ts
@@ -1,0 +1,5 @@
+import Root from './Select.svelte';
+
+export { Root, Root as Select };
+export { type SelectProps, type SelectState, selectVariants } from './select-variants.js';
+export type { SelectProps as Props } from './select-variants.js';

--- a/src/lib/components/ui/select/select-variants.ts
+++ b/src/lib/components/ui/select/select-variants.ts
@@ -2,12 +2,7 @@ import type { WithElementRef } from '$lib/utils.js';
 import type { HTMLSelectAttributes } from 'svelte/elements';
 import { tv } from 'tailwind-variants';
 
-const SELECT_STATE = {
-	default: 'default',
-	error: 'error',
-} as const;
-
-export type SelectState = (typeof SELECT_STATE)[keyof typeof SELECT_STATE];
+export type SelectState = 'default' | 'error';
 
 export const selectVariants = tv({
 	base: 'h-[var(--size-control-md)] w-full cursor-pointer appearance-none rounded-[var(--radius-md)] border border-border bg-surface px-2.5 pr-8 font-sans text-[length:var(--text-md)] text-foreground outline-none transition-[border-color,box-shadow] duration-[120ms] ease-[ease] bg-[url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2212%22%20height%3D%2212%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke%3D%22%23999%22%20stroke-width%3D%222%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%3E%3Cpath%20d%3D%22m6%209%206%206%206-6%22%2F%3E%3C%2Fsvg%3E")] bg-[length:14px] bg-[position:right_8px_center] bg-no-repeat hover:border-border-strong disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-surface-2 disabled:text-foreground-subtle disabled:opacity-70 focus-visible:border-ring focus-visible:shadow-[0_0_0_3px_color-mix(in_oklch,var(--ring)_22%,transparent)]',

--- a/src/lib/components/ui/select/select-variants.ts
+++ b/src/lib/components/ui/select/select-variants.ts
@@ -1,0 +1,27 @@
+import type { WithElementRef } from '$lib/utils.js';
+import type { HTMLSelectAttributes } from 'svelte/elements';
+import { tv } from 'tailwind-variants';
+
+const SELECT_STATE = {
+	default: 'default',
+	error: 'error',
+} as const;
+
+export type SelectState = (typeof SELECT_STATE)[keyof typeof SELECT_STATE];
+
+export const selectVariants = tv({
+	base: 'h-[var(--size-control-md)] w-full cursor-pointer appearance-none rounded-[var(--radius-md)] border border-border bg-surface px-2.5 pr-8 font-sans text-[length:var(--text-md)] text-foreground outline-none transition-[border-color,box-shadow] duration-[120ms] ease-[ease] bg-[url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2212%22%20height%3D%2212%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke%3D%22%23999%22%20stroke-width%3D%222%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%3E%3Cpath%20d%3D%22m6%209%206%206%206-6%22%2F%3E%3C%2Fsvg%3E")] bg-[length:14px] bg-[position:right_8px_center] bg-no-repeat hover:border-border-strong disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-surface-2 disabled:text-foreground-subtle disabled:opacity-70 focus-visible:border-ring focus-visible:shadow-[0_0_0_3px_color-mix(in_oklch,var(--ring)_22%,transparent)]',
+	variants: {
+		state: {
+			default: '',
+			error: 'border-status-danger shadow-[0_0_0_3px_color-mix(in_oklch,var(--status-danger)_18%,transparent)]',
+		},
+	},
+	defaultVariants: {
+		state: 'default',
+	},
+});
+
+export type SelectProps = WithElementRef<HTMLSelectAttributes> & {
+	state?: SelectState;
+};

--- a/src/lib/components/ui/switch/Switch.stories.svelte
+++ b/src/lib/components/ui/switch/Switch.stories.svelte
@@ -57,11 +57,11 @@
 </Story>
 
 <Story name="All States">
-	{#snippet template(_args: SwitchProps)}
+	{#snippet template(args: SwitchProps)}
 		<div class="grid grid-cols-4 gap-6">
 			<div class="flex flex-col items-center gap-2">
 				<span class="text-xs text-foreground-subtle">Off</span>
-				<Switch />
+				<Switch {...args} />
 			</div>
 			<div class="flex flex-col items-center gap-2">
 				<span class="text-xs text-foreground-subtle">On</span>

--- a/src/lib/components/ui/switch/Switch.stories.svelte
+++ b/src/lib/components/ui/switch/Switch.stories.svelte
@@ -1,0 +1,91 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import { Switch } from './index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import ThemeDecorator from '$lib/storybook/ThemeDecorator.svelte';
+
+	const { Story } = defineMeta({
+		title: 'UI/Switch',
+		component: Switch,
+		// @ts-expect-error — Storybook decorator typing doesn't match Svelte 5 Component type
+		decorators: [() => ThemeDecorator],
+		tags: ['autodocs'],
+		argTypes: {
+			checked: { control: 'boolean' },
+			disabled: { control: 'boolean' },
+		},
+	});
+</script>
+
+<script lang="ts">
+	import type { SwitchProps } from './switch-variants.js';
+</script>
+
+<Story name="Off">
+	{#snippet template(args: SwitchProps)}
+		<Switch {...args} />
+	{/snippet}
+</Story>
+
+<Story name="On">
+	{#snippet template(args: SwitchProps)}
+		<Switch checked {...args} />
+	{/snippet}
+</Story>
+
+<Story name="Disabled Off">
+	{#snippet template(args: SwitchProps)}
+		<Switch disabled {...args} />
+	{/snippet}
+</Story>
+
+<Story name="Disabled On">
+	{#snippet template(args: SwitchProps)}
+		<Switch disabled checked {...args} />
+	{/snippet}
+</Story>
+
+<Story name="With Label">
+	{#snippet template(args: SwitchProps)}
+		<div class="flex items-center gap-2.5">
+			<Switch id="auto-fetch" checked {...args} />
+			<Label for="auto-fetch" class="mb-0 cursor-pointer text-[length:var(--text-md)]"
+				>Auto-fetch</Label
+			>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="All States">
+	{#snippet template(_args: SwitchProps)}
+		<div class="grid grid-cols-4 gap-6">
+			<div class="flex flex-col items-center gap-2">
+				<span class="text-xs text-foreground-subtle">Off</span>
+				<Switch />
+			</div>
+			<div class="flex flex-col items-center gap-2">
+				<span class="text-xs text-foreground-subtle">On</span>
+				<Switch checked />
+			</div>
+			<div class="flex flex-col items-center gap-2">
+				<span class="text-xs text-foreground-subtle">Disabled Off</span>
+				<Switch disabled />
+			</div>
+			<div class="flex flex-col items-center gap-2">
+				<span class="text-xs text-foreground-subtle">Disabled On</span>
+				<Switch disabled checked />
+			</div>
+			<div class="col-span-4 flex flex-col gap-2">
+				<span class="text-xs text-foreground-subtle">With label</span>
+				<div class="flex items-center gap-2.5">
+					<Switch id="sw-label-demo" checked />
+					<Label
+						for="sw-label-demo"
+						class="mb-0 cursor-pointer text-[length:var(--text-md)]"
+						>Auto-fetch every 5 min</Label
+					>
+				</div>
+			</div>
+		</div>
+	{/snippet}
+</Story>

--- a/src/lib/components/ui/switch/Switch.svelte
+++ b/src/lib/components/ui/switch/Switch.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+	import { Switch as SwitchPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+	import type { SwitchProps } from './switch-variants.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		checked = $bindable(false),
+		...restProps
+	}: SwitchProps = $props();
+</script>
+
+<SwitchPrimitive.Root
+	bind:ref
+	bind:checked
+	data-slot="switch"
+	class={cn(
+		'peer relative inline-flex h-[18px] w-[32px] shrink-0 cursor-pointer items-center rounded-full border border-border bg-surface-3 px-px outline-none transition-[background,border-color] duration-[120ms] ease-[ease] hover:border-border-strong focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 data-checked:border-primary data-checked:bg-primary data-disabled:cursor-not-allowed data-disabled:opacity-40',
+		className,
+	)}
+	{...restProps}
+>
+	<SwitchPrimitive.Thumb
+		data-slot="switch-thumb"
+		class="pointer-events-none block size-[14px] rounded-full bg-surface shadow-sm transition-transform duration-[140ms] data-checked:translate-x-[14px] data-unchecked:translate-x-0"
+	/>
+</SwitchPrimitive.Root>

--- a/src/lib/components/ui/switch/index.ts
+++ b/src/lib/components/ui/switch/index.ts
@@ -1,0 +1,5 @@
+import Root from './Switch.svelte';
+
+export { Root, Root as Switch };
+export { type SwitchProps } from './switch-variants.js';
+export type { SwitchProps as Props } from './switch-variants.js';

--- a/src/lib/components/ui/switch/switch-variants.ts
+++ b/src/lib/components/ui/switch/switch-variants.ts
@@ -1,0 +1,4 @@
+import type { Switch as SwitchPrimitive } from 'bits-ui';
+import type { WithoutChildrenOrChild } from '$lib/utils.js';
+
+export type SwitchProps = WithoutChildrenOrChild<SwitchPrimitive.RootProps>;

--- a/src/lib/components/ui/textarea/Textarea.stories.svelte
+++ b/src/lib/components/ui/textarea/Textarea.stories.svelte
@@ -1,0 +1,101 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import { Textarea } from './index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import { HelpText } from '$lib/components/ui/help-text/index.js';
+	import ThemeDecorator from '$lib/storybook/ThemeDecorator.svelte';
+
+	const { Story } = defineMeta({
+		title: 'UI/Textarea',
+		component: Textarea,
+		// @ts-expect-error — Storybook decorator typing doesn't match Svelte 5 Component type
+		decorators: [() => ThemeDecorator],
+		tags: ['autodocs'],
+		argTypes: {
+			state: {
+				control: 'select',
+				options: ['default', 'error'],
+			},
+			disabled: { control: 'boolean' },
+		},
+	});
+</script>
+
+<script lang="ts">
+	import type { TextareaProps } from './textarea-variants.js';
+</script>
+
+<Story name="Default">
+	{#snippet template(args: TextareaProps)}
+		<div class="max-w-sm">
+			<Label for="desc">Description</Label>
+			<Textarea id="desc" rows={3} placeholder="Describe the change…" {...args} />
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Filled">
+	{#snippet template(args: TextareaProps)}
+		<div class="max-w-sm">
+			<Label for="filled">Description</Label>
+			<Textarea
+				id="filled"
+				rows={3}
+				value="Surface session failures and PR review state directly above each tree."
+				{...args}
+			/>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Error">
+	{#snippet template(args: TextareaProps)}
+		<div class="max-w-sm">
+			<Label for="error-ta">Description</Label>
+			<Textarea id="error-ta" state="error" rows={2} value="" {...args} />
+			<HelpText status="error">Description is required.</HelpText>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Disabled">
+	{#snippet template(args: TextareaProps)}
+		<div class="max-w-sm">
+			<Label for="disabled-ta">Description</Label>
+			<Textarea
+				id="disabled-ta"
+				disabled
+				rows={3}
+				value="Locked while session running"
+				{...args}
+			/>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="All States">
+	{#snippet template(_args: TextareaProps)}
+		<div class="grid max-w-2xl grid-cols-2 gap-4">
+			<div>
+				<Label>Default</Label>
+				<Textarea rows={3} placeholder="Describe the change…" />
+			</div>
+			<div>
+				<Label>Focus (interact)</Label>
+				<Textarea
+					rows={3}
+					value="Surface session failures and PR review state directly above each tree."
+				/>
+			</div>
+			<div>
+				<Label>Error</Label>
+				<Textarea state="error" rows={2} />
+				<HelpText status="error">Description is required.</HelpText>
+			</div>
+			<div>
+				<Label>Disabled</Label>
+				<Textarea disabled rows={3} value="Locked while session running" />
+			</div>
+		</div>
+	{/snippet}
+</Story>

--- a/src/lib/components/ui/textarea/Textarea.stories.svelte
+++ b/src/lib/components/ui/textarea/Textarea.stories.svelte
@@ -74,11 +74,11 @@
 </Story>
 
 <Story name="All States">
-	{#snippet template(_args: TextareaProps)}
+	{#snippet template(args: TextareaProps)}
 		<div class="grid max-w-2xl grid-cols-2 gap-4">
 			<div>
 				<Label>Default</Label>
-				<Textarea rows={3} placeholder="Describe the change…" />
+				<Textarea rows={3} placeholder="Describe the change…" {...args} />
 			</div>
 			<div>
 				<Label>Focus (interact)</Label>

--- a/src/lib/components/ui/textarea/Textarea.svelte
+++ b/src/lib/components/ui/textarea/Textarea.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+	import { textareaVariants, type TextareaProps } from './textarea-variants.js';
+
+	let {
+		ref = $bindable(null),
+		value = $bindable(),
+		state = 'default',
+		class: className,
+		...restProps
+	}: TextareaProps = $props();
+</script>
+
+<textarea
+	bind:this={ref}
+	bind:value
+	data-slot="textarea"
+	data-state={state}
+	aria-invalid={state === 'error' ? true : undefined}
+	class={cn(textareaVariants({ state }), className)}
+	{...restProps}
+></textarea>

--- a/src/lib/components/ui/textarea/index.ts
+++ b/src/lib/components/ui/textarea/index.ts
@@ -1,0 +1,5 @@
+import Root from './Textarea.svelte';
+
+export { Root, Root as Textarea };
+export { type TextareaProps, type TextareaState, textareaVariants } from './textarea-variants.js';
+export type { TextareaProps as Props } from './textarea-variants.js';

--- a/src/lib/components/ui/textarea/textarea-variants.ts
+++ b/src/lib/components/ui/textarea/textarea-variants.ts
@@ -1,0 +1,27 @@
+import type { WithElementRef, WithoutChildren } from '$lib/utils.js';
+import type { HTMLTextareaAttributes } from 'svelte/elements';
+import { tv } from 'tailwind-variants';
+
+const TEXTAREA_STATE = {
+	default: 'default',
+	error: 'error',
+} as const;
+
+export type TextareaState = (typeof TEXTAREA_STATE)[keyof typeof TEXTAREA_STATE];
+
+export const textareaVariants = tv({
+	base: 'w-full rounded-[var(--radius-md)] border border-border bg-surface px-2.5 py-2 font-sans text-[length:var(--text-md)] leading-[1.5] text-foreground outline-none transition-[border-color,box-shadow] duration-[120ms] ease-[ease] resize-vertical placeholder:text-foreground-subtle hover:border-border-strong disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-surface-2 disabled:text-foreground-subtle disabled:opacity-70 focus-visible:border-ring focus-visible:shadow-[0_0_0_3px_color-mix(in_oklch,var(--ring)_22%,transparent)]',
+	variants: {
+		state: {
+			default: '',
+			error: 'border-status-danger shadow-[0_0_0_3px_color-mix(in_oklch,var(--status-danger)_18%,transparent)]',
+		},
+	},
+	defaultVariants: {
+		state: 'default',
+	},
+});
+
+export type TextareaProps = WithoutChildren<WithElementRef<HTMLTextareaAttributes>> & {
+	state?: TextareaState;
+};

--- a/src/lib/components/ui/textarea/textarea-variants.ts
+++ b/src/lib/components/ui/textarea/textarea-variants.ts
@@ -2,12 +2,7 @@ import type { WithElementRef, WithoutChildren } from '$lib/utils.js';
 import type { HTMLTextareaAttributes } from 'svelte/elements';
 import { tv } from 'tailwind-variants';
 
-const TEXTAREA_STATE = {
-	default: 'default',
-	error: 'error',
-} as const;
-
-export type TextareaState = (typeof TEXTAREA_STATE)[keyof typeof TEXTAREA_STATE];
+export type TextareaState = 'default' | 'error';
 
 export const textareaVariants = tv({
 	base: 'w-full rounded-[var(--radius-md)] border border-border bg-surface px-2.5 py-2 font-sans text-[length:var(--text-md)] leading-[1.5] text-foreground outline-none transition-[border-color,box-shadow] duration-[120ms] ease-[ease] resize-vertical placeholder:text-foreground-subtle hover:border-border-strong disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-surface-2 disabled:text-foreground-subtle disabled:opacity-70 focus-visible:border-ring focus-visible:shadow-[0_0_0_3px_color-mix(in_oklch,var(--ring)_22%,transparent)]',

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -8,3 +8,9 @@ export function cn(...inputs: ClassValue[]) {
 export type WithElementRef<T, E extends HTMLElement = HTMLElement> = T & {
 	ref?: E | null;
 };
+
+export type WithoutChildren<T> = T extends { children?: unknown } ? Omit<T, 'children'> : T;
+
+export type WithoutChildrenOrChild<T> = T extends { children?: unknown; child?: unknown }
+	? Omit<T, 'children' | 'child'>
+	: WithoutChildren<T>;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -63,6 +63,7 @@ export default defineConfig({
 						instances: [{ browser: 'chromium', headless: true }],
 						api: {
 							host: '127.0.0.1',
+							port: 5174,
 							strictPort: false,
 						},
 					},
@@ -94,6 +95,7 @@ export default defineConfig({
 						instances: [{ browser: 'chromium' }],
 						api: {
 							host: '127.0.0.1',
+							port: 5175,
 							strictPort: false,
 						},
 					},

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -61,6 +61,10 @@ export default defineConfig({
 						enabled: true,
 						provider: playwright(),
 						instances: [{ browser: 'chromium', headless: true }],
+						api: {
+							host: '127.0.0.1',
+							strictPort: false,
+						},
 					},
 					include: ['src/**/*.svelte.{test,spec}.{js,ts}'],
 				},
@@ -88,6 +92,10 @@ export default defineConfig({
 						headless: true,
 						provider: playwright(),
 						instances: [{ browser: 'chromium' }],
+						api: {
+							host: '127.0.0.1',
+							strictPort: false,
+						},
 					},
 				},
 			},


### PR DESCRIPTION
## Description
- Added 9 form components (Input, Select, Textarea, Checkbox, RadioGroup, Switch, Label, HelpText, SearchField) with full Storybook stories
- All components use OKLCH design tokens from #97 for consistent styling and theming
- Implemented using bits-ui primitives (Checkbox, RadioGroup, Switch) for accessibility and tailwind-variants for variant-driven styling
- Each component includes comprehensive story states: default, focus, error, disabled, loading, and other interactive states
- Added SearchField component with search icon prefix and dropdown pattern for search results

## Resolves
Closes #98

## Testing
- [ ] All Storybook stories render correctly with ThemeDecorator
- [ ] Component states match Grovekeeper design artboards
- [ ] Accessibility features work (keyboard navigation, focus management)