### PR TITLE
#102 feat(ui): build overlay components with Storybook stories

### DIFF
--- a/src/lib/components/ui/dialog/Dialog.stories.svelte
+++ b/src/lib/components/ui/dialog/Dialog.stories.svelte
@@ -1,0 +1,199 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import * as Dialog from './index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { Textarea } from '$lib/components/ui/textarea/index.js';
+	import { Select } from '$lib/components/ui/select/index.js';
+	import { Checkbox } from '$lib/components/ui/checkbox/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import ThemeDecorator from '$lib/storybook/ThemeDecorator.svelte';
+	import XIcon from '@lucide/svelte/icons/x';
+	import PlusIcon from '@lucide/svelte/icons/plus';
+	import TrashIcon from '@lucide/svelte/icons/trash';
+
+	const { Story } = defineMeta({
+		title: 'UI/Dialog',
+		component: Dialog.Root,
+		// @ts-expect-error — Storybook decorator typing doesn't match Svelte 5 Component type
+		decorators: [() => ThemeDecorator],
+		tags: ['autodocs'],
+	});
+</script>
+
+<Story name="Plant Tree">
+	{#snippet template()}
+		<div class="flex items-center justify-center p-8">
+			<Dialog.Root>
+				<Dialog.Trigger>
+					{#snippet child({ props })}
+						<Button {...props}>
+							<PlusIcon class="size-3.5" />
+							Plant tree
+						</Button>
+					{/snippet}
+				</Dialog.Trigger>
+				<Dialog.Content portalProps={{ disabled: true }}>
+					<Dialog.Title class="sr-only">Start a new agent session</Dialog.Title>
+					<Dialog.Description class="sr-only">
+						Fill in the details to plant a new tree and start a new agent session.
+					</Dialog.Description>
+					<Dialog.Header>
+						<div>
+							<div
+								class="mb-0.5 text-[length:var(--text-xs)] font-medium uppercase tracking-wider text-foreground-subtle"
+							>
+								Modal · plant a tree
+							</div>
+							<div class="text-[length:var(--text-lg)] font-semibold">
+								Start a new agent session
+							</div>
+						</div>
+						<Dialog.Close>
+							{#snippet child({ props })}
+								<Button variant="ghost" size="icon-sm" {...props}>
+									<XIcon class="size-3" />
+								</Button>
+							{/snippet}
+						</Dialog.Close>
+					</Dialog.Header>
+					<Dialog.Body class="grid gap-3">
+						<div>
+							<Label for="issue-select">Issue</Label>
+							<Select id="issue-select">
+								<option value="142">#142 · Add usage tracking dashboard</option>
+							</Select>
+						</div>
+						<div class="grid grid-cols-2 gap-2.5">
+							<div>
+								<Label for="provider-select">Provider</Label>
+								<Select id="provider-select">
+									<option value="claude">Claude · Sonnet 4.5</option>
+								</Select>
+							</div>
+							<div>
+								<Label for="branch-input">Base branch</Label>
+								<Input id="branch-input" class="font-mono" value="dev" />
+							</div>
+						</div>
+						<div>
+							<Label for="prompt-textarea">Initial prompt (optional)</Label>
+							<Textarea
+								id="prompt-textarea"
+								rows={2}
+								placeholder="Pick up from the existing PR draft and add the per-day chart…"
+							/>
+						</div>
+						<div class="flex items-center gap-2">
+							<Checkbox id="worktree-checkbox" checked />
+							<Label
+								for="worktree-checkbox"
+								class="mb-0 cursor-pointer text-[length:var(--text-md)]"
+							>
+								Auto-create worktree
+							</Label>
+						</div>
+					</Dialog.Body>
+					<Dialog.Footer>
+						<Dialog.Close>
+							{#snippet child({ props })}
+								<Button variant="ghost" {...props}>Cancel</Button>
+							{/snippet}
+						</Dialog.Close>
+						<Button variant="primary">
+							<PlusIcon class="size-3.5" />
+							Plant tree
+						</Button>
+					</Dialog.Footer>
+				</Dialog.Content>
+			</Dialog.Root>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Destructive Confirm">
+	{#snippet template()}
+		<div class="flex items-center justify-center p-8">
+			<Dialog.Root>
+				<Dialog.Trigger>
+					{#snippet child({ props })}
+						<Button variant="danger" {...props}>
+							<TrashIcon class="size-3.5" />
+							Archive issue
+						</Button>
+					{/snippet}
+				</Dialog.Trigger>
+				<Dialog.Content class="max-w-[420px]" portalProps={{ disabled: true }}>
+					<Dialog.Title class="sr-only">Archive issue #066</Dialog.Title>
+					<Dialog.Description class="sr-only">
+						This will remove the worktree and stop any running session.
+					</Dialog.Description>
+					<Dialog.Header>
+						<div>
+							<div
+								class="mb-0.5 text-[length:var(--text-xs)] font-medium uppercase tracking-wider text-status-danger"
+							>
+								Modal · destructive confirm
+							</div>
+							<div class="text-[length:var(--text-lg)] font-semibold">
+								Archive #066?
+							</div>
+						</div>
+						<Dialog.Close>
+							{#snippet child({ props })}
+								<Button variant="ghost" size="icon-sm" {...props}>
+									<XIcon class="size-3" />
+								</Button>
+							{/snippet}
+						</Dialog.Close>
+					</Dialog.Header>
+					<Dialog.Body class="grid gap-3">
+						<p class="text-[length:var(--text-sm)] text-foreground-muted">
+							This will remove the worktree and stop any running session. The branch
+							and PR remain untouched on GitHub.
+						</p>
+						<div
+							class="flex items-center gap-2.5 rounded-lg border border-border bg-surface-2 p-2.5"
+						>
+							<div
+								class="flex size-12 items-center justify-center text-2xl opacity-40"
+							>
+								🌲
+							</div>
+							<div>
+								<div class="text-[12.5px] font-medium">
+									Deprecate polling system
+								</div>
+								<div
+									class="font-mono text-[length:var(--text-2xs)] text-foreground-muted"
+								>
+									#066 · feat/deprecated-polling
+								</div>
+							</div>
+						</div>
+						<div class="flex items-center gap-2">
+							<Checkbox id="delete-branch-checkbox" />
+							<Label
+								for="delete-branch-checkbox"
+								class="mb-0 cursor-pointer text-[length:var(--text-md)]"
+							>
+								Also delete the local branch
+							</Label>
+						</div>
+					</Dialog.Body>
+					<Dialog.Footer>
+						<Dialog.Close>
+							{#snippet child({ props })}
+								<Button variant="ghost" {...props}>Cancel</Button>
+							{/snippet}
+						</Dialog.Close>
+						<Button variant="danger">
+							<TrashIcon class="size-3.5" />
+							Archive
+						</Button>
+					</Dialog.Footer>
+				</Dialog.Content>
+			</Dialog.Root>
+		</div>
+	{/snippet}
+</Story>

--- a/src/lib/components/ui/dialog/dialog-body.svelte
+++ b/src/lib/components/ui/dialog/dialog-body.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+	import type { Snippet } from 'svelte';
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	let {
+		ref = $bindable<HTMLDivElement | null>(null),
+		class: className,
+		children,
+		...restProps
+	}: {
+		ref?: HTMLDivElement | null;
+		class?: string;
+		children?: Snippet;
+	} & HTMLAttributes<HTMLDivElement> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="dialog-body"
+	class={cn('overflow-y-auto px-5 py-4', className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/dialog/dialog-close.svelte
+++ b/src/lib/components/ui/dialog/dialog-close.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Dialog as DialogPrimitive } from 'bits-ui';
+
+	let { ref = $bindable(null), ...restProps }: DialogPrimitive.CloseProps = $props();
+</script>
+
+<DialogPrimitive.Close bind:ref data-slot="dialog-close" {...restProps} />

--- a/src/lib/components/ui/dialog/dialog-content.svelte
+++ b/src/lib/components/ui/dialog/dialog-content.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+	import { Dialog as DialogPrimitive } from 'bits-ui';
+	import type { Snippet } from 'svelte';
+	import { cn } from '$lib/utils.js';
+	import DialogOverlay from './dialog-overlay.svelte';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		portalProps,
+		...restProps
+	}: DialogPrimitive.ContentProps & {
+		children?: Snippet;
+		portalProps?: Omit<DialogPrimitive.PortalProps, 'children'>;
+	} = $props();
+</script>
+
+<DialogPrimitive.Portal {...portalProps}>
+	<DialogOverlay />
+	<DialogPrimitive.Content
+		bind:ref
+		data-slot="dialog-content"
+		class={cn(
+			'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+			'fixed left-1/2 top-1/2 z-50 w-[90%] max-w-[480px] -translate-x-1/2 -translate-y-1/2 rounded-xl border border-border bg-surface shadow-xl outline-none',
+			className,
+		)}
+		{...restProps}
+	>
+		{@render children?.()}
+	</DialogPrimitive.Content>
+</DialogPrimitive.Portal>

--- a/src/lib/components/ui/dialog/dialog-description.svelte
+++ b/src/lib/components/ui/dialog/dialog-description.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { Dialog as DialogPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: DialogPrimitive.DescriptionProps = $props();
+</script>
+
+<DialogPrimitive.Description
+	bind:ref
+	data-slot="dialog-description"
+	class={cn('text-[length:var(--text-sm)] text-foreground-muted', className)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/dialog/dialog-footer.svelte
+++ b/src/lib/components/ui/dialog/dialog-footer.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+	import type { Snippet } from 'svelte';
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	let {
+		ref = $bindable<HTMLDivElement | null>(null),
+		class: className,
+		children,
+		...restProps
+	}: {
+		ref?: HTMLDivElement | null;
+		class?: string;
+		children?: Snippet;
+	} & HTMLAttributes<HTMLDivElement> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="dialog-footer"
+	class={cn('flex items-center justify-end gap-2 border-t border-border px-5 py-4', className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/dialog/dialog-header.svelte
+++ b/src/lib/components/ui/dialog/dialog-header.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+	import type { Snippet } from 'svelte';
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	let {
+		ref = $bindable<HTMLDivElement | null>(null),
+		class: className,
+		children,
+		...restProps
+	}: {
+		ref?: HTMLDivElement | null;
+		class?: string;
+		children?: Snippet;
+	} & HTMLAttributes<HTMLDivElement> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="dialog-header"
+	class={cn('flex items-start justify-between gap-4 border-b border-border px-5 py-4', className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/dialog/dialog-overlay.svelte
+++ b/src/lib/components/ui/dialog/dialog-overlay.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { Dialog as DialogPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: DialogPrimitive.OverlayProps = $props();
+</script>
+
+<DialogPrimitive.Overlay
+	bind:ref
+	data-slot="dialog-overlay"
+	class={cn(
+		'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-40 bg-[color-mix(in_oklch,oklch(0.10_0.02_150)_50%,transparent)] backdrop-blur-[2px]',
+		className,
+	)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/dialog/dialog-title.svelte
+++ b/src/lib/components/ui/dialog/dialog-title.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { Dialog as DialogPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: DialogPrimitive.TitleProps = $props();
+</script>
+
+<DialogPrimitive.Title
+	bind:ref
+	data-slot="dialog-title"
+	class={cn('text-[length:var(--text-base)] font-semibold text-foreground', className)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/dialog/dialog-trigger.svelte
+++ b/src/lib/components/ui/dialog/dialog-trigger.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Dialog as DialogPrimitive } from 'bits-ui';
+
+	let { ref = $bindable(null), ...restProps }: DialogPrimitive.TriggerProps = $props();
+</script>
+
+<DialogPrimitive.Trigger bind:ref data-slot="dialog-trigger" {...restProps} />

--- a/src/lib/components/ui/dialog/dialog-variants.ts
+++ b/src/lib/components/ui/dialog/dialog-variants.ts
@@ -1,0 +1,8 @@
+export const DIALOG_TONE_OPTIONS = ['standard', 'destructive'] as const;
+
+export type DialogTone = (typeof DIALOG_TONE_OPTIONS)[number];
+
+export const dialogEyebrowColors = {
+	standard: 'text-foreground-subtle',
+	destructive: 'text-status-danger',
+} as const satisfies Record<DialogTone, string>;

--- a/src/lib/components/ui/dialog/dialog.svelte
+++ b/src/lib/components/ui/dialog/dialog.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Dialog as DialogPrimitive } from 'bits-ui';
+
+	let { open = $bindable(false), ...restProps }: DialogPrimitive.RootProps = $props();
+</script>
+
+<DialogPrimitive.Root bind:open {...restProps} />

--- a/src/lib/components/ui/dialog/index.ts
+++ b/src/lib/components/ui/dialog/index.ts
@@ -1,0 +1,26 @@
+import Root from './dialog.svelte';
+import Trigger from './dialog-trigger.svelte';
+import Overlay from './dialog-overlay.svelte';
+import Content from './dialog-content.svelte';
+import Header from './dialog-header.svelte';
+import Body from './dialog-body.svelte';
+import Footer from './dialog-footer.svelte';
+import Title from './dialog-title.svelte';
+import Description from './dialog-description.svelte';
+import Close from './dialog-close.svelte';
+
+export { Root, Trigger, Overlay, Content, Header, Body, Footer, Title, Description, Close };
+export {
+	Root as Dialog,
+	Trigger as DialogTrigger,
+	Overlay as DialogOverlay,
+	Content as DialogContent,
+	Header as DialogHeader,
+	Body as DialogBody,
+	Footer as DialogFooter,
+	Title as DialogTitle,
+	Description as DialogDescription,
+	Close as DialogClose,
+};
+export type { DialogTone } from './dialog-variants.js';
+export { DIALOG_TONE_OPTIONS, dialogEyebrowColors } from './dialog-variants.js';

--- a/src/lib/components/ui/popover/AccountDropdown.stories.svelte
+++ b/src/lib/components/ui/popover/AccountDropdown.stories.svelte
@@ -1,0 +1,117 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import * as Popover from './index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import ThemeDecorator from '$lib/storybook/ThemeDecorator.svelte';
+	import UserIcon from '@lucide/svelte/icons/user';
+	import SettingsIcon from '@lucide/svelte/icons/settings';
+	import DatabaseIcon from '@lucide/svelte/icons/database';
+	import SunIcon from '@lucide/svelte/icons/sun';
+	import MoonIcon from '@lucide/svelte/icons/moon';
+	import GlobeIcon from '@lucide/svelte/icons/globe';
+	import GithubIcon from '@lucide/svelte/icons/git-branch';
+	import LogOutIcon from '@lucide/svelte/icons/log-out';
+	import ChevronRightIcon from '@lucide/svelte/icons/chevron-right';
+	import ChevronDownIcon from '@lucide/svelte/icons/chevron-down';
+
+	const { Story } = defineMeta({
+		title: 'UI/Patterns/AccountDropdown',
+		component: Popover.Root,
+		// @ts-expect-error — Storybook decorator typing doesn't match Svelte 5 Component type
+		decorators: [() => ThemeDecorator],
+		tags: ['autodocs'],
+	});
+</script>
+
+<Story name="Account Dropdown">
+	{#snippet template()}
+		<div class="p-4">
+			<Popover.Root>
+				<Popover.Trigger>
+					{#snippet child({ props })}
+						<Button variant="secondary" class="w-[280px] justify-between" {...props}>
+							<span class="flex items-center gap-2">
+								<span
+									class="flex size-[22px] items-center justify-center rounded-full bg-primary text-[11px] font-semibold text-primary-foreground"
+								>
+									L
+								</span>
+								Lukas
+							</span>
+							<ChevronDownIcon class="size-3.5" />
+						</Button>
+					{/snippet}
+				</Popover.Trigger>
+				<Popover.Content class="w-[280px] p-0" portalProps={{ disabled: true }}>
+					<div class="flex items-center gap-2.5 border-b border-border px-3 py-3">
+						<span
+							class="flex size-8 items-center justify-center rounded-full bg-primary text-[13px] font-semibold text-primary-foreground"
+						>
+							L
+						</span>
+						<div class="min-w-0">
+							<div class="text-[length:var(--text-md)] font-medium">Lukas Hron</div>
+							<div
+								class="truncate text-[length:var(--text-2xs)] text-foreground-subtle"
+							>
+								lukas@grovekeeper.dev
+							</div>
+						</div>
+					</div>
+					<div class="p-1.5">
+						<Popover.Item>
+							<UserIcon class="size-3.5" />
+							Profile
+							<span
+								class="ml-auto inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-[4px] border border-border bg-surface-2 px-[5px] font-mono text-[10.5px] text-foreground-muted"
+							>
+								⌘P
+							</span>
+						</Popover.Item>
+						<Popover.Item>
+							<SettingsIcon class="size-3.5" />
+							Settings
+							<span
+								class="ml-auto inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-[4px] border border-border bg-surface-2 px-[5px] font-mono text-[10.5px] text-foreground-muted"
+							>
+								⌘,
+							</span>
+						</Popover.Item>
+						<Popover.Item>
+							<DatabaseIcon class="size-3.5" />
+							Billing &amp; usage
+						</Popover.Item>
+						<Popover.Divider />
+						<Popover.Label>Theme</Popover.Label>
+						<div class="flex gap-1 px-2 pb-1.5">
+							<Button variant="secondary" size="sm" class="flex-1">
+								<SunIcon class="size-3" />
+								Light
+							</Button>
+							<Button variant="primary" size="sm" class="flex-1">
+								<MoonIcon class="size-3" />
+								Dark
+							</Button>
+							<Button variant="secondary" size="sm" class="flex-1">Auto</Button>
+						</div>
+						<Popover.Divider />
+						<Popover.Item>
+							<GlobeIcon class="size-3.5" />
+							Workspaces
+							<ChevronRightIcon class="ml-auto size-3" />
+						</Popover.Item>
+						<Popover.Item>
+							<GithubIcon class="size-3.5" />
+							GitHub integrations
+						</Popover.Item>
+						<Popover.Divider />
+						<Popover.Item class="text-status-danger">
+							<LogOutIcon class="size-3.5" />
+							Sign out
+						</Popover.Item>
+					</div>
+				</Popover.Content>
+			</Popover.Root>
+		</div>
+	{/snippet}
+</Story>

--- a/src/lib/components/ui/popover/NotificationsPopover.stories.svelte
+++ b/src/lib/components/ui/popover/NotificationsPopover.stories.svelte
@@ -1,0 +1,114 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import * as Popover from './index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import ThemeDecorator from '$lib/storybook/ThemeDecorator.svelte';
+	import BellIcon from '@lucide/svelte/icons/bell';
+
+	const { Story } = defineMeta({
+		title: 'UI/Patterns/NotificationsPopover',
+		component: Popover.Root,
+		// @ts-expect-error — Storybook decorator typing doesn't match Svelte 5 Component type
+		decorators: [() => ThemeDecorator],
+		tags: ['autodocs'],
+	});
+
+	const NOTIFICATIONS = [
+		{
+			tone: 'warning' as const,
+			dotColor: 'bg-status-warning',
+			title: '#103 changes requested',
+			body: '@reviewer left 2 comments on PR #29',
+			time: '4m',
+			unread: true,
+		},
+		{
+			tone: 'success' as const,
+			dotColor: 'bg-status-success',
+			title: '#091 PR approved',
+			body: 'Provider trait expansion is ready to merge',
+			time: '1h',
+			unread: true,
+		},
+		{
+			tone: 'info' as const,
+			dotColor: 'bg-status-info',
+			title: '#118 PR draft pushed',
+			body: '2 new commits on feat/forest-overlays',
+			time: '3h',
+			unread: true,
+		},
+		{
+			tone: 'muted' as const,
+			dotColor: 'bg-foreground-subtle',
+			title: '#066 branch deleted',
+			body: 'Upstream removed feat/deprecated-polling',
+			time: 'yest',
+			unread: false,
+		},
+	] as const;
+</script>
+
+<Story name="Notifications Popover">
+	{#snippet template()}
+		<div class="p-4">
+			<Popover.Root>
+				<Popover.Trigger>
+					{#snippet child({ props })}
+						<div class="relative inline-block">
+							<Button variant="secondary" size="icon" {...props}>
+								<BellIcon class="size-3.5" />
+							</Button>
+							<span
+								class="absolute right-1 top-1 size-[7px] rounded-full bg-status-danger"
+							></span>
+						</div>
+					{/snippet}
+				</Popover.Trigger>
+				<Popover.Content class="w-[300px] p-0" align="end" portalProps={{ disabled: true }}>
+					<div
+						class="flex items-center justify-between border-b border-border px-3 py-2.5"
+					>
+						<div class="text-[length:var(--text-md)] font-semibold">
+							Inbox · 3 unread
+						</div>
+						<Button variant="ghost" size="sm">Mark all read</Button>
+					</div>
+					<div class="max-h-[320px] overflow-y-auto">
+						{#each NOTIFICATIONS as notification (notification.title)}
+							<div
+								class="flex gap-2.5 border-b border-border px-3 py-2.5 last:border-b-0"
+								style={notification.unread
+									? 'background: color-mix(in oklch, var(--primary) 4%, transparent)'
+									: ''}
+							>
+								<span
+									class="mt-1.5 size-1.5 shrink-0 rounded-full {notification.dotColor}"
+								></span>
+								<div class="min-w-0 flex-1">
+									<div
+										class="text-[12.5px] {notification.unread
+											? 'font-semibold'
+											: 'font-medium'}"
+									>
+										{notification.title}
+									</div>
+									<div
+										class="mt-px text-[length:var(--text-2xs)] text-foreground-muted"
+									>
+										{notification.body}
+									</div>
+								</div>
+								<div
+									class="shrink-0 font-mono text-[length:var(--text-2xs)] text-foreground-subtle"
+								>
+									{notification.time}
+								</div>
+							</div>
+						{/each}
+					</div>
+				</Popover.Content>
+			</Popover.Root>
+		</div>
+	{/snippet}
+</Story>

--- a/src/lib/components/ui/popover/Popover.stories.svelte
+++ b/src/lib/components/ui/popover/Popover.stories.svelte
@@ -1,0 +1,166 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import * as Popover from './index.js';
+	import { Checkbox } from '$lib/components/ui/checkbox/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import ThemeDecorator from '$lib/storybook/ThemeDecorator.svelte';
+	import FilterIcon from '@lucide/svelte/icons/filter';
+	import LayersIcon from '@lucide/svelte/icons/layers';
+	import SparklesIcon from '@lucide/svelte/icons/sparkles';
+	import CheckIcon from '@lucide/svelte/icons/check';
+
+	const { Story } = defineMeta({
+		title: 'UI/Popover',
+		component: Popover.Root,
+		// @ts-expect-error — Storybook decorator typing doesn't match Svelte 5 Component type
+		decorators: [() => ThemeDecorator],
+		tags: ['autodocs'],
+	});
+</script>
+
+<Story name="Filter">
+	{#snippet template()}
+		<div class="flex items-start gap-4 p-4">
+			<Popover.Root>
+				<Popover.Trigger>
+					{#snippet child({ props })}
+						<Button variant="secondary" {...props}>
+							<FilterIcon class="size-3.5" />
+							Filter
+						</Button>
+					{/snippet}
+				</Popover.Trigger>
+				<Popover.Content class="w-[240px]" portalProps={{ disabled: true }}>
+					<Popover.Label>Status</Popover.Label>
+					<label
+						class="flex min-h-[28px] cursor-pointer items-center gap-2 rounded-md px-2 py-1 text-[length:var(--text-sm)] hover:bg-surface-2"
+					>
+						<Checkbox checked />
+						Running
+					</label>
+					<label
+						class="flex min-h-[28px] cursor-pointer items-center gap-2 rounded-md px-2 py-1 text-[length:var(--text-sm)] hover:bg-surface-2"
+					>
+						<Checkbox checked />
+						PR draft
+					</label>
+					<label
+						class="flex min-h-[28px] cursor-pointer items-center gap-2 rounded-md px-2 py-1 text-[length:var(--text-sm)] hover:bg-surface-2"
+					>
+						<Checkbox />
+						Approved
+					</label>
+					<label
+						class="flex min-h-[28px] cursor-pointer items-center gap-2 rounded-md px-2 py-1 text-[length:var(--text-sm)] hover:bg-surface-2"
+					>
+						<Checkbox />
+						Merged
+					</label>
+					<Popover.Divider />
+					<Popover.Label>Provider</Popover.Label>
+					<label
+						class="flex min-h-[28px] cursor-pointer items-center gap-2 rounded-md px-2 py-1 text-[length:var(--text-sm)] hover:bg-surface-2"
+					>
+						<Checkbox checked />
+						Claude
+					</label>
+					<label
+						class="flex min-h-[28px] cursor-pointer items-center gap-2 rounded-md px-2 py-1 text-[length:var(--text-sm)] hover:bg-surface-2"
+					>
+						<Checkbox />
+						Codex
+					</label>
+					<Popover.Divider />
+					<div class="flex gap-1.5 px-1 pb-1 pt-0.5">
+						<Button variant="ghost" size="sm" class="flex-1">Reset</Button>
+						<Button variant="primary" size="sm" class="flex-1">Apply</Button>
+					</div>
+				</Popover.Content>
+			</Popover.Root>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Sort">
+	{#snippet template()}
+		<div class="flex items-start gap-4 p-4">
+			<Popover.Root>
+				<Popover.Trigger>
+					{#snippet child({ props })}
+						<Button variant="secondary" {...props}>
+							<LayersIcon class="size-3.5" />
+							Sort by
+						</Button>
+					{/snippet}
+				</Popover.Trigger>
+				<Popover.Content class="w-[220px]" portalProps={{ disabled: true }}>
+					<Popover.Label>Sort by</Popover.Label>
+					<Popover.Item active>
+						<CheckIcon class="size-[11px]" />
+						Updated · newest
+					</Popover.Item>
+					<Popover.Item>
+						<span class="size-[11px]"></span>
+						Created · newest
+					</Popover.Item>
+					<Popover.Item>
+						<span class="size-[11px]"></span>
+						Issue # · ascending
+					</Popover.Item>
+					<Popover.Item>
+						<span class="size-[11px]"></span>
+						Tree stage
+					</Popover.Item>
+					<Popover.Item>
+						<span class="size-[11px]"></span>
+						Provider
+					</Popover.Item>
+					<Popover.Divider />
+					<Popover.Label>Group by</Popover.Label>
+					<Popover.Item>
+						<span class="size-[11px]"></span>
+						None
+					</Popover.Item>
+					<Popover.Item active>
+						<CheckIcon class="size-[11px]" />
+						Repository
+					</Popover.Item>
+					<Popover.Item>
+						<span class="size-[11px]"></span>
+						Status
+					</Popover.Item>
+				</Popover.Content>
+			</Popover.Root>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Legend">
+	{#snippet template()}
+		<div class="flex items-start gap-4 p-4">
+			<Popover.Root>
+				<Popover.Trigger>
+					{#snippet child({ props })}
+						<Button variant="secondary" {...props}>
+							<SparklesIcon class="size-3.5" />
+							Legend
+						</Button>
+					{/snippet}
+				</Popover.Trigger>
+				<Popover.Content class="w-[240px]" portalProps={{ disabled: true }}>
+					<Popover.Label>Tree state legend</Popover.Label>
+					<div class="grid gap-1.5 px-2 pb-1.5">
+						{#each [{ color: 'bg-[oklch(0.69_0.098_132)]', label: 'Growing — session active' }, { color: 'bg-[oklch(0.77_0.15_65)]', label: 'Fruiting — PR open' }, { color: 'bg-[#e8a8c0]', label: 'Flowering — approved' }, { color: 'bg-[#e8a64a]', label: 'Seasonal — review' }, { color: 'bg-foreground-subtle', label: 'Bare — merged' }, { color: 'bg-[#6c5d4e]', label: 'Dead — branch gone' }] as entry (entry.label)}
+							<div class="flex items-center gap-2">
+								<span class="size-2 shrink-0 rounded-[2px] {entry.color}"></span>
+								<span class="text-[length:var(--text-2xs)] text-foreground"
+									>{entry.label}</span
+								>
+							</div>
+						{/each}
+					</div>
+				</Popover.Content>
+			</Popover.Root>
+		</div>
+	{/snippet}
+</Story>

--- a/src/lib/components/ui/popover/index.ts
+++ b/src/lib/components/ui/popover/index.ts
@@ -1,0 +1,17 @@
+import Root from './popover.svelte';
+import Trigger from './popover-trigger.svelte';
+import Content from './popover-content.svelte';
+import Item from './popover-item.svelte';
+import Label from './popover-label.svelte';
+import Divider from './popover-divider.svelte';
+
+export { Root, Trigger, Content, Item, Label, Divider };
+export {
+	Root as Popover,
+	Trigger as PopoverTrigger,
+	Content as PopoverContent,
+	Item as PopoverItem,
+	Label as PopoverLabel,
+	Divider as PopoverDivider,
+};
+export type { PopoverItemProps } from './popover-variants.js';

--- a/src/lib/components/ui/popover/popover-content.svelte
+++ b/src/lib/components/ui/popover/popover-content.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import { Popover as PopoverPrimitive } from 'bits-ui';
+	import type { Snippet } from 'svelte';
+	import { cn } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		sideOffset = 6,
+		side = 'bottom' as const,
+		align = 'start' as const,
+		children,
+		portalProps,
+		...restProps
+	}: PopoverPrimitive.ContentProps & {
+		children?: Snippet;
+		portalProps?: Omit<PopoverPrimitive.PortalProps, 'children'>;
+	} = $props();
+</script>
+
+<PopoverPrimitive.Portal {...portalProps}>
+	<PopoverPrimitive.Content
+		bind:ref
+		data-slot="popover-content"
+		{sideOffset}
+		{side}
+		{align}
+		class={cn(
+			'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+			'z-20 min-w-[220px] rounded-lg border border-border bg-surface py-1.5 shadow-lg outline-none',
+			className,
+		)}
+		{...restProps}
+	>
+		{@render children?.()}
+	</PopoverPrimitive.Content>
+</PopoverPrimitive.Portal>

--- a/src/lib/components/ui/popover/popover-divider.svelte
+++ b/src/lib/components/ui/popover/popover-divider.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	let {
+		ref = $bindable<HTMLHRElement | null>(null),
+		class: className,
+		...restProps
+	}: { ref?: HTMLHRElement | null; class?: string } & HTMLAttributes<HTMLHRElement> = $props();
+</script>
+
+<hr
+	bind:this={ref}
+	data-slot="popover-divider"
+	class={cn('my-1 border-t border-border', className)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/popover/popover-item.svelte
+++ b/src/lib/components/ui/popover/popover-item.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+	import type { PopoverItemProps } from './popover-variants.js';
+
+	let {
+		ref = $bindable<HTMLDivElement | null>(null),
+		class: className,
+		active = false,
+		children,
+		...restProps
+	}: PopoverItemProps = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="popover-item"
+	data-state={active ? 'active' : undefined}
+	class={cn(
+		'flex min-h-[28px] w-full cursor-pointer select-none items-center gap-2 rounded-md px-2 py-1 text-[length:var(--text-sm)] text-foreground outline-none',
+		'hover:bg-surface-2 focus-visible:bg-surface-2',
+		'data-[state=active]:text-primary',
+		className,
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/popover/popover-label.svelte
+++ b/src/lib/components/ui/popover/popover-label.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+	import type { Snippet } from 'svelte';
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	let {
+		ref = $bindable<HTMLDivElement | null>(null),
+		class: className,
+		children,
+		...restProps
+	}: {
+		ref?: HTMLDivElement | null;
+		class?: string;
+		children?: Snippet;
+	} & HTMLAttributes<HTMLDivElement> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="popover-label"
+	class={cn(
+		'px-2 pb-1 pt-1.5 text-[length:var(--text-2xs)] font-medium uppercase tracking-wider text-foreground-subtle',
+		className,
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/popover/popover-trigger.svelte
+++ b/src/lib/components/ui/popover/popover-trigger.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Popover as PopoverPrimitive } from 'bits-ui';
+
+	let { ref = $bindable(null), ...restProps }: PopoverPrimitive.TriggerProps = $props();
+</script>
+
+<PopoverPrimitive.Trigger bind:ref data-slot="popover-trigger" {...restProps} />

--- a/src/lib/components/ui/popover/popover-variants.ts
+++ b/src/lib/components/ui/popover/popover-variants.ts
@@ -1,0 +1,9 @@
+import type { Snippet } from 'svelte';
+import type { HTMLAttributes } from 'svelte/elements';
+
+export type PopoverItemProps = {
+	ref?: HTMLDivElement | null;
+	class?: string;
+	active?: boolean;
+	children?: Snippet;
+} & HTMLAttributes<HTMLDivElement>;

--- a/src/lib/components/ui/popover/popover.svelte
+++ b/src/lib/components/ui/popover/popover.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Popover as PopoverPrimitive } from 'bits-ui';
+
+	let { open = $bindable(false), ...restProps }: PopoverPrimitive.RootProps = $props();
+</script>
+
+<PopoverPrimitive.Root bind:open {...restProps} />

--- a/src/lib/components/ui/toast/Toast.stories.svelte
+++ b/src/lib/components/ui/toast/Toast.stories.svelte
@@ -1,0 +1,157 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import { Toast, TOAST_TONE_OPTIONS } from './index.js';
+	import ThemeDecorator from '$lib/storybook/ThemeDecorator.svelte';
+	import RefreshIcon from '@lucide/svelte/icons/refresh-cw';
+	import CheckIcon from '@lucide/svelte/icons/check';
+	import AlertTriangleIcon from '@lucide/svelte/icons/triangle-alert';
+	import XIcon from '@lucide/svelte/icons/x';
+
+	const { Story } = defineMeta({
+		title: 'UI/Toast',
+		component: Toast,
+		// @ts-expect-error — Storybook decorator typing doesn't match Svelte 5 Component type
+		decorators: [() => ThemeDecorator],
+		tags: ['autodocs'],
+		argTypes: {
+			tone: {
+				control: 'select',
+				options: [...TOAST_TONE_OPTIONS],
+			},
+			title: { control: 'text' },
+			body: { control: 'text' },
+		},
+	});
+</script>
+
+<Story name="Info">
+	{#snippet template()}
+		<div class="max-w-[540px]">
+			<Toast
+				tone="info"
+				title="Syncing grovekeeper…"
+				body="Fetching 3 new commits from origin."
+			>
+				{#snippet icon()}<RefreshIcon class="size-3.5" />{/snippet}
+			</Toast>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Success">
+	{#snippet template()}
+		<div class="max-w-[540px]">
+			<Toast
+				tone="success"
+				title="Worktree created"
+				body="Branch feat/forest-overlays checked out."
+			>
+				{#snippet icon()}<CheckIcon class="size-3.5" />{/snippet}
+			</Toast>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Warning">
+	{#snippet template()}
+		<div class="max-w-[540px]">
+			<Toast
+				tone="warning"
+				title="Permission required"
+				body="Session #128 wants to run a Bash command."
+			>
+				{#snippet icon()}<AlertTriangleIcon class="size-3.5" />{/snippet}
+				{#snippet action()}
+					<button
+						class="inline-flex h-[var(--size-control-sm)] items-center rounded-[var(--radius-sm)] border border-border bg-surface-2 px-[9px] text-[length:var(--text-sm)] text-foreground hover:bg-surface-3"
+					>
+						Review
+					</button>
+				{/snippet}
+			</Toast>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Danger">
+	{#snippet template()}
+		<div class="max-w-[540px]">
+			<Toast
+				tone="danger"
+				title="Sync failed"
+				body="GitHub returned 401 — check token in Settings."
+			>
+				{#snippet icon()}<XIcon class="size-3.5" />{/snippet}
+				{#snippet action()}
+					<button
+						class="inline-flex h-[var(--size-control-sm)] items-center rounded-[var(--radius-sm)] border border-border bg-surface-2 px-[9px] text-[length:var(--text-sm)] text-foreground hover:bg-surface-3"
+					>
+						Retry
+					</button>
+				{/snippet}
+			</Toast>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Loading">
+	{#snippet template()}
+		<div class="max-w-[540px]">
+			<Toast tone="loading" title="Planting tree…" body="Setting up worktree for #142">
+				{#snippet icon()}<RefreshIcon class="size-3.5 animate-spin" />{/snippet}
+			</Toast>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Stack">
+	{#snippet template()}
+		<div class="flex max-w-[540px] flex-col gap-3">
+			<Toast
+				tone="info"
+				title="Syncing grovekeeper…"
+				body="Fetching 3 new commits from origin."
+			>
+				{#snippet icon()}<RefreshIcon class="size-3.5" />{/snippet}
+			</Toast>
+			<Toast
+				tone="success"
+				title="Worktree created"
+				body="Branch feat/forest-overlays checked out."
+			>
+				{#snippet icon()}<CheckIcon class="size-3.5" />{/snippet}
+			</Toast>
+			<Toast
+				tone="warning"
+				title="Permission required"
+				body="Session #128 wants to run a Bash command."
+			>
+				{#snippet icon()}<AlertTriangleIcon class="size-3.5" />{/snippet}
+				{#snippet action()}
+					<button
+						class="inline-flex h-[var(--size-control-sm)] items-center rounded-[var(--radius-sm)] border border-border bg-surface-2 px-[9px] text-[length:var(--text-sm)] text-foreground hover:bg-surface-3"
+					>
+						Review
+					</button>
+				{/snippet}
+			</Toast>
+			<Toast
+				tone="danger"
+				title="Sync failed"
+				body="GitHub returned 401 — check token in Settings."
+			>
+				{#snippet icon()}<XIcon class="size-3.5" />{/snippet}
+				{#snippet action()}
+					<button
+						class="inline-flex h-[var(--size-control-sm)] items-center rounded-[var(--radius-sm)] border border-border bg-surface-2 px-[9px] text-[length:var(--text-sm)] text-foreground hover:bg-surface-3"
+					>
+						Retry
+					</button>
+				{/snippet}
+			</Toast>
+			<Toast tone="loading" title="Planting tree…" body="Setting up worktree for #142">
+				{#snippet icon()}<RefreshIcon class="size-3.5 animate-spin" />{/snippet}
+			</Toast>
+		</div>
+	{/snippet}
+</Story>

--- a/src/lib/components/ui/toast/Toast.svelte
+++ b/src/lib/components/ui/toast/Toast.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+	import { toastVariants, toastIconColors, type ToastProps } from './toast-variants.js';
+	import XIcon from '@lucide/svelte/icons/x';
+
+	let {
+		ref = $bindable<HTMLDivElement | null>(null),
+		class: className,
+		tone = 'info',
+		title,
+		body,
+		icon,
+		action,
+		onDismiss,
+		...restProps
+	}: ToastProps = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="toast"
+	data-tone={tone}
+	role="status"
+	aria-live="polite"
+	class={cn(toastVariants({ tone }), className)}
+	{...restProps}
+>
+	{#if icon}
+		<div class={cn('shrink-0', toastIconColors[tone])}>
+			{@render icon()}
+		</div>
+	{/if}
+
+	<div class="min-w-0 flex-1">
+		<div class="text-[12.5px] font-semibold text-foreground">{title}</div>
+		{#if body}
+			<div class="mt-0.5 text-[length:var(--text-sm)] text-foreground-muted">{body}</div>
+		{/if}
+	</div>
+
+	{#if action}
+		{@render action()}
+	{/if}
+
+	<button
+		type="button"
+		onclick={onDismiss}
+		aria-label="Dismiss"
+		class="shrink-0 inline-flex size-6 items-center justify-center rounded-md text-foreground-subtle transition-colors hover:bg-surface-2 hover:text-foreground"
+	>
+		<XIcon class="size-3" />
+	</button>
+</div>

--- a/src/lib/components/ui/toast/index.ts
+++ b/src/lib/components/ui/toast/index.ts
@@ -1,0 +1,5 @@
+import Toast from './Toast.svelte';
+
+export { Toast };
+export type { ToastProps, ToastTone } from './toast-variants.js';
+export { TOAST_TONE_OPTIONS, toastVariants, toastIconColors } from './toast-variants.js';

--- a/src/lib/components/ui/toast/toast-variants.ts
+++ b/src/lib/components/ui/toast/toast-variants.ts
@@ -1,0 +1,43 @@
+import type { Snippet } from 'svelte';
+import type { HTMLAttributes } from 'svelte/elements';
+import { tv, type VariantProps } from 'tailwind-variants';
+
+export const TOAST_TONE_OPTIONS = ['info', 'success', 'warning', 'danger', 'loading'] as const;
+
+export type ToastTone = (typeof TOAST_TONE_OPTIONS)[number];
+
+export const toastVariants = tv({
+	base: 'flex items-center gap-3 rounded-lg border border-border bg-surface p-3 shadow-md',
+	variants: {
+		tone: {
+			info: 'border-l-2 border-l-status-info',
+			success: 'border-l-2 border-l-status-success',
+			warning: 'border-l-2 border-l-status-warning',
+			danger: 'border-l-2 border-l-status-danger',
+			loading: 'border-l-2 border-l-primary',
+		},
+	},
+	defaultVariants: {
+		tone: 'info',
+	},
+});
+
+export const toastIconColors = {
+	info: 'text-status-info',
+	success: 'text-status-success',
+	warning: 'text-status-warning',
+	danger: 'text-status-danger',
+	loading: 'text-primary',
+} as const satisfies Record<ToastTone, string>;
+
+export type ToastProps = {
+	ref?: HTMLDivElement | null;
+	class?: string;
+	tone?: ToastTone;
+	title: string;
+	body?: string;
+	icon?: Snippet;
+	action?: Snippet;
+	onDismiss?: () => void;
+} & Omit<HTMLAttributes<HTMLDivElement>, 'title'> &
+	VariantProps<typeof toastVariants>;

--- a/src/lib/components/ui/tooltip/Tooltip.stories.svelte
+++ b/src/lib/components/ui/tooltip/Tooltip.stories.svelte
@@ -1,0 +1,249 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import * as Tooltip from './index.js';
+	import ThemeDecorator from '$lib/storybook/ThemeDecorator.svelte';
+	import SettingsIcon from '@lucide/svelte/icons/settings';
+
+	const { Story } = defineMeta({
+		title: 'UI/Tooltip',
+		component: Tooltip.Provider,
+		// @ts-expect-error — Storybook decorator typing doesn't match Svelte 5 Component type
+		decorators: [() => ThemeDecorator],
+		tags: ['autodocs'],
+	});
+</script>
+
+<Story name="Top">
+	{#snippet template()}
+		<Tooltip.Provider>
+			<div class="flex items-center justify-center p-16">
+				<Tooltip.Root>
+					<Tooltip.Trigger>
+						<button
+							class="inline-flex h-8 items-center rounded-md border border-border bg-surface-2 px-3 text-sm text-foreground"
+						>
+							Hover me
+						</button>
+					</Tooltip.Trigger>
+					<Tooltip.Content side="top" portalProps={{ disabled: true }}
+						>Sync now</Tooltip.Content
+					>
+				</Tooltip.Root>
+			</div>
+		</Tooltip.Provider>
+	{/snippet}
+</Story>
+
+<Story name="Bottom">
+	{#snippet template()}
+		<Tooltip.Provider>
+			<div class="flex items-center justify-center p-16">
+				<Tooltip.Root>
+					<Tooltip.Trigger>
+						<button
+							class="inline-flex h-8 items-center rounded-md border border-border bg-surface-2 px-3 text-sm text-foreground"
+						>
+							Hover me
+						</button>
+					</Tooltip.Trigger>
+					<Tooltip.Content side="bottom" portalProps={{ disabled: true }}>
+						Plant a tree
+						<kbd
+							data-slot="kbd"
+							class="inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-[4px] border border-border bg-surface-2 px-[5px] font-mono text-[10.5px] text-foreground-muted"
+						>
+							⌘N
+						</kbd>
+					</Tooltip.Content>
+				</Tooltip.Root>
+			</div>
+		</Tooltip.Provider>
+	{/snippet}
+</Story>
+
+<Story name="Left">
+	{#snippet template()}
+		<Tooltip.Provider>
+			<div class="flex items-center justify-center p-16">
+				<Tooltip.Root>
+					<Tooltip.Trigger>
+						<button
+							class="inline-flex size-8 items-center justify-center rounded-md border border-border bg-surface-2 text-foreground"
+						>
+							<SettingsIcon class="size-3.5" />
+						</button>
+					</Tooltip.Trigger>
+					<Tooltip.Content side="left" portalProps={{ disabled: true }}
+						>Filter issues</Tooltip.Content
+					>
+				</Tooltip.Root>
+			</div>
+		</Tooltip.Provider>
+	{/snippet}
+</Story>
+
+<Story name="Right">
+	{#snippet template()}
+		<Tooltip.Provider>
+			<div class="flex items-center justify-center p-16">
+				<Tooltip.Root>
+					<Tooltip.Trigger>
+						<button
+							class="inline-flex size-8 items-center justify-center rounded-md border border-border bg-surface-2 text-foreground"
+						>
+							<SettingsIcon class="size-3.5" />
+						</button>
+					</Tooltip.Trigger>
+					<Tooltip.Content side="right" portalProps={{ disabled: true }}
+						>Forest view</Tooltip.Content
+					>
+				</Tooltip.Root>
+			</div>
+		</Tooltip.Provider>
+	{/snippet}
+</Story>
+
+<Story name="With Kbd">
+	{#snippet template()}
+		<Tooltip.Provider>
+			<div class="flex items-center justify-center p-16">
+				<Tooltip.Root>
+					<Tooltip.Trigger>
+						<button
+							class="inline-flex h-8 items-center rounded-md border border-border bg-surface-2 px-3 text-sm text-foreground"
+						>
+							Plant a tree
+						</button>
+					</Tooltip.Trigger>
+					<Tooltip.Content side="top" portalProps={{ disabled: true }}>
+						Start a new agent session
+						<kbd
+							data-slot="kbd"
+							class="inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-[4px] border border-border bg-surface-2 px-[5px] font-mono text-[10.5px] text-foreground-muted"
+						>
+							⌘N
+						</kbd>
+					</Tooltip.Content>
+				</Tooltip.Root>
+			</div>
+		</Tooltip.Provider>
+	{/snippet}
+</Story>
+
+<Story name="Rich">
+	{#snippet template()}
+		<Tooltip.Provider>
+			<div class="flex items-center justify-center p-16">
+				<Tooltip.Root>
+					<Tooltip.Trigger>
+						<div
+							class="flex size-14 items-center justify-center rounded-lg border border-border bg-surface-2 text-2xl"
+						>
+							🌳
+						</div>
+					</Tooltip.Trigger>
+					<Tooltip.Content
+						side="top"
+						class="w-[220px] whitespace-normal p-2.5"
+						portalProps={{ disabled: true }}
+					>
+						<div class="font-semibold">#128 · Build kanban DnD</div>
+						<div class="mt-0.5 text-[10.5px] leading-[1.4] opacity-80">
+							Claude · 2m 14s · 3 commits ahead
+						</div>
+					</Tooltip.Content>
+				</Tooltip.Root>
+			</div>
+		</Tooltip.Provider>
+	{/snippet}
+</Story>
+
+<Story name="Multi-line">
+	{#snippet template()}
+		<Tooltip.Provider>
+			<div class="flex items-center justify-center p-16">
+				<Tooltip.Root>
+					<Tooltip.Trigger>
+						<button
+							class="inline-flex h-8 items-center rounded-md border border-border bg-surface-2 px-3 text-sm text-foreground"
+						>
+							Hover me
+						</button>
+					</Tooltip.Trigger>
+					<Tooltip.Content
+						side="top"
+						class="w-[200px] whitespace-normal"
+						portalProps={{ disabled: true }}
+					>
+						Long tooltip text wraps onto multiple lines if it has to
+					</Tooltip.Content>
+				</Tooltip.Root>
+			</div>
+		</Tooltip.Provider>
+	{/snippet}
+</Story>
+
+<Story name="All Placements">
+	{#snippet template()}
+		<Tooltip.Provider>
+			<div class="grid grid-cols-2 gap-16 p-20">
+				<div class="flex items-center justify-center">
+					<Tooltip.Root>
+						<Tooltip.Trigger>
+							<button
+								class="inline-flex size-8 items-center justify-center rounded-md border border-border bg-surface-2 text-foreground"
+							>
+								<SettingsIcon class="size-3.5" />
+							</button>
+						</Tooltip.Trigger>
+						<Tooltip.Content side="top" portalProps={{ disabled: true }}
+							>Top · Sync now</Tooltip.Content
+						>
+					</Tooltip.Root>
+				</div>
+				<div class="flex items-center justify-center">
+					<Tooltip.Root>
+						<Tooltip.Trigger>
+							<button
+								class="inline-flex size-8 items-center justify-center rounded-md border border-border bg-surface-2 text-foreground"
+							>
+								<SettingsIcon class="size-3.5" />
+							</button>
+						</Tooltip.Trigger>
+						<Tooltip.Content side="bottom" portalProps={{ disabled: true }}
+							>Bottom · Plant a tree</Tooltip.Content
+						>
+					</Tooltip.Root>
+				</div>
+				<div class="flex items-center justify-center">
+					<Tooltip.Root>
+						<Tooltip.Trigger>
+							<button
+								class="inline-flex size-8 items-center justify-center rounded-md border border-border bg-surface-2 text-foreground"
+							>
+								<SettingsIcon class="size-3.5" />
+							</button>
+						</Tooltip.Trigger>
+						<Tooltip.Content side="left" portalProps={{ disabled: true }}
+							>Left · Filter issues</Tooltip.Content
+						>
+					</Tooltip.Root>
+				</div>
+				<div class="flex items-center justify-center">
+					<Tooltip.Root>
+						<Tooltip.Trigger>
+							<button
+								class="inline-flex size-8 items-center justify-center rounded-md border border-border bg-surface-2 text-foreground"
+							>
+								<SettingsIcon class="size-3.5" />
+							</button>
+						</Tooltip.Trigger>
+						<Tooltip.Content side="right" portalProps={{ disabled: true }}
+							>Right · Forest view</Tooltip.Content
+						>
+					</Tooltip.Root>
+				</div>
+			</div>
+		</Tooltip.Provider>
+	{/snippet}
+</Story>


### PR DESCRIPTION
## Description

Implemented all overlay/floating UI primitives as shadcn-style component wrappers around bits-ui v2:

- **Toast** (5-tone system): info/success/warning/danger/loading with dismissable, icon/action support, 6 Storybook stories
- **Tooltip** (4 placement stories): Rich, With Kbd, Multi-line, All Placements patterns
- **Popover** (composition model): Content wrapper with portalProps forwarding, Item/Label/Divider sub-components, 5 demo stories (Filter, Sort, Legend, Account Dropdown, Notifications)
- **Dialog** (full composition): Header/Body/Footer/Title/Description/Close/Overlay, portalProps forwarding, 2 stories (Plant Tree + Destructive Confirm)
- All components use `tailwind-variants` + semantic CSS tokens per existing patterns
- `portalProps` forwarding allows disabling portals in Storybook (prevents context breaks in Chromium)
- Storybook `defineMeta` targets `Root/Provider` (not `Content`) to prevent bits-ui context errors

## Resolves

Closes #102

## Testing

- Storybook stories added for all components (Toast 6 stories, Tooltip 4, Popover 5, Dialog 2)
- Components tested in isolation with various prop combinations