### PR TITLE
#103 feat(ui): build command palette with action registry

### DIFF
--- a/messages/cs.json
+++ b/messages/cs.json
@@ -222,5 +222,16 @@
 	"notification_toast_errored": "Session errored",
 	"notification_toast_pr_ready": "PR ready",
 
-	"lang_switcher": "Language"
+	"lang_switcher": "Language",
+
+	"command_palette_title": "Příkazová paleta",
+	"command_palette_placeholder": "Zadejte příkaz, hledejte…",
+	"command_palette_actions": "Akce",
+	"command_palette_navigation": "Navigace",
+	"command_palette_issues": "Úkoly",
+	"command_palette_navigate": "navigovat",
+	"command_palette_select": "vybrat",
+	"command_palette_close": "zavřít",
+	"command_palette_results": "{count} výsledků",
+	"command_palette_no_results": "Žádné výsledky"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -222,5 +222,16 @@
 	"notification_toast_errored": "Session errored",
 	"notification_toast_pr_ready": "PR ready",
 
-	"lang_switcher": "Language"
+	"lang_switcher": "Language",
+
+	"command_palette_title": "Command Palette",
+	"command_palette_placeholder": "Type a command, search…",
+	"command_palette_actions": "Actions",
+	"command_palette_navigation": "Navigation",
+	"command_palette_issues": "Issues",
+	"command_palette_navigate": "navigate",
+	"command_palette_select": "select",
+	"command_palette_close": "close",
+	"command_palette_results": "{count} results",
+	"command_palette_no_results": "No results found"
 }

--- a/src/lib/components/CommandPalette.svelte
+++ b/src/lib/components/CommandPalette.svelte
@@ -1,0 +1,159 @@
+<script lang="ts">
+	import * as m from '$lib/paraglide/messages.js';
+	import SearchIcon from '@lucide/svelte/icons/search';
+	import * as Dialog from '$lib/components/ui/dialog/index.js';
+	import { Kbd } from '$lib/components/ui/kbd/index.js';
+	import { Badge } from '$lib/components/ui/badge/index.js';
+	import {
+		useCommandPalette,
+		COMMAND_PALETTE_CATEGORIES,
+		type CommandPaletteCategory,
+	} from '$lib/modules/command-palette/index.js';
+
+	const paletteCtx = useCommandPalette();
+
+	let searchInputElement = $state<HTMLInputElement | null>(null);
+
+	const CATEGORY_LABELS: Record<CommandPaletteCategory, () => string> = {
+		[COMMAND_PALETTE_CATEGORIES.actions]: () => m.command_palette_actions(),
+		[COMMAND_PALETTE_CATEGORIES.navigation]: () => m.command_palette_navigation(),
+		[COMMAND_PALETTE_CATEGORIES.issues]: () => m.command_palette_issues(),
+	};
+
+	function handleKeydown(event: KeyboardEvent) {
+		if (event.key === 'ArrowDown') {
+			event.preventDefault();
+			paletteCtx.selectNext();
+		} else if (event.key === 'ArrowUp') {
+			event.preventDefault();
+			paletteCtx.selectPrevious();
+		} else if (event.key === 'Enter') {
+			event.preventDefault();
+			paletteCtx.executeSelected();
+		}
+	}
+
+	function handleDialogOpenChange(isOpen: boolean) {
+		paletteCtx.open = isOpen;
+		if (isOpen) {
+			requestAnimationFrame(() => {
+				searchInputElement?.focus();
+			});
+		}
+	}
+</script>
+
+<Dialog.Root open={paletteCtx.open} onOpenChange={handleDialogOpenChange}>
+	<Dialog.Content
+		class="top-[20%] -translate-y-0 max-w-[540px] overflow-hidden p-0"
+		onkeydown={handleKeydown}
+	>
+		<Dialog.Title class="sr-only">{m.command_palette_title()}</Dialog.Title>
+
+		<!-- Search row -->
+		<div class="flex items-center gap-2.5 border-b border-border px-3.5 py-3">
+			<SearchIcon size={14} class="shrink-0 text-foreground-subtle" />
+			<input
+				bind:this={searchInputElement}
+				type="text"
+				class="h-6 flex-1 border-none bg-transparent p-0 text-sm text-foreground shadow-none outline-none placeholder:text-foreground-subtle"
+				placeholder={m.command_palette_placeholder()}
+				value={paletteCtx.query}
+				oninput={(event) => {
+					paletteCtx.query = event.currentTarget.value;
+				}}
+			/>
+			<Kbd>esc</Kbd>
+		</div>
+
+		<!-- Results area -->
+		<div class="max-h-[320px] overflow-y-auto p-1.5">
+			{#each [...paletteCtx.groupedResults] as [category, items], groupIndex (category)}
+				{#if groupIndex > 0}
+					<hr data-slot="popover-divider" class="my-1 border-t border-border" />
+				{/if}
+
+				<div
+					data-slot="popover-label"
+					class="px-2 pb-1 pt-1.5 text-[length:var(--text-2xs)] font-medium uppercase tracking-wider text-foreground-subtle"
+				>
+					{CATEGORY_LABELS[category]()}
+				</div>
+
+				{#each items as item (item.id)}
+					{@const flatIdx = paletteCtx.flatIndexByItemId.get(item.id) ?? -1}
+					{@const isSelected = flatIdx === paletteCtx.selectedIndex}
+					<div
+						data-slot="popover-item"
+						data-state={isSelected ? 'active' : undefined}
+						role="option"
+						aria-selected={isSelected}
+						tabindex={-1}
+						class="flex min-h-[28px] w-full cursor-pointer select-none items-center gap-2 rounded-md px-2 py-1 text-[length:var(--text-sm)] text-foreground outline-none hover:bg-surface-2 focus-visible:bg-surface-2 data-[state=active]:bg-surface-2 data-[state=active]:text-primary"
+						onclick={() => paletteCtx.executeItem(item)}
+						onkeydown={(event) => {
+							if (event.key === 'Enter') {
+								event.preventDefault();
+								paletteCtx.executeItem(item);
+							}
+						}}
+						onmouseenter={() => {
+							paletteCtx.selectedIndex = flatIdx;
+						}}
+					>
+						<span class="truncate">{item.label}</span>
+						<span class="ml-auto flex shrink-0 items-center gap-1.5">
+							{#if item.shortcut}
+								<Kbd>{item.shortcut}</Kbd>
+							{/if}
+							{#if item.description}
+								{#if item.category === COMMAND_PALETTE_CATEGORIES.issues}
+									<Badge
+										variant={item.description === 'active'
+											? 'success'
+											: 'default'}
+									>
+										{item.description}
+									</Badge>
+								{:else}
+									<span
+										class="text-[length:var(--text-2xs)] text-foreground-subtle"
+									>
+										{item.description}
+									</span>
+								{/if}
+							{/if}
+						</span>
+					</div>
+				{/each}
+			{/each}
+
+			{#if paletteCtx.resultCount === 0 && paletteCtx.query.trim() !== ''}
+				<div class="px-2 py-4 text-center text-sm text-foreground-subtle">
+					{m.command_palette_no_results()}
+				</div>
+			{/if}
+		</div>
+
+		<!-- Footer -->
+		<div
+			class="flex items-center gap-3 border-t border-border px-3 py-2 text-[length:var(--text-2xs)] text-foreground-subtle"
+		>
+			<span class="flex items-center gap-1">
+				<Kbd>↑↓</Kbd>
+				{m.command_palette_navigate()}
+			</span>
+			<span class="flex items-center gap-1">
+				<Kbd>↵</Kbd>
+				{m.command_palette_select()}
+			</span>
+			<span class="flex items-center gap-1">
+				<Kbd>esc</Kbd>
+				{m.command_palette_close()}
+			</span>
+			<span class="ml-auto">
+				{m.command_palette_results({ count: paletteCtx.resultCount })}
+			</span>
+		</div>
+	</Dialog.Content>
+</Dialog.Root>

--- a/src/lib/modules/command-palette/command_palette.context.svelte.ts
+++ b/src/lib/modules/command-palette/command_palette.context.svelte.ts
@@ -1,0 +1,227 @@
+import { createContext } from 'svelte';
+import { SvelteMap } from 'svelte/reactivity';
+import { goto } from '$app/navigation';
+import { resolve } from '$app/paths';
+import { StateRaw } from '$lib/reactivity/state.svelte.js';
+import { useBoard } from '$lib/modules/board/index.js';
+import { useActions } from '$lib/modules/actions/index.js';
+import { useIssues } from '$lib/modules/issues/index.js';
+import { useKeyboardShortcuts } from '$lib/modules/keyboard-shortcuts/index.js';
+import { filterItems, groupByCategory, flattenGrouped } from './search.js';
+import { COMMAND_PALETTE_CATEGORIES } from './types.js';
+import type { CommandPaletteCategory, CommandPaletteItem } from './types.js';
+import type { ThemeMode } from '$lib/modules/board/index.js';
+
+// ─── Context ──────────────────────────────────────────────────────────────────
+
+type CommandPaletteContext = ReturnType<typeof createCommandPaletteContext>;
+
+const [useCommandPalette, setCommandPaletteInternal] = createContext<CommandPaletteContext>();
+export { useCommandPalette };
+
+export function setCommandPaletteContext() {
+	const ctx = createCommandPaletteContext();
+	setCommandPaletteInternal(ctx);
+	return ctx;
+}
+
+// ─── Factory ──────────────────────────────────────────────────────────────────
+
+function createCommandPaletteContext() {
+	const themeCycleOrder: ThemeMode[] = ['light', 'dark', 'system'];
+
+	const boardStore = useBoard();
+	const actionsCtx = useActions();
+	const issuesCtx = useIssues();
+	const shortcutsCtx = useKeyboardShortcuts();
+
+	const open = new StateRaw(false);
+	const query = new StateRaw('');
+	const selectedIndex = new StateRaw(0);
+
+	// ── Built-in navigation items ──────────────────────────────────────────
+
+	const navigationItems: CommandPaletteItem[] = [
+		{
+			id: 'nav-dashboard',
+			category: COMMAND_PALETTE_CATEGORIES.navigation,
+			label: 'Go to Dashboard',
+			onSelect: () => void goto(resolve('/')),
+		},
+		{
+			id: 'nav-sessions',
+			category: COMMAND_PALETTE_CATEGORIES.navigation,
+			label: 'Go to Sessions',
+			onSelect: () => void goto(resolve('/sessions')),
+		},
+		{
+			id: 'nav-settings',
+			category: COMMAND_PALETTE_CATEGORIES.navigation,
+			label: 'Go to Settings',
+			shortcut: shortcutsCtx.getBindingForDisplay('open-settings'),
+			onSelect: () => void goto(resolve('/settings')),
+		},
+	];
+
+	// ── Built-in utility items ─────────────────────────────────────────────
+
+	const utilityItems: CommandPaletteItem[] = [
+		{
+			id: 'util-toggle-theme',
+			category: COMMAND_PALETTE_CATEGORIES.actions,
+			label: 'Toggle Theme',
+			get description() {
+				return `Current: ${boardStore.theme.mode}`;
+			},
+			onSelect: () => {
+				const currentIndex = themeCycleOrder.indexOf(boardStore.theme.mode);
+				const nextIndex = (currentIndex + 1) % themeCycleOrder.length;
+				boardStore.theme.mode = themeCycleOrder[nextIndex];
+			},
+		},
+		{
+			id: 'util-toggle-sidebar',
+			category: COMMAND_PALETTE_CATEGORIES.actions,
+			label: 'Toggle Sidebar',
+			shortcut: shortcutsCtx.getBindingForDisplay('toggle-sidebar'),
+			onSelect: () => boardStore.toggleSidebar(),
+		},
+	];
+
+	// ── Derived items ──────────────────────────────────────────────────────
+
+	const actionItems = $derived(
+		actionsCtx.visibleActions.map(
+			(action): CommandPaletteItem => ({
+				id: `action-${action.id}`,
+				category: COMMAND_PALETTE_CATEGORIES.actions,
+				label: action.name,
+				onSelect: () => {},
+			}),
+		),
+	);
+
+	const issueItems = $derived(
+		issuesCtx.activeIssues.map(
+			(issue): CommandPaletteItem => ({
+				id: `issue-${issue.id}`,
+				category: COMMAND_PALETTE_CATEGORIES.issues,
+				label:
+					issue.github_issue_number !== null
+						? `#${issue.github_issue_number} ${issue.name}`
+						: issue.name,
+				description: issue.status,
+				onSelect: () => {},
+			}),
+		),
+	);
+
+	const allItems = $derived([...utilityItems, ...actionItems, ...navigationItems, ...issueItems]);
+	const filteredItems = $derived(filterItems(allItems, query.current));
+	const groupedResults = $derived(groupByCategory(filteredItems));
+	const flatResults = $derived(flattenGrouped(groupedResults));
+	const resultCount = $derived(flatResults.length);
+
+	const flatIndexByItemId = $derived.by(() => {
+		const map = new SvelteMap<string, number>();
+		for (let index = 0; index < flatResults.length; index++) {
+			map.set(flatResults[index].id, index);
+		}
+		return map;
+	});
+
+	// ── Methods ────────────────────────────────────────────────────────────
+
+	function resetState() {
+		query.current = '';
+		selectedIndex.current = 0;
+	}
+
+	function toggle() {
+		if (open.current) {
+			close();
+		} else {
+			open.current = true;
+			resetState();
+		}
+	}
+
+	function close() {
+		open.current = false;
+		resetState();
+	}
+
+	function selectNext() {
+		if (resultCount === 0) {
+			return;
+		}
+		selectedIndex.current = (selectedIndex.current + 1) % resultCount;
+	}
+
+	function selectPrevious() {
+		if (resultCount === 0) {
+			return;
+		}
+		selectedIndex.current = (selectedIndex.current - 1 + resultCount) % resultCount;
+	}
+
+	function executeSelected() {
+		if (resultCount === 0) {
+			return;
+		}
+		const item = flatResults[selectedIndex.current];
+		if (item !== undefined) {
+			item.onSelect();
+			close();
+		}
+	}
+
+	function executeItem(item: CommandPaletteItem) {
+		item.onSelect();
+		close();
+	}
+
+	return {
+		get open() {
+			return open.current;
+		},
+		set open(value: boolean) {
+			open.current = value;
+			if (!value) {
+				resetState();
+			}
+		},
+		get query() {
+			return query.current;
+		},
+		set query(value: string) {
+			query.current = value;
+			selectedIndex.current = 0;
+		},
+		get selectedIndex() {
+			return selectedIndex.current;
+		},
+		set selectedIndex(value: number) {
+			selectedIndex.current = value;
+		},
+		get groupedResults(): Map<CommandPaletteCategory, CommandPaletteItem[]> {
+			return groupedResults;
+		},
+		get flatResults(): CommandPaletteItem[] {
+			return flatResults;
+		},
+		get resultCount() {
+			return resultCount;
+		},
+		get flatIndexByItemId(): Map<string, number> {
+			return flatIndexByItemId;
+		},
+
+		toggle,
+		close,
+		selectNext,
+		selectPrevious,
+		executeSelected,
+		executeItem,
+	};
+}

--- a/src/lib/modules/command-palette/index.ts
+++ b/src/lib/modules/command-palette/index.ts
@@ -1,0 +1,8 @@
+export { filterItems, groupByCategory, flattenGrouped } from './search.js';
+export {
+	COMMAND_PALETTE_CATEGORIES,
+	CATEGORY_DISPLAY_ORDER,
+	type CommandPaletteCategory,
+	type CommandPaletteItem,
+} from './types.js';
+export { setCommandPaletteContext, useCommandPalette } from './command_palette.context.svelte.js';

--- a/src/lib/modules/command-palette/search.test.ts
+++ b/src/lib/modules/command-palette/search.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { filterItems, groupByCategory, flattenGrouped } from './search.js';
+import type { CommandPaletteItem } from './types.js';
+
+function makeItem(overrides: Partial<CommandPaletteItem> & { id: string }): CommandPaletteItem {
+	return {
+		category: 'actions',
+		label: 'Test Action',
+		onSelect: () => {},
+		...overrides,
+	};
+}
+
+describe('filterItems', () => {
+	const items: CommandPaletteItem[] = [
+		makeItem({ id: 'a1', label: 'Switch to forest view', category: 'navigation' }),
+		makeItem({ id: 'a2', label: 'Create new issue', description: 'session running' }),
+		makeItem({ id: 'a3', label: 'Open settings' }),
+	];
+
+	it('returns all items when query is empty string', () => {
+		const result = filterItems(items, '');
+		expect(result).toHaveLength(3);
+		expect(result).toEqual(items);
+	});
+
+	it('matches substring in label (case-insensitive)', () => {
+		const result = filterItems(items, 'for');
+		expect(result).toHaveLength(1);
+		expect(result[0].id).toBe('a1');
+	});
+
+	it('matches substring in description', () => {
+		const result = filterItems(items, 'running');
+		expect(result).toHaveLength(1);
+		expect(result[0].id).toBe('a2');
+	});
+
+	it('returns empty array when nothing matches', () => {
+		const result = filterItems(items, 'zzzznotfound');
+		expect(result).toHaveLength(0);
+	});
+
+	it('returns all items when query is whitespace-only', () => {
+		const result = filterItems(items, '   ');
+		expect(result).toHaveLength(3);
+		expect(result).toEqual(items);
+	});
+});
+
+describe('groupByCategory', () => {
+	it('groups items by their category field', () => {
+		const items: CommandPaletteItem[] = [
+			makeItem({ id: 'a1', category: 'actions' }),
+			makeItem({ id: 'n1', category: 'navigation' }),
+			makeItem({ id: 'a2', category: 'actions' }),
+		];
+
+		const grouped = groupByCategory(items);
+
+		expect(grouped.get('actions')).toHaveLength(2);
+		expect(grouped.get('navigation')).toHaveLength(1);
+	});
+
+	it('preserves display order: actions, navigation, issues', () => {
+		const items: CommandPaletteItem[] = [
+			makeItem({ id: 'i1', category: 'issues' }),
+			makeItem({ id: 'n1', category: 'navigation' }),
+			makeItem({ id: 'a1', category: 'actions' }),
+		];
+
+		const grouped = groupByCategory(items);
+		const keys = [...grouped.keys()];
+
+		expect(keys).toEqual(['actions', 'navigation', 'issues']);
+	});
+
+	it('omits categories with no items', () => {
+		const items: CommandPaletteItem[] = [
+			makeItem({ id: 'a1', category: 'actions' }),
+			makeItem({ id: 'i1', category: 'issues' }),
+		];
+
+		const grouped = groupByCategory(items);
+
+		expect(grouped.has('navigation')).toBe(false);
+		expect(grouped.size).toBe(2);
+	});
+});
+
+describe('flattenGrouped', () => {
+	it('produces a flat array in category order', () => {
+		const items: CommandPaletteItem[] = [
+			makeItem({ id: 'i1', category: 'issues', label: 'Issue 1' }),
+			makeItem({ id: 'a1', category: 'actions', label: 'Action 1' }),
+			makeItem({ id: 'n1', category: 'navigation', label: 'Nav 1' }),
+		];
+
+		const grouped = groupByCategory(items);
+		const flat = flattenGrouped(grouped);
+
+		expect(flat.map((item) => item.id)).toEqual(['a1', 'n1', 'i1']);
+	});
+
+	it('returns empty array when given empty map', () => {
+		const emptyMap = new Map();
+		const result = flattenGrouped(emptyMap);
+
+		expect(result).toEqual([]);
+		expect(result).toHaveLength(0);
+	});
+});

--- a/src/lib/modules/command-palette/search.ts
+++ b/src/lib/modules/command-palette/search.ts
@@ -1,0 +1,57 @@
+import { CATEGORY_DISPLAY_ORDER } from './types.js';
+import type { CommandPaletteCategory, CommandPaletteItem } from './types.js';
+
+export function filterItems(
+	items: readonly CommandPaletteItem[],
+	query: string,
+): CommandPaletteItem[] {
+	const trimmedQuery = query.trim().toLowerCase();
+
+	if (trimmedQuery === '') {
+		return [...items];
+	}
+
+	return items.filter((item) => {
+		const labelMatch = item.label.toLowerCase().includes(trimmedQuery);
+		const descriptionMatch = item.description?.toLowerCase().includes(trimmedQuery) ?? false;
+		return labelMatch || descriptionMatch;
+	});
+}
+
+export function groupByCategory(
+	items: readonly CommandPaletteItem[],
+): Map<CommandPaletteCategory, CommandPaletteItem[]> {
+	const categoryItemsLookup = new Map<CommandPaletteCategory, CommandPaletteItem[]>();
+
+	for (const item of items) {
+		const existing = categoryItemsLookup.get(item.category);
+		if (existing) {
+			existing.push(item);
+		} else {
+			categoryItemsLookup.set(item.category, [item]);
+		}
+	}
+
+	const orderedResult = new Map<CommandPaletteCategory, CommandPaletteItem[]>();
+
+	for (const category of CATEGORY_DISPLAY_ORDER) {
+		const categoryItems = categoryItemsLookup.get(category);
+		if (categoryItems) {
+			orderedResult.set(category, categoryItems);
+		}
+	}
+
+	return orderedResult;
+}
+
+export function flattenGrouped(
+	grouped: Map<CommandPaletteCategory, CommandPaletteItem[]>,
+): CommandPaletteItem[] {
+	const result: CommandPaletteItem[] = [];
+
+	for (const items of grouped.values()) {
+		result.push(...items);
+	}
+
+	return result;
+}

--- a/src/lib/modules/command-palette/types.ts
+++ b/src/lib/modules/command-palette/types.ts
@@ -1,0 +1,19 @@
+export const COMMAND_PALETTE_CATEGORIES = {
+	actions: 'actions',
+	navigation: 'navigation',
+	issues: 'issues',
+} as const;
+
+export type CommandPaletteCategory =
+	(typeof COMMAND_PALETTE_CATEGORIES)[keyof typeof COMMAND_PALETTE_CATEGORIES];
+
+export const CATEGORY_DISPLAY_ORDER: CommandPaletteCategory[] = ['actions', 'navigation', 'issues'];
+
+export interface CommandPaletteItem {
+	id: string;
+	category: CommandPaletteCategory;
+	label: string;
+	description?: string;
+	shortcut?: string;
+	onSelect: () => void;
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -21,6 +21,8 @@
 	import { setActionsContext } from '$lib/modules/actions';
 	import { setWindowContext, openWorkspaceWindow } from '$lib/modules/window';
 	import { setKeyboardShortcutsContext } from '$lib/modules/keyboard-shortcuts';
+	import { setCommandPaletteContext } from '$lib/modules/command-palette';
+	import CommandPalette from '$lib/components/CommandPalette.svelte';
 	import type { Dashboard } from '$lib/types/generated';
 
 	let { children } = $props();
@@ -33,6 +35,7 @@
 	setVersionControlContext();
 	setActionsContext();
 	const shortcutsCtx = setKeyboardShortcutsContext();
+	const commandPaletteCtx = setCommandPaletteContext();
 
 	let editingDashboard = $state<Dashboard | null>(null);
 
@@ -49,7 +52,7 @@
 			id: 'command-palette',
 			label: 'Command Palette',
 			defaultBinding: 'Ctrl+K',
-			callback: () => {},
+			callback: () => commandPaletteCtx.toggle(),
 		});
 		shortcutsCtx.registerShortcut({
 			id: 'toggle-sidebar',
@@ -157,3 +160,5 @@
 	onUpdate={handleUpdateDashboard}
 	onDelete={handleDeleteDashboard}
 />
+
+<CommandPalette />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -21,6 +21,7 @@
 	import PruneWorktreesDialog from '$lib/components/PruneWorktreesDialog.svelte';
 	import ScissorsIcon from '@lucide/svelte/icons/scissors';
 	import type { PrunableIssue } from '$lib/types/generated';
+	import { useCommandPalette } from '$lib/modules/command-palette';
 
 	const boardStore = useBoard();
 	const issueStore = useIssues();
@@ -28,6 +29,7 @@
 	const actionStore = useActions();
 	const notificationStore = useNotifications();
 	const sessionStore = useSessions();
+	const commandPaletteCtx = useCommandPalette();
 
 	function getNotificationDotColor(issueId: string): string | null {
 		const issueSessions = sessionStore.sessionsByIssueId.get(issueId);
@@ -266,6 +268,7 @@
 		onViewModeChange={(mode) => (boardStore.viewMode = mode)}
 		onSync={githubRepoParts ? handleSyncAll : undefined}
 		onPlant={openCreateDialog}
+		onSearch={() => commandPaletteCtx.toggle()}
 	>
 		<button
 			class="inline-flex items-center gap-1 rounded-md border border-border px-2.5 py-1 text-xs text-muted-foreground transition-colors hover:border-border-strong hover:text-foreground"


### PR DESCRIPTION
## Summary

- Add global `Ctrl+K` command palette overlay with search-driven action list
- Fuzzy substring search across actions, navigation routes, and issues
- Results grouped by category (Actions, Navigation, Issues) with keyboard navigation
- Built-in actions: toggle theme, toggle sidebar; navigation: Dashboard, Sessions, Settings
- Issues from `useIssues()` display with `#number title` and status badge

## Implementation

- **`src/lib/modules/command-palette/`** — types, pure search functions (TDD, 10 tests), context with `StateRaw`, barrel
- **`src/lib/components/CommandPalette.svelte`** — Dialog-based overlay using popover primitives, Kbd hints, Badge for issue status
- **`src/routes/+layout.svelte`** — context provider, shortcut callback wiring, component render
- **`src/routes/+page.svelte`** — TopBar search button wiring
- **`messages/en.json` + `cs.json`** — 10 i18n keys each

## Known v1 limitations

- Action registry items (`useActions()`) appear but `onSelect` is a no-op — `executeAction(actionId, issueId)` requires an issue ID not available in the palette context. Future PRDs add domain-specific action execution.
- Issue items appear but `onSelect` is a no-op — opening the edit dialog requires page-level state. Future PRDs wire this.

## Test plan

- [x] `pnpm check:all` passes (format, lint, fallow, typecheck, eslint)
- [x] `pnpm test` — 378 tests pass (10 new search tests)
- [ ] Manual: `Ctrl+K` opens palette, search filters results, `↑↓` navigates, `Enter` selects, `Esc` closes
- [ ] Manual: Toggle theme action cycles light → dark → system
- [ ] Manual: Navigation actions route correctly
- [ ] Manual: TopBar search button opens palette

Fixes #103