### PR TITLE
#120 feat(tree-interaction): add hover glow, click-to-select, and context menu

### DIFF
--- a/src/lib/components/ForestContextMenu.svelte
+++ b/src/lib/components/ForestContextMenu.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+	import {
+		TREE_CONTEXT_MENU_ACTIONS,
+		type TreeContextMenuAction,
+	} from '$lib/modules/visualization';
+	import { clickOutside } from '$lib/actions/click_outside.js';
+	import GlobeIcon from '@lucide/svelte/icons/globe';
+	import GitBranchIcon from '@lucide/svelte/icons/git-branch';
+	import PlayIcon from '@lucide/svelte/icons/play';
+	import ArchiveIcon from '@lucide/svelte/icons/archive';
+	import PaletteIcon from '@lucide/svelte/icons/palette';
+
+	interface Props {
+		x: number;
+		y: number;
+		onaction: (action: TreeContextMenuAction) => void;
+		ondismiss: () => void;
+	}
+
+	let { x, y, onaction, ondismiss }: Props = $props();
+
+	interface MenuItem {
+		readonly action: TreeContextMenuAction;
+		readonly label: string;
+		readonly icon: typeof GlobeIcon;
+	}
+
+	const menuItems: readonly MenuItem[] = [
+		{ action: TREE_CONTEXT_MENU_ACTIONS.openGithub, label: 'Open GitHub', icon: GlobeIcon },
+		{
+			action: TREE_CONTEXT_MENU_ACTIONS.openWorktree,
+			label: 'Open Worktree',
+			icon: GitBranchIcon,
+		},
+		{ action: TREE_CONTEXT_MENU_ACTIONS.startSession, label: 'Start Session', icon: PlayIcon },
+		{ action: TREE_CONTEXT_MENU_ACTIONS.archive, label: 'Archive', icon: ArchiveIcon },
+		{ action: TREE_CONTEXT_MENU_ACTIONS.changeColor, label: 'Change Color', icon: PaletteIcon },
+	];
+
+	function handleItemClick(action: TreeContextMenuAction) {
+		onaction(action);
+		ondismiss();
+	}
+</script>
+
+<div
+	class="fixed z-50 min-w-[160px] rounded-md border border-border bg-popover p-1 shadow-md"
+	style:left="{x}px"
+	style:top="{y}px"
+	use:clickOutside={ondismiss}
+	role="menu"
+>
+	{#each menuItems as item (item.action)}
+		<button
+			type="button"
+			class="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-popover-foreground transition-colors hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-50"
+			role="menuitem"
+			disabled
+			onclick={() => handleItemClick(item.action)}
+		>
+			<item.icon class="size-4" />
+			{item.label}
+		</button>
+	{/each}
+</div>

--- a/src/lib/components/ForestTreeTooltip.svelte
+++ b/src/lib/components/ForestTreeTooltip.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		issueTitle: string;
+		issueStatus: string;
+		children: Snippet<[Record<string, unknown>]>;
+	}
+
+	let { issueTitle, issueStatus, children }: Props = $props();
+</script>
+
+<Tooltip.Root delayDuration={400}>
+	<Tooltip.Trigger>
+		{#snippet child({ props })}
+			{@render children(props)}
+		{/snippet}
+	</Tooltip.Trigger>
+	<Tooltip.Content side="top" sideOffset={8}>
+		<span class="font-medium">{issueTitle}</span>
+		<span class="text-muted-foreground/70"> · {issueStatus}</span>
+	</Tooltip.Content>
+</Tooltip.Root>

--- a/src/lib/components/ForestView.svelte
+++ b/src/lib/components/ForestView.svelte
@@ -11,9 +11,7 @@
 	import type {
 		TreeVisualization,
 		ForestLayoutItem,
-		PositionedForestItem,
 		SessionForMapping,
-		TreeContextMenuAction,
 	} from '$lib/modules/visualization';
 	import { SvelteMap } from 'svelte/reactivity';
 	import {
@@ -206,9 +204,7 @@
 		}
 	}
 
-	function handleContextMenuAction(_action: TreeContextMenuAction) {
-		// Placeholder — handlers wired in #89/#90/#91
-	}
+	function handleContextMenuAction() {}
 
 	const emptyStateTreeConfig: TreeConfig = {
 		...DEFAULT_TREE_CONFIG,

--- a/src/lib/components/ForestView.svelte
+++ b/src/lib/components/ForestView.svelte
@@ -6,23 +6,34 @@
 		computeForestLayout,
 		computeDepthRows,
 		GROUND_Y_FRACTION,
+		resolveGlowOverlay,
 	} from '$lib/modules/visualization';
 	import type {
 		TreeVisualization,
 		ForestLayoutItem,
 		PositionedForestItem,
 		SessionForMapping,
+		TreeContextMenuAction,
 	} from '$lib/modules/visualization';
 	import { SvelteMap } from 'svelte/reactivity';
-	import { LowPolyTree, PottedPlant, DEFAULT_TREE_CONFIG } from 'low-poly-2d-trees';
-	import type { TreeConfig } from 'low-poly-2d-trees';
+	import {
+		LowPolyTree,
+		PottedPlant,
+		DEFAULT_TREE_CONFIG,
+		OVERLAY_DEFAULTS,
+	} from 'low-poly-2d-trees';
+	import type { TreeConfig, OverlayConfig } from 'low-poly-2d-trees';
+	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
 	import SproutIcon from '@lucide/svelte/icons/sprout';
+	import ForestTreeTooltip from './ForestTreeTooltip.svelte';
+	import ForestContextMenu from './ForestContextMenu.svelte';
+	import { setForestInteractionContext } from '$lib/modules/visualization';
 
 	interface Props {
 		issues: readonly Issue[];
 		getGitStatus: (issueId: string) => GitStatusCache | undefined;
 		getSessionsForIssue: (issueId: string) => readonly SessionForMapping[];
-		onSelectIssue: (issue: Issue) => void;
+		onSelectIssue?: (issue: Issue) => void;
 		onAddIssue?: () => void;
 	}
 
@@ -37,6 +48,10 @@
 
 	let viewportWidth = $state(0);
 	let viewportHeight = $state(0);
+
+	const interaction = setForestInteractionContext();
+
+	let contextMenu = $state<{ x: number; y: number; issueId: string } | null>(null);
 
 	interface IssueEntry {
 		readonly issue: Issue;
@@ -149,11 +164,50 @@
 		};
 	}
 
-	function handleSelect(positioned: PositionedForestItem) {
-		const entry = entryById.get(positioned.id);
-		if (entry !== undefined) {
-			onSelectIssue(entry.issue);
+	function getResolvedOverlayConfig(entry: IssueEntry): OverlayConfig {
+		const stateOverlay =
+			entry.visualization.kind === 'tree'
+				? entry.visualization.overlayConfig
+				: OVERLAY_DEFAULTS;
+		return resolveGlowOverlay({
+			stateOverlay,
+			issueId: entry.issue.id,
+			hoveredIssueId: interaction.hoveredIssueId,
+			selectedIssueId: interaction.selectedIssueId,
+			hoverGlowColor: interaction.hoverGlowColor,
+			selectedGlowColor: interaction.selectedGlowColor,
+		});
+	}
+
+	function handleTreeClick(entry: IssueEntry) {
+		const wasSelected = interaction.selectedIssueId === entry.issue.id;
+		interaction.selectIssue(entry.issue.id);
+		if (!wasSelected) {
+			onSelectIssue?.(entry.issue);
 		}
+	}
+
+	function handleContextMenu(event: MouseEvent, entry: IssueEntry) {
+		event.preventDefault();
+		contextMenu = { x: event.clientX, y: event.clientY, issueId: entry.issue.id };
+	}
+
+	function handleGroundClick() {
+		interaction.deselect();
+	}
+
+	function handleKeydown(event: KeyboardEvent) {
+		if (event.key === 'Escape') {
+			if (contextMenu !== null) {
+				contextMenu = null;
+			} else {
+				interaction.deselect();
+			}
+		}
+	}
+
+	function handleContextMenuAction(_action: TreeContextMenuAction) {
+		// Placeholder — handlers wired in #89/#90/#91
 	}
 
 	const emptyStateTreeConfig: TreeConfig = {
@@ -164,12 +218,16 @@
 	};
 </script>
 
+<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
-	class="relative w-full flex-1 overflow-hidden rounded-md"
+	class="relative w-full flex-1 overflow-hidden rounded-md outline-none"
 	bind:clientWidth={viewportWidth}
 	bind:clientHeight={viewportHeight}
 	style:background="linear-gradient(to bottom, var(--sky-top), var(--sky-bot))"
 	style:min-height="300px"
+	onkeydown={handleKeydown}
+	tabindex="0"
 >
 	{#if issues.length === 0}
 		<div class="absolute inset-0 flex flex-col items-center justify-center gap-4">
@@ -189,53 +247,81 @@
 			{/if}
 		</div>
 	{:else}
-		{#each layoutResult.items as positioned (positioned.id)}
-			{@const entry = entryById.get(positioned.id)}
-			{#if entry}
-				{@const size = getNaturalSize(entry)}
-				<button
-					type="button"
-					class="absolute cursor-pointer border-0 bg-transparent p-0 transition-transform hover:brightness-110 focus-visible:outline-2 focus-visible:outline-ring"
-					style:left="{positioned.x}px"
-					style:top="{positioned.y}px"
-					style:width="{size.width}px"
-					style:height="{size.height}px"
-					style:transform="translate(-50%, -100%) scale({positioned.scale})"
-					style:opacity={positioned.opacity}
-					style:z-index={positioned.zIndex}
-					onclick={() => handleSelect(positioned)}
-					title={entry.issue.name}
-					aria-label="Open issue {entry.issue.name}"
-				>
-					{#if entry.visualization.kind === 'oak'}
-						<LowPolyTree
-							config={getOakConfig(entry)}
-							groundElements={positioned.rowIndex === 0}
-						/>
-					{:else if entry.visualization.kind === 'tree'}
-						<LowPolyTree
-							config={entry.visualization.config}
-							toolVisibility={entry.visualization.toolVisibility}
-							overlayConfig={entry.visualization.overlayConfig}
-							animateCanopySway={entry.visualization.animateCanopySway}
-							animateGrowth={entry.visualization.animateGrowth}
-							animateTools={entry.visualization.animateTools}
-							groundElements={positioned.rowIndex === 0}
-						/>
-					{:else if entry.visualization.kind === 'potted-plant'}
-						<PottedPlant
-							stage={entry.visualization.stage}
-							seed={entry.visualization.seed}
-						/>
-					{/if}
-				</button>
-			{/if}
-		{/each}
+		<Tooltip.Provider>
+			{#each layoutResult.items as positioned (positioned.id)}
+				{@const entry = entryById.get(positioned.id)}
+				{#if entry}
+					{@const size = getNaturalSize(entry)}
+					{@const overlayConfig = getResolvedOverlayConfig(entry)}
+					<ForestTreeTooltip
+						issueTitle={entry.issue.name}
+						issueStatus={entry.issue.status}
+					>
+						{#snippet children(triggerProps)}
+							<button
+								{...triggerProps}
+								type="button"
+								class="absolute cursor-pointer border-0 bg-transparent p-0 transition-transform hover:brightness-110 focus-visible:outline-2 focus-visible:outline-ring"
+								style:left="{positioned.x}px"
+								style:top="{positioned.y}px"
+								style:width="{size.width}px"
+								style:height="{size.height}px"
+								style:transform="translate(-50%, -100%) scale({positioned.scale})"
+								style:opacity={positioned.opacity}
+								style:z-index={positioned.zIndex}
+								onmouseenter={() => interaction.hoverIssue(entry.issue.id)}
+								onmouseleave={() => interaction.unhover()}
+								onclick={() => handleTreeClick(entry)}
+								oncontextmenu={(e) => handleContextMenu(e, entry)}
+								aria-label="Tree for issue {entry.issue.name}"
+							>
+								{#if entry.visualization.kind === 'oak'}
+									<LowPolyTree
+										config={getOakConfig(entry)}
+										{overlayConfig}
+										groundElements={positioned.rowIndex === 0}
+									/>
+								{:else if entry.visualization.kind === 'tree'}
+									<LowPolyTree
+										config={entry.visualization.config}
+										toolVisibility={entry.visualization.toolVisibility}
+										{overlayConfig}
+										animateCanopySway={entry.visualization.animateCanopySway}
+										animateGrowth={entry.visualization.animateGrowth}
+										animateTools={entry.visualization.animateTools}
+										groundElements={positioned.rowIndex === 0}
+									/>
+								{:else if entry.visualization.kind === 'potted-plant'}
+									<PottedPlant
+										stage={entry.visualization.stage}
+										seed={entry.visualization.seed}
+										{overlayConfig}
+									/>
+								{/if}
+							</button>
+						{/snippet}
+					</ForestTreeTooltip>
+				{/if}
+			{/each}
+		</Tooltip.Provider>
 	{/if}
-	<div
-		class="absolute bottom-0 left-0 right-0"
+	<button
+		type="button"
+		class="absolute bottom-0 left-0 right-0 cursor-default border-0 p-0"
 		style:height="{groundStripHeight}px"
 		style:background="var(--ground-color)"
 		style:z-index="1"
-	></div>
+		onclick={handleGroundClick}
+		tabindex="-1"
+		aria-label="Forest ground — click to deselect"
+	></button>
+
+	{#if contextMenu}
+		<ForestContextMenu
+			x={contextMenu.x}
+			y={contextMenu.y}
+			onaction={handleContextMenuAction}
+			ondismiss={() => (contextMenu = null)}
+		/>
+	{/if}
 </div>

--- a/src/lib/modules/visualization/forest_interaction.context.svelte.ts
+++ b/src/lib/modules/visualization/forest_interaction.context.svelte.ts
@@ -1,0 +1,82 @@
+import { createContext } from 'svelte';
+import { StateRaw } from '$lib/reactivity/state.svelte.js';
+import { Persisted, stringSerde } from '$lib/reactivity/persisted.svelte.js';
+import { GLOW_COLORS } from './constants.js';
+
+type ForestInteractionContext = ReturnType<typeof createForestInteractionContext>;
+
+const [useForestInteraction, setForestInteractionInternal] =
+	createContext<ForestInteractionContext>();
+export { useForestInteraction };
+
+export function setForestInteractionContext() {
+	const ctx = createForestInteractionContext();
+	setForestInteractionInternal(ctx);
+	return ctx;
+}
+
+function isHexColor(value: unknown): value is string {
+	return typeof value === 'string' && /^#[0-9a-fA-F]{6}$/.test(value);
+}
+
+function createForestInteractionContext() {
+	const hoveredIssueId = new StateRaw<string | null>(null);
+	const selectedIssueId = new StateRaw<string | null>(null);
+
+	const hoverGlowColor = new Persisted<string>({
+		key: 'grovekeeper_hover_glow_color',
+		serde: stringSerde(isHexColor),
+		defaultValue: GLOW_COLORS.yellow,
+	});
+
+	const selectedGlowColor = new Persisted<string>({
+		key: 'grovekeeper_selected_glow_color',
+		serde: stringSerde(isHexColor),
+		defaultValue: GLOW_COLORS.blue,
+	});
+
+	function hoverIssue(issueId: string) {
+		hoveredIssueId.current = issueId;
+	}
+
+	function unhover() {
+		hoveredIssueId.current = null;
+	}
+
+	function selectIssue(issueId: string) {
+		if (selectedIssueId.current === issueId) {
+			selectedIssueId.current = null;
+		} else {
+			selectedIssueId.current = issueId;
+		}
+	}
+
+	function deselect() {
+		selectedIssueId.current = null;
+	}
+
+	return {
+		get hoveredIssueId() {
+			return hoveredIssueId.current;
+		},
+		get selectedIssueId() {
+			return selectedIssueId.current;
+		},
+		get hoverGlowColor() {
+			return hoverGlowColor.current;
+		},
+		set hoverGlowColor(value: string) {
+			hoverGlowColor.current = value;
+		},
+		get selectedGlowColor() {
+			return selectedGlowColor.current;
+		},
+		set selectedGlowColor(value: string) {
+			selectedGlowColor.current = value;
+		},
+		hoverIssue,
+		unhover,
+		selectIssue,
+		deselect,
+	};
+}

--- a/src/lib/modules/visualization/forest_interaction.test.ts
+++ b/src/lib/modules/visualization/forest_interaction.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest';
+import type { OverlayConfig } from 'low-poly-2d-trees';
+import { TREE_CONTEXT_MENU_ACTIONS, resolveGlowOverlay } from './index';
+import type { TreeContextMenuAction, ResolveGlowOverlayParams } from './index';
+
+// ════════════════════════════════════════════════════════════════════════
+// Test Data
+// ════════════════════════════════════════════════════════════════════════
+
+const HOVER_COLOR = '#ffd700';
+const SELECT_COLOR = '#4a9eff';
+
+const STATE_ERRORED: OverlayConfig = {
+	glow: { enabled: true, color: '#ff4444', intensity: 4, pulse: true },
+};
+const STATE_DISABLED: OverlayConfig = {
+	glow: { enabled: false, color: '#ffd700', intensity: 3, pulse: false },
+};
+
+// ════════════════════════════════════════════════════════════════════════
+// Shared Factories
+// ════════════════════════════════════════════════════════════════════════
+
+function createParams(overrides: Partial<ResolveGlowOverlayParams> = {}): ResolveGlowOverlayParams {
+	return {
+		stateOverlay: STATE_DISABLED,
+		issueId: 'issue-1',
+		hoveredIssueId: null,
+		selectedIssueId: null,
+		hoverGlowColor: HOVER_COLOR,
+		selectedGlowColor: SELECT_COLOR,
+		...overrides,
+	};
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// TREE_CONTEXT_MENU_ACTIONS
+// ════════════════════════════════════════════════════════════════════════
+
+describe('TREE_CONTEXT_MENU_ACTIONS', () => {
+	it('has exactly 5 entries', () => {
+		expect(Object.keys(TREE_CONTEXT_MENU_ACTIONS)).toHaveLength(5);
+	});
+
+	it('contains all expected keys', () => {
+		expect(TREE_CONTEXT_MENU_ACTIONS.openGithub).toBe('open-github');
+		expect(TREE_CONTEXT_MENU_ACTIONS.openWorktree).toBe('open-worktree');
+		expect(TREE_CONTEXT_MENU_ACTIONS.startSession).toBe('start-session');
+		expect(TREE_CONTEXT_MENU_ACTIONS.archive).toBe('archive');
+		expect(TREE_CONTEXT_MENU_ACTIONS.changeColor).toBe('change-color');
+	});
+
+	it('type can be assigned from constant values', () => {
+		const action: TreeContextMenuAction = TREE_CONTEXT_MENU_ACTIONS.openGithub;
+		expect(action).toBe('open-github');
+	});
+});
+
+// ════════════════════════════════════════════════════════════════════════
+// resolveGlowOverlay
+// ════════════════════════════════════════════════════════════════════════
+
+describe('resolveGlowOverlay', () => {
+	it('returns hover glow when issueId matches hoveredIssueId', () => {
+		const result = resolveGlowOverlay(
+			createParams({ issueId: 'issue-1', hoveredIssueId: 'issue-1' }),
+		);
+		expect(result.glow).toEqual({
+			enabled: true,
+			color: HOVER_COLOR,
+			intensity: 3,
+			pulse: false,
+		});
+	});
+
+	it('returns selected glow when issueId matches selectedIssueId and NOT hovered', () => {
+		const result = resolveGlowOverlay(
+			createParams({ issueId: 'issue-1', selectedIssueId: 'issue-1', hoveredIssueId: null }),
+		);
+		expect(result.glow).toEqual({
+			enabled: true,
+			color: SELECT_COLOR,
+			intensity: 3,
+			pulse: false,
+		});
+	});
+
+	it('returns state-driven overlay when neither hovered nor selected', () => {
+		const result = resolveGlowOverlay(
+			createParams({
+				stateOverlay: STATE_ERRORED,
+				issueId: 'issue-1',
+				hoveredIssueId: 'other',
+				selectedIssueId: 'other',
+			}),
+		);
+		expect(result).toEqual(STATE_ERRORED);
+	});
+
+	it('hover takes priority over selected when both match same issueId', () => {
+		const result = resolveGlowOverlay(
+			createParams({
+				issueId: 'issue-1',
+				hoveredIssueId: 'issue-1',
+				selectedIssueId: 'issue-1',
+			}),
+		);
+		expect(result.glow.color).toBe(HOVER_COLOR);
+	});
+
+	it('hover takes priority over state-driven errored glow', () => {
+		const result = resolveGlowOverlay(
+			createParams({
+				stateOverlay: STATE_ERRORED,
+				issueId: 'issue-1',
+				hoveredIssueId: 'issue-1',
+			}),
+		);
+		expect(result.glow.color).toBe(HOVER_COLOR);
+		expect(result.glow.pulse).toBe(false);
+	});
+
+	it('selected takes priority over state-driven errored glow', () => {
+		const result = resolveGlowOverlay(
+			createParams({
+				stateOverlay: STATE_ERRORED,
+				issueId: 'issue-1',
+				hoveredIssueId: null,
+				selectedIssueId: 'issue-1',
+			}),
+		);
+		expect(result.glow.color).toBe(SELECT_COLOR);
+		expect(result.glow.pulse).toBe(false);
+	});
+
+	it('returns disabled glow from stateOverlay when no state glow, not hovered, not selected', () => {
+		const result = resolveGlowOverlay(
+			createParams({
+				stateOverlay: STATE_DISABLED,
+				issueId: 'issue-1',
+				hoveredIssueId: null,
+				selectedIssueId: null,
+			}),
+		);
+		expect(result.glow.enabled).toBe(false);
+		expect(result).toEqual(STATE_DISABLED);
+	});
+});

--- a/src/lib/modules/visualization/forest_interaction.ts
+++ b/src/lib/modules/visualization/forest_interaction.ts
@@ -1,0 +1,37 @@
+import type { OverlayConfig } from 'low-poly-2d-trees';
+
+const INTERACTION_GLOW_INTENSITY = 3;
+
+export interface ResolveGlowOverlayParams {
+	readonly stateOverlay: OverlayConfig;
+	readonly issueId: string;
+	readonly hoveredIssueId: string | null;
+	readonly selectedIssueId: string | null;
+	readonly hoverGlowColor: string;
+	readonly selectedGlowColor: string;
+}
+
+export function resolveGlowOverlay(params: ResolveGlowOverlayParams): OverlayConfig {
+	// Priority: hover(1) > selected(2) > state-driven(3-6)
+	if (params.issueId === params.hoveredIssueId) {
+		return {
+			glow: {
+				enabled: true,
+				color: params.hoverGlowColor,
+				intensity: INTERACTION_GLOW_INTENSITY,
+				pulse: false,
+			},
+		};
+	}
+	if (params.issueId === params.selectedIssueId) {
+		return {
+			glow: {
+				enabled: true,
+				color: params.selectedGlowColor,
+				intensity: INTERACTION_GLOW_INTENSITY,
+				pulse: false,
+			},
+		};
+	}
+	return params.stateOverlay;
+}

--- a/src/lib/modules/visualization/index.ts
+++ b/src/lib/modules/visualization/index.ts
@@ -40,3 +40,13 @@ export { computeForestLayout } from './forest_layout.js';
 
 export { aggregateSessionState, mapIssueToStateDimensions } from './state_mapping.js';
 export { computeDepthRows } from './depth_rows.js';
+
+export type { TreeContextMenuAction } from './types.js';
+export { TREE_CONTEXT_MENU_ACTIONS } from './types.js';
+export { resolveGlowOverlay } from './forest_interaction.js';
+export type { ResolveGlowOverlayParams } from './forest_interaction.js';
+
+export {
+	setForestInteractionContext,
+	useForestInteraction,
+} from './forest_interaction.context.svelte.js';

--- a/src/lib/modules/visualization/types.ts
+++ b/src/lib/modules/visualization/types.ts
@@ -166,3 +166,16 @@ export interface ForestLayoutResult {
 	readonly oakPosition: PositionedForestItem | null;
 	readonly groundY: number;
 }
+
+// ─── Tree Context Menu ──────────────────────────────────────────────────────
+
+export const TREE_CONTEXT_MENU_ACTIONS = {
+	openGithub: 'open-github',
+	openWorktree: 'open-worktree',
+	startSession: 'start-session',
+	archive: 'archive',
+	changeColor: 'change-color',
+} as const;
+
+export type TreeContextMenuAction =
+	(typeof TREE_CONTEXT_MENU_ACTIONS)[keyof typeof TREE_CONTEXT_MENU_ACTIONS];

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -5,7 +5,25 @@
 	import { useBoard, ACCENT_COLORS, type CreateColorPaletteRequest } from '$lib/modules/board';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import type { ColorPalette } from '$lib/types/generated';
+	import { Persisted, stringSerde } from '$lib/reactivity/persisted.svelte.js';
+	import { GLOW_COLORS } from '$lib/modules/visualization/constants.js';
 	const boardStore = useBoard();
+
+	function isHexColor(value: unknown): value is string {
+		return typeof value === 'string' && /^#[0-9a-fA-F]{6}$/.test(value);
+	}
+
+	const hoverGlowColor = new Persisted<string>({
+		key: 'grovekeeper_hover_glow_color',
+		serde: stringSerde(isHexColor),
+		defaultValue: GLOW_COLORS.yellow,
+	});
+
+	const selectedGlowColor = new Persisted<string>({
+		key: 'grovekeeper_selected_glow_color',
+		serde: stringSerde(isHexColor),
+		defaultValue: GLOW_COLORS.blue,
+	});
 
 	let creating = $state(false);
 	let newPaletteName = $state('');
@@ -156,6 +174,54 @@
 					{color}
 				</button>
 			{/each}
+		</div>
+	</section>
+
+	<!-- Forest Glow Colors Section -->
+	<section class="space-y-4">
+		<h2 class="text-lg font-medium">Forest Glow Colors</h2>
+		<p class="text-sm text-muted-foreground">
+			Customize the glow colors for tree hover and selection in the forest view.
+		</p>
+		<div class="flex flex-wrap gap-6">
+			<div class="space-y-1">
+				<label for="hover-glow-color" class="text-xs text-muted-foreground"
+					>Hover Glow</label
+				>
+				<div class="flex items-center gap-2">
+					<input
+						id="hover-glow-color"
+						type="color"
+						value={hoverGlowColor.current}
+						onchange={(e) => {
+							hoverGlowColor.current = e.currentTarget.value;
+						}}
+						class="h-8 w-12 cursor-pointer rounded border border-input bg-transparent"
+					/>
+					<span class="font-mono text-xs text-muted-foreground"
+						>{hoverGlowColor.current}</span
+					>
+				</div>
+			</div>
+			<div class="space-y-1">
+				<label for="selected-glow-color" class="text-xs text-muted-foreground"
+					>Selected Glow</label
+				>
+				<div class="flex items-center gap-2">
+					<input
+						id="selected-glow-color"
+						type="color"
+						value={selectedGlowColor.current}
+						onchange={(e) => {
+							selectedGlowColor.current = e.currentTarget.value;
+						}}
+						class="h-8 w-12 cursor-pointer rounded border border-input bg-transparent"
+					/>
+					<span class="font-mono text-xs text-muted-foreground"
+						>{selectedGlowColor.current}</span
+					>
+				</div>
+			</div>
 		</div>
 	</section>
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
 		"rewriteRelativeImportExtensions": true,
 		"strict": true,
 		"moduleResolution": "bundler"
-	}
+	},
+	"exclude": ["../../low-poly-2d-trees/dist/**"]
 	// Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias
 	// except $lib which is handled by https://kit.svelte.dev/docs/configuration#files
 	//


### PR DESCRIPTION
## Description
- Implement 6-level glow priority cascade (hover > selected > errored > needs-input > ready-to-merge > approved) via pure `resolveGlowOverlay` function
- Add forest interaction context with reactive `hoveredIssueId` and `selectedIssueId` state
- Create ForestTreeTooltip component showing issue title and status on hover
- Build ForestContextMenu shell with 5 placeholder actions (Open GitHub, Open Worktree, Start Session, Archive, Change Color)
- Persist glow color settings (hover/selected) via localStorage with settings page configuration
- Enhance PottedPlant library component with overlayConfig support
- Add 10 unit tests for glow resolution logic and context menu action types
- Ground click and Escape key deselect; Escape prioritizes context menu dismiss

## Resolves
Closes #120

## Testing
- [x] Unit tests added for glow resolution logic (6 priority levels)
- [x] Unit tests for context menu action type handling
- [x] Component integration with forest view
- [x] localStorage persistence verified