### PR TITLE
#122 feat(ui): collapsible split panel with tabs, PRD overview, and global selection bus

### DIFF
--- a/src/lib/components/ForestView.svelte
+++ b/src/lib/components/ForestView.svelte
@@ -25,17 +25,16 @@
 	import SproutIcon from '@lucide/svelte/icons/sprout';
 	import ForestTreeTooltip from './ForestTreeTooltip.svelte';
 	import ForestContextMenu from './ForestContextMenu.svelte';
-	import { setForestInteractionContext } from '$lib/modules/visualization';
+	import { useSelection } from '$lib/modules/board';
 
 	interface Props {
 		issues: readonly Issue[];
 		getGitStatus: (issueId: string) => GitStatusCache | undefined;
 		getSessionsForIssue: (issueId: string) => readonly SessionForMapping[];
-		onSelectIssue?: (issue: Issue) => void;
 		onAddIssue?: () => void;
 	}
 
-	let { issues, getGitStatus, getSessionsForIssue, onSelectIssue, onAddIssue }: Props = $props();
+	let { issues, getGitStatus, getSessionsForIssue, onAddIssue }: Props = $props();
 
 	const TREE_NATURAL_WIDTH = 100;
 	const TREE_NATURAL_HEIGHT = 100;
@@ -47,7 +46,7 @@
 	let viewportWidth = $state(0);
 	let viewportHeight = $state(0);
 
-	const interaction = setForestInteractionContext();
+	const interaction = useSelection();
 
 	let contextMenu = $state<{ x: number; y: number; issueId: string } | null>(null);
 
@@ -96,6 +95,11 @@
 			map.set(entry.issue.id, entry);
 		}
 		return map;
+	});
+
+	$effect(() => {
+		const oakEntry = entries.find((entry) => entry.visualization.kind === 'oak');
+		interaction.setPrdIssueId(oakEntry?.issue.id ?? null);
 	});
 
 	const layoutResult = $derived(
@@ -178,11 +182,7 @@
 	}
 
 	function handleTreeClick(entry: IssueEntry) {
-		const wasSelected = interaction.selectedIssueId === entry.issue.id;
 		interaction.selectIssue(entry.issue.id);
-		if (!wasSelected) {
-			onSelectIssue?.(entry.issue);
-		}
 	}
 
 	function handleContextMenu(event: MouseEvent, entry: IssueEntry) {
@@ -221,7 +221,7 @@
 	bind:clientWidth={viewportWidth}
 	bind:clientHeight={viewportHeight}
 	style:background="linear-gradient(to bottom, var(--sky-top), var(--sky-bot))"
-	style:min-height="300px"
+	style:min-height="0"
 	onkeydown={handleKeydown}
 	tabindex="0"
 >

--- a/src/lib/components/PrdOverview.svelte
+++ b/src/lib/components/PrdOverview.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+	import type { StageCounts } from '$lib/modules/board';
+
+	interface Props {
+		title: string;
+		completionRatio: number;
+		issueCount: number;
+		stageCounts: StageCounts;
+	}
+
+	let { title, completionRatio, issueCount, stageCounts }: Props = $props();
+
+	const completionPercent = $derived(Math.round(completionRatio * 100));
+	const stageEntries = $derived(Object.entries(stageCounts).filter(([, count]) => count > 0));
+</script>
+
+<div class="flex flex-col gap-4 p-4">
+	<div class="flex flex-col gap-1">
+		<h2 class="text-lg font-semibold text-foreground">{title}</h2>
+		<p class="text-sm text-muted-foreground">
+			{issueCount}
+			{issueCount === 1 ? 'issue' : 'issues'} · {completionPercent}% complete
+		</p>
+	</div>
+
+	<div class="flex flex-col gap-1.5">
+		<div class="flex items-center justify-between text-xs text-muted-foreground">
+			<span>Progress</span>
+			<span>{completionPercent}%</span>
+		</div>
+		<div class="h-2 w-full overflow-hidden rounded-full bg-muted">
+			<div
+				class="h-full rounded-full bg-primary transition-all duration-300"
+				style:width="{completionPercent}%"
+			></div>
+		</div>
+	</div>
+
+	{#if stageEntries.length > 0}
+		<div class="flex flex-col gap-2">
+			<h3 class="text-xs font-medium text-muted-foreground">Stages</h3>
+			<div class="flex flex-wrap gap-1.5">
+				{#each stageEntries as [stage, count] (stage)}
+					<span
+						class="inline-flex items-center gap-1 rounded-md bg-surface-2 px-2 py-0.5 text-xs text-foreground"
+					>
+						{stage}
+						<span class="text-muted-foreground">({count})</span>
+					</span>
+				{/each}
+			</div>
+		</div>
+	{/if}
+</div>

--- a/src/lib/components/WorkspaceBottomPanel.svelte
+++ b/src/lib/components/WorkspaceBottomPanel.svelte
@@ -1,0 +1,125 @@
+<script lang="ts">
+	import type { Issue } from '$lib/modules/issues';
+	import type { TreeVisualization } from '$lib/modules/visualization';
+	import {
+		useSelection,
+		BOTTOM_PANEL_TABS,
+		BOTTOM_PANEL_TAB_LABELS,
+		computeStageCounts,
+	} from '$lib/modules/board';
+	import type { BottomPanelTab } from '$lib/modules/board';
+	import * as Tabs from '$lib/components/ui/tabs/index.js';
+	import PrdOverview from './PrdOverview.svelte';
+
+	interface Props {
+		issues: readonly Issue[];
+		getVisualization: (issueId: string) => TreeVisualization | undefined;
+	}
+
+	let { issues, getVisualization }: Props = $props();
+
+	const selection = useSelection();
+
+	const tabValues = Object.values(BOTTOM_PANEL_TABS);
+
+	const prdIssue = $derived(issues.find((issue) => issue.id === selection.prdIssueId) ?? null);
+
+	const prdVisualization = $derived.by(() => {
+		if (prdIssue === null) {
+			return null;
+		}
+		const visualization = getVisualization(prdIssue.id);
+		if (visualization?.kind === 'oak') {
+			return visualization;
+		}
+		return null;
+	});
+
+	const stageCounts = $derived.by(() => {
+		const visualizations: Array<{ kind: string; stage?: string }> = [];
+		for (const issue of issues) {
+			const visualization = getVisualization(issue.id);
+			if (visualization === undefined) {
+				continue;
+			}
+			if (visualization.kind === 'tree') {
+				visualizations.push({ kind: 'tree', stage: visualization.config.stage });
+			} else if (visualization.kind === 'potted-plant') {
+				visualizations.push({ kind: 'potted-plant', stage: visualization.stage });
+			} else {
+				visualizations.push({ kind: visualization.kind });
+			}
+		}
+		return computeStageCounts(visualizations);
+	});
+
+	function handleTabClick(tab: BottomPanelTab) {
+		if (selection.activeTab === tab) {
+			selection.setActiveTab(null);
+		} else {
+			selection.setActiveTab(tab);
+		}
+	}
+
+	const selectedIssue = $derived(
+		selection.selectedIssueId !== null
+			? (issues.find((issue) => issue.id === selection.selectedIssueId) ?? null)
+			: null,
+	);
+</script>
+
+<div class="flex h-full flex-col">
+	<div class="shrink-0 border-b border-border px-2 pt-1">
+		<Tabs.Root>
+			{#each tabValues as tab (tab)}
+				<Tabs.Tab active={selection.activeTab === tab} onclick={() => handleTabClick(tab)}>
+					{BOTTOM_PANEL_TAB_LABELS[tab]}
+				</Tabs.Tab>
+			{/each}
+		</Tabs.Root>
+	</div>
+
+	<div class="flex-1 overflow-auto">
+		{#if selection.showPrdOverview}
+			<PrdOverview
+				title={prdIssue?.name ?? 'Workspace'}
+				completionRatio={prdVisualization?.completionRatio ?? 0}
+				issueCount={prdVisualization?.issueCount ?? issues.length}
+				{stageCounts}
+			/>
+		{:else if selection.activeTab === BOTTOM_PANEL_TABS.issueDetail}
+			<div class="p-4">
+				{#if selectedIssue}
+					<div class="flex flex-col gap-2">
+						<h3 class="text-sm font-semibold text-foreground">{selectedIssue.name}</h3>
+						<p class="text-xs text-muted-foreground">
+							Status: {selectedIssue.status} · Priority: {selectedIssue.priority ??
+								'none'}
+						</p>
+					</div>
+				{:else}
+					<p class="text-sm text-muted-foreground">Select an issue to view details</p>
+				{/if}
+			</div>
+		{:else if selection.activeTab === BOTTOM_PANEL_TABS.dependencies}
+			<div class="p-4">
+				<p class="text-sm text-muted-foreground">Dependencies view coming soon</p>
+			</div>
+		{:else if selection.activeTab === BOTTOM_PANEL_TABS.activity}
+			<div class="p-4">
+				<p class="text-sm text-muted-foreground">Activity feed coming soon</p>
+			</div>
+		{:else if selection.activeTab === BOTTOM_PANEL_TABS.session}
+			<div class="p-4">
+				<p class="text-sm text-muted-foreground">Session view coming soon</p>
+			</div>
+		{:else}
+			<PrdOverview
+				title={prdIssue?.name ?? 'Workspace'}
+				completionRatio={prdVisualization?.completionRatio ?? 0}
+				issueCount={prdVisualization?.issueCount ?? issues.length}
+				{stageCounts}
+			/>
+		{/if}
+	</div>
+</div>

--- a/src/lib/components/WorkspaceDashboardLayout.svelte
+++ b/src/lib/components/WorkspaceDashboardLayout.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import { PaneGroup, Pane, PaneResizer } from 'paneforge';
+	import TreesIcon from '@lucide/svelte/icons/trees';
+
+	interface Props {
+		forestPanel: Snippet;
+		bottomPanel: Snippet;
+	}
+
+	let { forestPanel, bottomPanel }: Props = $props();
+
+	let topPane = $state<ReturnType<typeof Pane>>();
+	let collapsed = $state(false);
+
+	function handleCollapseToggle() {
+		if (collapsed) {
+			topPane?.expand();
+		} else {
+			topPane?.collapse();
+		}
+	}
+</script>
+
+<PaneGroup direction="vertical" class="h-full" autoSaveId="grovekeeper-forest-split">
+	<Pane
+		bind:this={topPane}
+		defaultSize={65}
+		collapsible={true}
+		collapsedSize={0}
+		onCollapse={() => (collapsed = true)}
+		onExpand={() => (collapsed = false)}
+	>
+		<div class="h-full overflow-hidden">
+			{@render forestPanel()}
+		</div>
+	</Pane>
+	<button
+		type="button"
+		class="flex w-full shrink-0 items-center justify-center gap-1.5 border-y border-border bg-surface-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+		onclick={handleCollapseToggle}
+		aria-label={collapsed ? 'Expand forest panel' : 'Collapse forest panel'}
+	>
+		<TreesIcon class="size-3.5" />
+	</button>
+	<PaneResizer
+		class="relative flex h-1 cursor-row-resize items-center justify-center bg-transparent transition-colors hover:bg-border data-[active]:bg-border"
+	>
+		<div class="absolute h-[3px] w-8 rounded-full bg-border transition-colors"></div>
+	</PaneResizer>
+	<Pane minSize={20}>
+		<div class="flex h-full flex-col overflow-hidden">
+			{@render bottomPanel()}
+		</div>
+	</Pane>
+</PaneGroup>

--- a/src/lib/modules/board/index.ts
+++ b/src/lib/modules/board/index.ts
@@ -15,3 +15,14 @@ export type {
 	AccentColor,
 } from './types.js';
 export { ACCENT_COLORS } from './types.js';
+
+export { setSelectionContext, useSelection } from './selection.context.svelte.js';
+export {
+	BOTTOM_PANEL_TABS,
+	TAB_BEHAVIOR_MAP,
+	BOTTOM_PANEL_TAB_LABELS,
+	shouldShowPrdOverview,
+	computeStageCounts,
+	isBottomPanelTab,
+} from './selection.js';
+export type { BottomPanelTab, TabBehavior, StageCounts } from './selection.js';

--- a/src/lib/modules/board/selection.context.svelte.ts
+++ b/src/lib/modules/board/selection.context.svelte.ts
@@ -1,17 +1,18 @@
 import { createContext } from 'svelte';
 import { StateRaw } from '$lib/reactivity/state.svelte.js';
 import { Persisted, stringSerde } from '$lib/reactivity/persisted.svelte.js';
-import { GLOW_COLORS } from './constants.js';
+import { GLOW_COLORS } from '$lib/modules/visualization/constants.js';
+import { BOTTOM_PANEL_TABS, shouldShowPrdOverview } from './selection.js';
+import type { BottomPanelTab } from './selection.js';
 
-type ForestInteractionContext = ReturnType<typeof createForestInteractionContext>;
+type SelectionContext = ReturnType<typeof createSelectionContext>;
 
-const [useForestInteraction, setForestInteractionInternal] =
-	createContext<ForestInteractionContext>();
-export { useForestInteraction };
+const [useSelection, setSelectionInternal] = createContext<SelectionContext>();
+export { useSelection };
 
-export function setForestInteractionContext() {
-	const ctx = createForestInteractionContext();
-	setForestInteractionInternal(ctx);
+export function setSelectionContext() {
+	const ctx = createSelectionContext();
+	setSelectionInternal(ctx);
 	return ctx;
 }
 
@@ -19,9 +20,12 @@ function isHexColor(value: unknown): value is string {
 	return typeof value === 'string' && /^#[0-9a-fA-F]{6}$/.test(value);
 }
 
-function createForestInteractionContext() {
-	const hoveredIssueId = new StateRaw<string | null>(null);
+function createSelectionContext() {
 	const selectedIssueId = new StateRaw<string | null>(null);
+	const hoveredIssueId = new StateRaw<string | null>(null);
+	const activeTab = new StateRaw<BottomPanelTab | null>(null);
+	const prdIssueId = new StateRaw<string | null>(null);
+	const forestCollapsed = new StateRaw(false);
 
 	const hoverGlowColor = new Persisted<string>({
 		key: 'grovekeeper_hover_glow_color',
@@ -46,13 +50,30 @@ function createForestInteractionContext() {
 	function selectIssue(issueId: string) {
 		if (selectedIssueId.current === issueId) {
 			selectedIssueId.current = null;
+			activeTab.current = null;
 		} else {
 			selectedIssueId.current = issueId;
+			if (activeTab.current === null && !shouldShowPrdOverview(issueId, prdIssueId.current)) {
+				activeTab.current = BOTTOM_PANEL_TABS.issueDetail;
+			}
 		}
 	}
 
 	function deselect() {
 		selectedIssueId.current = null;
+		activeTab.current = null;
+	}
+
+	function setActiveTab(tab: BottomPanelTab | null) {
+		activeTab.current = tab;
+	}
+
+	function setPrdIssueId(id: string | null) {
+		prdIssueId.current = id;
+	}
+
+	function toggleForestCollapsed() {
+		forestCollapsed.current = !forestCollapsed.current;
 	}
 
 	return {
@@ -61,6 +82,15 @@ function createForestInteractionContext() {
 		},
 		get selectedIssueId() {
 			return selectedIssueId.current;
+		},
+		get activeTab() {
+			return activeTab.current;
+		},
+		get prdIssueId() {
+			return prdIssueId.current;
+		},
+		get showPrdOverview() {
+			return shouldShowPrdOverview(selectedIssueId.current, prdIssueId.current);
 		},
 		get hoverGlowColor() {
 			return hoverGlowColor.current;
@@ -74,9 +104,15 @@ function createForestInteractionContext() {
 		set selectedGlowColor(value: string) {
 			selectedGlowColor.current = value;
 		},
+		get forestCollapsed() {
+			return forestCollapsed.current;
+		},
 		hoverIssue,
 		unhover,
 		selectIssue,
 		deselect,
+		setActiveTab,
+		setPrdIssueId,
+		toggleForestCollapsed,
 	};
 }

--- a/src/lib/modules/board/selection.test.ts
+++ b/src/lib/modules/board/selection.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from 'vitest';
+import {
+	BOTTOM_PANEL_TABS,
+	TAB_BEHAVIOR_MAP,
+	BOTTOM_PANEL_TAB_LABELS,
+	shouldShowPrdOverview,
+	computeStageCounts,
+	isBottomPanelTab,
+} from './selection.js';
+
+describe('BOTTOM_PANEL_TABS', () => {
+	it('has exactly 4 entries with correct values', () => {
+		expect(BOTTOM_PANEL_TABS).toEqual({
+			issueDetail: 'issue-detail',
+			dependencies: 'dependencies',
+			activity: 'activity',
+			session: 'session',
+		});
+		expect(Object.keys(BOTTOM_PANEL_TABS)).toHaveLength(4);
+	});
+});
+
+describe('TAB_BEHAVIOR_MAP', () => {
+	it('maps issue-detail to replace', () => {
+		expect(TAB_BEHAVIOR_MAP['issue-detail']).toBe('replace');
+	});
+
+	it('maps dependencies to highlight', () => {
+		expect(TAB_BEHAVIOR_MAP['dependencies']).toBe('highlight');
+	});
+
+	it('maps activity to filter', () => {
+		expect(TAB_BEHAVIOR_MAP['activity']).toBe('filter');
+	});
+
+	it('maps session to replace', () => {
+		expect(TAB_BEHAVIOR_MAP['session']).toBe('replace');
+	});
+
+	it('covers all tabs', () => {
+		const tabValues = Object.values(BOTTOM_PANEL_TABS);
+		const mappedTabs = Object.keys(TAB_BEHAVIOR_MAP);
+		expect(mappedTabs).toHaveLength(tabValues.length);
+		for (const tab of tabValues) {
+			expect(TAB_BEHAVIOR_MAP).toHaveProperty(tab);
+		}
+	});
+});
+
+describe('shouldShowPrdOverview', () => {
+	it('returns true when selectedIssueId is null (no selection)', () => {
+		expect(shouldShowPrdOverview(null, 'prd-123')).toBe(true);
+	});
+
+	it('returns true when selectedIssueId equals prdIssueId', () => {
+		expect(shouldShowPrdOverview('prd-123', 'prd-123')).toBe(true);
+	});
+
+	it('returns false when selectedIssueId is a non-PRD issue', () => {
+		expect(shouldShowPrdOverview('issue-456', 'prd-123')).toBe(false);
+	});
+
+	it('returns true when both are null', () => {
+		expect(shouldShowPrdOverview(null, null)).toBe(true);
+	});
+
+	it('returns false when prdIssueId is null but selectedIssueId is set', () => {
+		expect(shouldShowPrdOverview('issue-456', null)).toBe(false);
+	});
+});
+
+describe('BOTTOM_PANEL_TAB_LABELS', () => {
+	it('maps each tab to correct display label', () => {
+		expect(BOTTOM_PANEL_TAB_LABELS['issue-detail']).toBe('Issue Detail');
+		expect(BOTTOM_PANEL_TAB_LABELS['dependencies']).toBe('Dependencies');
+		expect(BOTTOM_PANEL_TAB_LABELS['activity']).toBe('Activity');
+		expect(BOTTOM_PANEL_TAB_LABELS['session']).toBe('Session');
+	});
+
+	it('has a non-empty label for every tab', () => {
+		const tabValues = Object.values(BOTTOM_PANEL_TABS);
+		for (const tab of tabValues) {
+			const label = BOTTOM_PANEL_TAB_LABELS[tab];
+			expect(label).toBeDefined();
+			expect(typeof label).toBe('string');
+			expect(label.length).toBeGreaterThan(0);
+		}
+	});
+});
+
+describe('computeStageCounts', () => {
+	it('returns empty object for empty array', () => {
+		expect(computeStageCounts([])).toEqual({});
+	});
+
+	it('counts trees by stage field', () => {
+		const visualizations = [
+			{ kind: 'tree', stage: 'seed' },
+			{ kind: 'tree', stage: 'sapling' },
+			{ kind: 'tree', stage: 'seed' },
+		];
+		expect(computeStageCounts(visualizations)).toEqual({ seed: 2, sapling: 1 });
+	});
+
+	it('counts potted-plant by stage field', () => {
+		const visualizations = [
+			{ kind: 'potted-plant', stage: 'sprout' },
+			{ kind: 'potted-plant', stage: 'flowering' },
+		];
+		expect(computeStageCounts(visualizations)).toEqual({ sprout: 1, flowering: 1 });
+	});
+
+	it('uses kind as stage name for oak', () => {
+		const visualizations = [{ kind: 'oak' }];
+		expect(computeStageCounts(visualizations)).toEqual({ oak: 1 });
+	});
+
+	it('handles mixed visualizations correctly', () => {
+		const visualizations = [
+			{ kind: 'tree', stage: 'seed' },
+			{ kind: 'potted-plant', stage: 'sprout' },
+			{ kind: 'oak' },
+			{ kind: 'tree', stage: 'seed' },
+			{ kind: 'oak' },
+		];
+		expect(computeStageCounts(visualizations)).toEqual({
+			seed: 2,
+			sprout: 1,
+			oak: 2,
+		});
+	});
+});
+
+describe('isBottomPanelTab', () => {
+	it('returns true for valid tab values', () => {
+		expect(isBottomPanelTab('issue-detail')).toBe(true);
+		expect(isBottomPanelTab('dependencies')).toBe(true);
+		expect(isBottomPanelTab('activity')).toBe(true);
+		expect(isBottomPanelTab('session')).toBe(true);
+	});
+
+	it('returns false for invalid strings', () => {
+		expect(isBottomPanelTab('unknown-tab')).toBe(false);
+		expect(isBottomPanelTab('')).toBe(false);
+		expect(isBottomPanelTab('issueDetail')).toBe(false);
+	});
+
+	it('returns false for non-string values', () => {
+		expect(isBottomPanelTab(null)).toBe(false);
+		expect(isBottomPanelTab(undefined)).toBe(false);
+		expect(isBottomPanelTab(42)).toBe(false);
+	});
+});

--- a/src/lib/modules/board/selection.ts
+++ b/src/lib/modules/board/selection.ts
@@ -1,0 +1,75 @@
+// ─── Bottom Panel Tab Constants ──────────────────────────────────────────
+
+export const BOTTOM_PANEL_TABS = {
+	issueDetail: 'issue-detail',
+	dependencies: 'dependencies',
+	activity: 'activity',
+	session: 'session',
+} as const;
+
+export type BottomPanelTab = (typeof BOTTOM_PANEL_TABS)[keyof typeof BOTTOM_PANEL_TABS];
+
+// ─── Tab Behavior ────────────────────────────────────────────────────────
+
+export type TabBehavior = 'replace' | 'filter' | 'highlight';
+
+export const TAB_BEHAVIOR_MAP = {
+	'issue-detail': 'replace',
+	dependencies: 'highlight',
+	activity: 'filter',
+	session: 'replace',
+} as const satisfies Record<BottomPanelTab, TabBehavior>;
+
+// ─── Tab Labels ──────────────────────────────────────────────────────────
+
+export const BOTTOM_PANEL_TAB_LABELS = {
+	'issue-detail': 'Issue Detail',
+	dependencies: 'Dependencies',
+	activity: 'Activity',
+	session: 'Session',
+} as const satisfies Record<BottomPanelTab, string>;
+
+// ─── PRD Overview Logic ──────────────────────────────────────────────────
+
+export function shouldShowPrdOverview(
+	selectedIssueId: string | null,
+	prdIssueId: string | null,
+): boolean {
+	if (selectedIssueId === null) {
+		return true;
+	}
+	if (selectedIssueId === prdIssueId) {
+		return true;
+	}
+	return false;
+}
+
+// ─── Stage Counts ────────────────────────────────────────────────────────
+
+export interface StageCounts {
+	readonly [stage: string]: number;
+}
+
+export function computeStageCounts(
+	visualizations: ReadonlyArray<{ readonly kind: string; readonly stage?: string }>,
+): StageCounts {
+	const counts: Record<string, number> = {};
+	for (const visualization of visualizations) {
+		const stageName =
+			visualization.kind === 'tree' || visualization.kind === 'potted-plant'
+				? visualization.stage
+				: visualization.kind;
+		if (stageName !== undefined) {
+			counts[stageName] = (counts[stageName] ?? 0) + 1;
+		}
+	}
+	return counts;
+}
+
+// ─── Type Guards ─────────────────────────────────────────────────────────
+
+const BOTTOM_PANEL_TAB_VALUES: ReadonlySet<string> = new Set(Object.values(BOTTOM_PANEL_TABS));
+
+export function isBottomPanelTab(value: unknown): value is BottomPanelTab {
+	return typeof value === 'string' && BOTTOM_PANEL_TAB_VALUES.has(value);
+}

--- a/src/lib/modules/visualization/index.ts
+++ b/src/lib/modules/visualization/index.ts
@@ -45,8 +45,3 @@ export type { TreeContextMenuAction } from './types.js';
 export { TREE_CONTEXT_MENU_ACTIONS } from './types.js';
 export { resolveGlowOverlay } from './forest_interaction.js';
 export type { ResolveGlowOverlayParams } from './forest_interaction.js';
-
-export {
-	setForestInteractionContext,
-	useForestInteraction,
-} from './forest_interaction.context.svelte.js';

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -11,6 +11,7 @@
 	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
 	import {
 		setBoardContext,
+		setSelectionContext,
 		type CreateDashboardRequest,
 		type UpdateDashboardRequest,
 	} from '$lib/modules/board';
@@ -29,6 +30,7 @@
 
 	const windowCtx = setWindowContext();
 	const boardStore = setBoardContext();
+	setSelectionContext();
 	const notificationsCtx = setNotificationsContext();
 	const sessionStore = setSessionsContext(notificationsCtx);
 	setIssuesContext();

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
 	import { onMount, untrack } from 'svelte';
-	import { useBoard, FALLBACK_ISSUE_COLOR } from '$lib/modules/board';
+	import { useBoard, useSelection, FALLBACK_ISSUE_COLOR } from '$lib/modules/board';
 	import { useIssues } from '$lib/modules/issues';
 	import { useVersionControl } from '$lib/modules/version-control';
 	import { useActions } from '$lib/modules/actions';
@@ -17,6 +17,10 @@
 	import TopBar from '$lib/components/TopBar.svelte';
 	import IssueCardList from '$lib/components/IssueCardList.svelte';
 	import ForestView from '$lib/components/ForestView.svelte';
+	import WorkspaceDashboardLayout from '$lib/components/WorkspaceDashboardLayout.svelte';
+	import WorkspaceBottomPanel from '$lib/components/WorkspaceBottomPanel.svelte';
+	import { computeVisualization } from '$lib/modules/visualization';
+	import type { TreeVisualization } from '$lib/modules/visualization';
 	import IssueCreateDialog from '$lib/components/IssueCreateDialog.svelte';
 	import IssueEditDialog from '$lib/components/IssueEditDialog.svelte';
 	import GhSetupBanner from '$lib/components/GhSetupBanner.svelte';
@@ -33,6 +37,7 @@
 	const notificationStore = useNotifications();
 	const sessionStore = useSessions();
 	const commandPaletteCtx = useCommandPalette();
+	const selection = useSelection();
 
 	function getNotificationDotColor(issueId: string): string | null {
 		const issueSessions = sessionStore.sessionsByIssueId.get(issueId);
@@ -248,7 +253,27 @@
 			pruneRemoving = false;
 		}
 	}
+
+	function getVisualization(issueId: string): TreeVisualization | undefined {
+		const issue = forestIssues.find((i) => i.id === issueId);
+		if (issue === undefined) {
+			return undefined;
+		}
+		return computeVisualization(
+			issue,
+			versionControlStore.getState(issueId),
+			sessionStore.sessionsByIssueId.get(issueId) ?? [],
+		);
+	}
+
+	function handlePageKeydown(event: KeyboardEvent) {
+		if (event.key === 'Escape' && boardStore.viewMode === 'forest') {
+			selection.deselect();
+		}
+	}
 </script>
+
+<svelte:window onkeydown={handlePageKeydown} />
 
 {#if boardStore.loading}
 	<p class="text-muted-foreground">{m.loading()}</p>
@@ -283,30 +308,45 @@
 		</button>
 	</TopBar>
 
-	<div class="flex flex-col gap-4 p-5">
-		<!-- gh CLI setup banner -->
-		{#if githubRepoParts && versionControlStore.ghAvailability !== 'available'}
-			<GhSetupBanner availability={versionControlStore.ghAvailability} />
-		{/if}
-
-		<!-- Issue list or empty state -->
-		{#if issueStore.loading}
+	{#if issueStore.loading}
+		<div class="p-5">
 			<p class="text-muted-foreground">{m.loading_issues()}</p>
-		{:else if issueStore.error}
+		</div>
+	{:else if issueStore.error}
+		<div class="p-5">
 			<p class="text-destructive">{m.error_prefix({ message: issueStore.error })}</p>
-		{:else if issueStore.activeIssues.length === 0 && issueStore.archivedIssues.length === 0}
+		</div>
+	{:else if issueStore.activeIssues.length === 0 && issueStore.archivedIssues.length === 0}
+		<div class="p-5">
 			<EmptyIssueState onAddIssue={openCreateDialog} />
-		{:else if boardStore.viewMode === 'kanban'}
+		</div>
+	{:else if boardStore.viewMode === 'kanban'}
+		<div class="p-5">
 			<p class="text-muted-foreground">{m.kanban_coming_soon()}</p>
-		{:else if boardStore.viewMode === 'forest'}
-			<ForestView
-				issues={forestIssues}
-				getGitStatus={(issueId) => versionControlStore.getState(issueId)}
-				getSessionsForIssue={(issueId) => sessionStore.sessionsByIssueId.get(issueId) ?? []}
-				onSelectIssue={(issue) => (editingIssue = issue)}
-				onAddIssue={openCreateDialog}
-			/>
-		{:else}
+		</div>
+	{:else if boardStore.viewMode === 'forest'}
+		<div class="flex-1 overflow-hidden">
+			<WorkspaceDashboardLayout>
+				{#snippet forestPanel()}
+					<ForestView
+						issues={forestIssues}
+						getGitStatus={(issueId) => versionControlStore.getState(issueId)}
+						getSessionsForIssue={(issueId) =>
+							sessionStore.sessionsByIssueId.get(issueId) ?? []}
+						onAddIssue={openCreateDialog}
+					/>
+				{/snippet}
+				{#snippet bottomPanel()}
+					<WorkspaceBottomPanel issues={forestIssues} {getVisualization} />
+				{/snippet}
+			</WorkspaceDashboardLayout>
+		</div>
+	{:else}
+		<div class="flex flex-col gap-4 p-5">
+			{#if githubRepoParts && versionControlStore.ghAvailability !== 'available'}
+				<GhSetupBanner availability={versionControlStore.ghAvailability} />
+			{/if}
+
 			<IssueCardList
 				parentIssues={issueStore.parentIssues}
 				archivedIssues={issueStore.archivedIssues}
@@ -327,16 +367,15 @@
 				onRemoveWorktree={handleRemoveWorktree}
 				onExecuteAction={handleExecuteAction}
 			/>
-		{/if}
 
-		<!-- Assigned issues panel -->
-		{#if versionControlStore.assignedIssues.length > 0}
-			<AssignedIssuesPanel
-				issues={versionControlStore.assignedIssues}
-				disabled={versionControlStore.isGhAvailable !== true}
-			/>
-		{/if}
-	</div>
+			{#if versionControlStore.assignedIssues.length > 0}
+				<AssignedIssuesPanel
+					issues={versionControlStore.assignedIssues}
+					disabled={versionControlStore.isGhAvailable !== true}
+				/>
+			{/if}
+		</div>
+	{/if}
 
 	<IssueCreateDialog
 		open={createDialogOpen}


### PR DESCRIPTION
## Summary

- **Global selection bus**: Lifts `selectedIssueId`/`hoveredIssueId` from ForestView's local context into a shared layout-level context (`selection.context.svelte.ts`), enabling bidirectional selection between forest and bottom panels
- **Collapsible split panel**: Paneforge-based vertical split with collapsible top (forest) pane, forest-icon handle, draggable resizer, and `autoSaveId` persistence
- **Tabbed bottom panel**: 4 tabs (Issue Detail, Dependencies, Activity, Session) with PRD overview as default content showing title, progress bar, and stage counts
- **Selection wiring**: Forest click → bottom panel updates (auto-promotes to Issue Detail tab), toggle deselect, Escape key deselect, ground click deselect

## Files Changed

| File | Change |
|------|--------|
| `selection.ts` | New — pure logic: tab types, behavior map, `shouldShowPrdOverview`, `computeStageCounts` |
| `selection.test.ts` | New — 24 unit tests for selection bus logic |
| `selection.context.svelte.ts` | New — global reactive context (replaces `forest_interaction.context.svelte.ts`) |
| `WorkspaceDashboardLayout.svelte` | New — collapsible split panel layout |
| `WorkspaceBottomPanel.svelte` | New — tabbed bottom panel with PRD overview |
| `PrdOverview.svelte` | New — PRD title, progress bar, stage counts |
| `ForestView.svelte` | Refactored — uses `useSelection()` instead of local context |
| `+page.svelte` | Restructured — forest mode uses split layout, added Escape handler |
| `+layout.svelte` | Added `setSelectionContext()` provider |

## Test plan

- [x] 478 unit tests pass (including 24 new selection bus tests)
- [x] `check:all` passes (format + lint + fallow + typecheck + eslint)
- [ ] Visual: forest panel collapses/expands via handle click
- [ ] Visual: dragging resizer adjusts panel proportions
- [ ] Visual: tab bar shows 4 tabs, PRD overview displays by default
- [ ] Visual: clicking tree → Issue Detail tab shows selected issue
- [ ] Visual: Escape key deselects → returns to PRD overview

Fixes #122