### PR TITLE
#128 refactor(ui): migrate all raw HTML form elements to component library

### DIFF
--- a/src/lib/components/CommandPalette.svelte
+++ b/src/lib/components/CommandPalette.svelte
@@ -2,6 +2,7 @@
 	import * as m from '$lib/paraglide/messages.js';
 	import SearchIcon from '@lucide/svelte/icons/search';
 	import * as Dialog from '$lib/components/ui/dialog/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
 	import { Kbd } from '$lib/components/ui/kbd/index.js';
 	import { Badge } from '$lib/components/ui/badge/index.js';
 	import {
@@ -53,10 +54,9 @@
 		<!-- Search row -->
 		<div class="flex items-center gap-2.5 border-b border-border px-3.5 py-3">
 			<SearchIcon size={14} class="shrink-0 text-foreground-subtle" />
-			<input
-				bind:this={searchInputElement}
-				type="text"
-				class="h-6 flex-1 border-none bg-transparent p-0 text-sm text-foreground shadow-none outline-none placeholder:text-foreground-subtle"
+			<Input
+				bind:ref={searchInputElement}
+				class="h-6 flex-1 border-none bg-transparent p-0 text-sm shadow-none outline-none placeholder:text-foreground-subtle"
 				placeholder={m.command_palette_placeholder()}
 				value={paletteCtx.query}
 				oninput={(event) => {

--- a/src/lib/components/DashboardCreateDialog.svelte
+++ b/src/lib/components/DashboardCreateDialog.svelte
@@ -2,8 +2,13 @@
 	import * as m from '$lib/paraglide/messages.js';
 	import type { CreateDashboardRequest } from '$lib/modules/board';
 	import type { Dashboard, ColorPalette } from '$lib/types/generated';
+	import * as Dialog from '$lib/components/ui/dialog/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import { Checkbox } from '$lib/components/ui/checkbox/index.js';
 	import PaletteSelector from './PaletteSelector.svelte';
-	import { syncDialogVisibility, buildCreateDashboardRequest } from './dialog_helpers.js';
+	import { buildCreateDashboardRequest } from './dialog_helpers.js';
 
 	interface Props {
 		open: boolean;
@@ -23,11 +28,6 @@
 	let worktreeParentFolder = $state('');
 	let colorPaletteId = $state<string | null>(null);
 	let selectedRepoIds = $state<Set<string>>(new Set());
-	let dialogElement: HTMLDialogElement | undefined = $state();
-
-	$effect(() => {
-		syncDialogVisibility(open, dialogElement);
-	});
 
 	function resetForm() {
 		dashboardType = 'repo';
@@ -63,154 +63,153 @@
 		resetForm();
 		onClose();
 	}
+
+	function handleOpenChange(isOpen: boolean) {
+		if (!isOpen) {
+			handleCancel();
+		}
+	}
 </script>
 
-<dialog
-	bind:this={dialogElement}
-	onclose={handleCancel}
-	class="w-full max-w-md rounded-lg border border-border bg-popover p-0 text-popover-foreground shadow-xl backdrop:bg-black/50"
->
-	<form onsubmit={handleSubmit} class="flex flex-col gap-4 p-6">
-		<h2 class="text-lg font-semibold">{m.dashboard_create_title()}</h2>
+<Dialog.Root {open} onOpenChange={handleOpenChange}>
+	<Dialog.Content class="max-w-md">
+		<form onsubmit={handleSubmit} class="flex flex-col gap-4">
+			<Dialog.Header>
+				<Dialog.Title>{m.dashboard_create_title()}</Dialog.Title>
+			</Dialog.Header>
 
-		<!-- Type selector -->
-		<div class="flex gap-2">
-			<button
-				type="button"
-				onclick={() => (dashboardType = 'repo')}
-				class="flex-1 rounded px-3 py-2 text-sm transition-colors {dashboardType === 'repo'
-					? 'bg-primary text-primary-foreground'
-					: 'bg-muted text-muted-foreground hover:text-foreground'}"
-			>
-				◆ {m.dashboard_type_repo()}
-			</button>
-			<button
-				type="button"
-				onclick={() => (dashboardType = 'portfolio')}
-				class="flex-1 rounded px-3 py-2 text-sm transition-colors {dashboardType ===
-				'portfolio'
-					? 'bg-primary text-primary-foreground'
-					: 'bg-muted text-muted-foreground hover:text-foreground'}"
-			>
-				◇ {m.dashboard_type_portfolio()}
-			</button>
-		</div>
+			<Dialog.Body class="flex flex-col gap-4">
+				<!-- Type selector -->
+				<div class="flex gap-2">
+					<Button
+						type="button"
+						variant={dashboardType === 'repo' ? 'primary' : 'secondary'}
+						size="sm"
+						class="flex-1"
+						onclick={() => (dashboardType = 'repo')}
+					>
+						◆ {m.dashboard_type_repo()}
+					</Button>
+					<Button
+						type="button"
+						variant={dashboardType === 'portfolio' ? 'primary' : 'secondary'}
+						size="sm"
+						class="flex-1"
+						onclick={() => (dashboardType = 'portfolio')}
+					>
+						◇ {m.dashboard_type_portfolio()}
+					</Button>
+				</div>
 
-		<!-- Name (always shown) -->
-		<label class="flex flex-col gap-1">
-			<span class="text-xs text-muted-foreground">{m.dashboard_field_name()}</span>
-			<input
-				bind:value={name}
-				required
-				class="rounded border border-input bg-muted px-3 py-2 text-sm text-foreground outline-none focus:border-ring"
-				placeholder={m.dashboard_placeholder_name()}
-			/>
-		</label>
+				<!-- Name -->
+				<div class="flex flex-col gap-1.5">
+					<Label for="dashboard-name">{m.dashboard_field_name()}</Label>
+					<Input
+						id="dashboard-name"
+						bind:value={name}
+						required
+						placeholder={m.dashboard_placeholder_name()}
+					/>
+				</div>
 
-		<!-- Color palette -->
-		<PaletteSelector
-			palettes={colorPalettes}
-			selectedPaletteId={colorPaletteId}
-			onSelect={(id) => (colorPaletteId = id)}
-		/>
+				<!-- Color palette -->
+				<PaletteSelector
+					palettes={colorPalettes}
+					selectedPaletteId={colorPaletteId}
+					onSelect={(id) => (colorPaletteId = id)}
+				/>
 
-		<!-- Repo-specific fields -->
-		{#if dashboardType === 'portfolio'}
-			<!-- Portfolio repo picker -->
-			<fieldset class="flex flex-col gap-1">
-				<legend class="text-xs text-muted-foreground"
-					>{m.dashboard_field_repo_dashboards()}</legend
-				>
-				{#if repoDashboards.length === 0}
-					<p class="text-xs text-muted-foreground">
-						{m.dashboard_no_repo_dashboards()}
-					</p>
-				{:else}
-					<div class="flex flex-col gap-1 rounded border border-input bg-muted p-2">
-						{#each repoDashboards as repo (repo.id)}
-							<label
-								class="flex items-center gap-2 rounded px-2 py-1 text-sm hover:bg-accent"
+				<!-- Repo-specific fields -->
+				{#if dashboardType === 'portfolio'}
+					<fieldset class="flex flex-col gap-1">
+						<legend class="text-xs text-muted-foreground"
+							>{m.dashboard_field_repo_dashboards()}</legend
+						>
+						{#if repoDashboards.length === 0}
+							<p class="text-xs text-muted-foreground">
+								{m.dashboard_no_repo_dashboards()}
+							</p>
+						{:else}
+							<div
+								class="flex flex-col gap-1 rounded border border-input bg-muted p-2"
 							>
-								<input
-									type="checkbox"
-									checked={selectedRepoIds.has(repo.id)}
-									onchange={() => {
-										const next = new Set(selectedRepoIds);
-										if (next.has(repo.id)) {
-											next.delete(repo.id);
-										} else {
-											next.add(repo.id);
-										}
-										selectedRepoIds = next;
-									}}
-									class="accent-primary"
-								/>
-								<span class="text-foreground">{repo.name}</span>
-								{#if repo.github_repo}
-									<span class="text-xs text-muted-foreground"
-										>{repo.github_repo}</span
+								{#each repoDashboards as repo (repo.id)}
+									<label
+										class="flex items-center gap-2 rounded px-2 py-1 text-sm hover:bg-accent"
 									>
-								{/if}
-							</label>
-						{/each}
+										<Checkbox
+											checked={selectedRepoIds.has(repo.id)}
+											onCheckedChange={(checked) => {
+												const next = new Set(selectedRepoIds);
+												if (checked === true) {
+													next.add(repo.id);
+												} else {
+													next.delete(repo.id);
+												}
+												selectedRepoIds = next;
+											}}
+										/>
+										<span class="text-foreground">{repo.name}</span>
+										{#if repo.github_repo}
+											<span class="text-xs text-muted-foreground"
+												>{repo.github_repo}</span
+											>
+										{/if}
+									</label>
+								{/each}
+							</div>
+						{/if}
+					</fieldset>
+				{:else if dashboardType === 'repo'}
+					<div class="flex flex-col gap-1.5">
+						<Label for="dashboard-github-repo">{m.dashboard_field_github_repo()}</Label>
+						<Input
+							id="dashboard-github-repo"
+							bind:value={githubRepo}
+							placeholder={m.dashboard_placeholder_github_repo()}
+						/>
+					</div>
+					<div class="flex flex-col gap-1.5">
+						<Label for="dashboard-local-folder"
+							>{m.dashboard_field_local_folder()}</Label
+						>
+						<Input
+							id="dashboard-local-folder"
+							bind:value={localFolder}
+							placeholder={m.dashboard_placeholder_local_folder()}
+						/>
+					</div>
+					<div class="flex flex-col gap-1.5">
+						<Label for="dashboard-base-branch"
+							>{m.dashboard_field_default_base_branch()}</Label
+						>
+						<Input
+							id="dashboard-base-branch"
+							bind:value={defaultBaseBranch}
+							placeholder={m.dashboard_placeholder_base_branch()}
+						/>
+					</div>
+					<div class="flex flex-col gap-1.5">
+						<Label for="dashboard-worktree-folder"
+							>{m.dashboard_field_worktree_parent_folder()}</Label
+						>
+						<Input
+							id="dashboard-worktree-folder"
+							bind:value={worktreeParentFolder}
+							placeholder={m.dashboard_placeholder_worktree_parent()}
+						/>
 					</div>
 				{/if}
-			</fieldset>
-		{:else if dashboardType === 'repo'}
-			<label class="flex flex-col gap-1">
-				<span class="text-xs text-muted-foreground">{m.dashboard_field_github_repo()}</span>
-				<input
-					bind:value={githubRepo}
-					class="rounded border border-input bg-muted px-3 py-2 text-sm text-foreground outline-none focus:border-ring"
-					placeholder={m.dashboard_placeholder_github_repo()}
-				/>
-			</label>
-			<label class="flex flex-col gap-1">
-				<span class="text-xs text-muted-foreground">{m.dashboard_field_local_folder()}</span
-				>
-				<input
-					bind:value={localFolder}
-					class="rounded border border-input bg-muted px-3 py-2 text-sm text-foreground outline-none focus:border-ring"
-					placeholder={m.dashboard_placeholder_local_folder()}
-				/>
-			</label>
-			<label class="flex flex-col gap-1">
-				<span class="text-xs text-muted-foreground"
-					>{m.dashboard_field_default_base_branch()}</span
-				>
-				<input
-					bind:value={defaultBaseBranch}
-					class="rounded border border-input bg-muted px-3 py-2 text-sm text-foreground outline-none focus:border-ring"
-					placeholder={m.dashboard_placeholder_base_branch()}
-				/>
-			</label>
-			<label class="flex flex-col gap-1">
-				<span class="text-xs text-muted-foreground"
-					>{m.dashboard_field_worktree_parent_folder()}</span
-				>
-				<input
-					bind:value={worktreeParentFolder}
-					class="rounded border border-input bg-muted px-3 py-2 text-sm text-foreground outline-none focus:border-ring"
-					placeholder={m.dashboard_placeholder_worktree_parent()}
-				/>
-			</label>
-		{/if}
+			</Dialog.Body>
 
-		<!-- Actions -->
-		<div class="flex justify-end gap-2 pt-2">
-			<button
-				type="button"
-				onclick={handleCancel}
-				class="rounded px-4 py-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
-			>
-				{m.btn_cancel()}
-			</button>
-			<button
-				type="submit"
-				class="rounded bg-primary px-4 py-2 text-sm text-primary-foreground transition-colors hover:bg-primary/90"
-			>
-				{m.btn_create()}
-			</button>
-		</div>
-	</form>
-</dialog>
+			<Dialog.Footer>
+				<Button variant="ghost" type="button" onclick={handleCancel}>
+					{m.btn_cancel()}
+				</Button>
+				<Button type="submit">
+					{m.btn_create()}
+				</Button>
+			</Dialog.Footer>
+		</form>
+	</Dialog.Content>
+</Dialog.Root>

--- a/src/lib/components/DashboardEditDialog.svelte
+++ b/src/lib/components/DashboardEditDialog.svelte
@@ -2,8 +2,12 @@
 	import * as m from '$lib/paraglide/messages.js';
 	import type { UpdateDashboardRequest } from '$lib/modules/board';
 	import type { Dashboard, ColorPalette } from '$lib/types/generated';
+	import * as Dialog from '$lib/components/ui/dialog/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
 	import PaletteSelector from './PaletteSelector.svelte';
-	import { syncDialogVisibility, buildUpdateDashboardRequest } from './dialog_helpers.js';
+	import { buildUpdateDashboardRequest } from './dialog_helpers.js';
 
 	interface Props {
 		dashboard: Dashboard | null;
@@ -22,20 +26,19 @@
 	let worktreeParentFolder = $state('');
 	let colorPaletteId = $state<string | null>(null);
 	let confirmDelete = $state(false);
-	let dialogElement: HTMLDialogElement | undefined = $state();
+
+	const open = $derived(dashboard !== null);
 
 	$effect(() => {
-		syncDialogVisibility(dashboard !== null, dialogElement, () => {
-			if (dashboard !== null) {
-				name = dashboard.name;
-				githubRepo = dashboard.github_repo ?? '';
-				localFolder = dashboard.local_folder ?? '';
-				defaultBaseBranch = dashboard.default_base_branch ?? '';
-				worktreeParentFolder = dashboard.worktree_parent_folder ?? '';
-				colorPaletteId = dashboard.color_palette_id ?? null;
-				confirmDelete = false;
-			}
-		});
+		if (dashboard !== null) {
+			name = dashboard.name;
+			githubRepo = dashboard.github_repo ?? '';
+			localFolder = dashboard.local_folder ?? '';
+			defaultBaseBranch = dashboard.default_base_branch ?? '';
+			worktreeParentFolder = dashboard.worktree_parent_folder ?? '';
+			colorPaletteId = dashboard.color_palette_id ?? null;
+			confirmDelete = false;
+		}
 	});
 
 	function handleSubmit(event: SubmitEvent) {
@@ -67,99 +70,80 @@
 		onDelete(dashboard.id);
 		onClose();
 	}
+
+	function handleOpenChange(isOpen: boolean) {
+		if (!isOpen) {
+			onClose();
+		}
+	}
 </script>
 
-<dialog
-	bind:this={dialogElement}
-	onclose={onClose}
-	class="w-full max-w-md rounded-lg border border-border bg-popover p-0 text-popover-foreground shadow-xl backdrop:bg-black/50"
->
-	{#if dashboard}
-		<form onsubmit={handleSubmit} class="flex flex-col gap-4 p-6">
-			<h2 class="text-lg font-semibold">{m.dashboard_edit_title()}</h2>
+<Dialog.Root {open} onOpenChange={handleOpenChange}>
+	<Dialog.Content class="max-w-md">
+		{#if dashboard}
+			<form onsubmit={handleSubmit} class="flex flex-col gap-4">
+				<Dialog.Header>
+					<Dialog.Title>{m.dashboard_edit_title()}</Dialog.Title>
+				</Dialog.Header>
 
-			<label class="flex flex-col gap-1">
-				<span class="text-xs text-muted-foreground">{m.dashboard_field_name()}</span>
-				<input
-					bind:value={name}
-					required
-					class="rounded border border-input bg-muted px-3 py-2 text-sm text-foreground outline-none focus:border-ring"
-				/>
-			</label>
+				<Dialog.Body class="flex flex-col gap-4">
+					<div class="flex flex-col gap-1.5">
+						<Label for="edit-dashboard-name">{m.dashboard_field_name()}</Label>
+						<Input id="edit-dashboard-name" bind:value={name} required />
+					</div>
 
-			<!-- Color palette -->
-			<PaletteSelector
-				palettes={colorPalettes}
-				selectedPaletteId={colorPaletteId}
-				onSelect={(id) => (colorPaletteId = id)}
-			/>
+					<PaletteSelector
+						palettes={colorPalettes}
+						selectedPaletteId={colorPaletteId}
+						onSelect={(id) => (colorPaletteId = id)}
+					/>
 
-			{#if dashboard.type === 'repo'}
-				<label class="flex flex-col gap-1">
-					<span class="text-xs text-muted-foreground"
-						>{m.dashboard_field_github_repo()}</span
-					>
-					<input
-						bind:value={githubRepo}
-						class="rounded border border-input bg-muted px-3 py-2 text-sm text-foreground outline-none focus:border-ring"
-						placeholder={m.dashboard_placeholder_github_repo()}
-					/>
-				</label>
-				<label class="flex flex-col gap-1">
-					<span class="text-xs text-muted-foreground"
-						>{m.dashboard_field_local_folder()}</span
-					>
-					<input
-						bind:value={localFolder}
-						class="rounded border border-input bg-muted px-3 py-2 text-sm text-foreground outline-none focus:border-ring"
-					/>
-				</label>
-				<label class="flex flex-col gap-1">
-					<span class="text-xs text-muted-foreground"
-						>{m.dashboard_field_default_base_branch()}</span
-					>
-					<input
-						bind:value={defaultBaseBranch}
-						class="rounded border border-input bg-muted px-3 py-2 text-sm text-foreground outline-none focus:border-ring"
-					/>
-				</label>
-				<label class="flex flex-col gap-1">
-					<span class="text-xs text-muted-foreground"
-						>{m.dashboard_field_worktree_parent_folder()}</span
-					>
-					<input
-						bind:value={worktreeParentFolder}
-						class="rounded border border-input bg-muted px-3 py-2 text-sm text-foreground outline-none focus:border-ring"
-					/>
-				</label>
-			{/if}
+					{#if dashboard.type === 'repo'}
+						<div class="flex flex-col gap-1.5">
+							<Label for="edit-dashboard-github-repo"
+								>{m.dashboard_field_github_repo()}</Label
+							>
+							<Input
+								id="edit-dashboard-github-repo"
+								bind:value={githubRepo}
+								placeholder={m.dashboard_placeholder_github_repo()}
+							/>
+						</div>
+						<div class="flex flex-col gap-1.5">
+							<Label for="edit-dashboard-local-folder"
+								>{m.dashboard_field_local_folder()}</Label
+							>
+							<Input id="edit-dashboard-local-folder" bind:value={localFolder} />
+						</div>
+						<div class="flex flex-col gap-1.5">
+							<Label for="edit-dashboard-base-branch"
+								>{m.dashboard_field_default_base_branch()}</Label
+							>
+							<Input id="edit-dashboard-base-branch" bind:value={defaultBaseBranch} />
+						</div>
+						<div class="flex flex-col gap-1.5">
+							<Label for="edit-dashboard-worktree"
+								>{m.dashboard_field_worktree_parent_folder()}</Label
+							>
+							<Input id="edit-dashboard-worktree" bind:value={worktreeParentFolder} />
+						</div>
+					{/if}
+				</Dialog.Body>
 
-			<div class="flex items-center justify-between pt-2">
-				<button
-					type="button"
-					onclick={handleDelete}
-					class="rounded px-3 py-2 text-sm transition-colors {confirmDelete
-						? 'bg-destructive text-destructive-foreground'
-						: 'text-destructive hover:text-destructive/80'}"
-				>
-					{confirmDelete ? m.btn_confirm_delete() : m.btn_delete()}
-				</button>
-				<div class="flex gap-2">
-					<button
-						type="button"
-						onclick={onClose}
-						class="rounded px-4 py-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
-					>
-						{m.btn_cancel()}
-					</button>
-					<button
-						type="submit"
-						class="rounded bg-primary px-4 py-2 text-sm text-primary-foreground transition-colors hover:bg-primary/90"
-					>
-						{m.btn_save()}
-					</button>
-				</div>
-			</div>
-		</form>
-	{/if}
-</dialog>
+				<Dialog.Footer class="justify-between">
+					<Button variant="danger" type="button" size="sm" onclick={handleDelete}>
+						{confirmDelete ? m.btn_confirm_delete() : m.btn_delete()}
+					</Button>
+					<div class="flex gap-2">
+						<Button variant="ghost" type="button" onclick={onClose}>
+							{m.btn_cancel()}
+						</Button>
+						<Button type="submit">
+							{m.btn_save()}
+						</Button>
+					</div>
+				</Dialog.Footer>
+			</form>
+		{/if}
+	</Dialog.Content>
+</Dialog.Root>

--- a/src/lib/components/DashboardSidebar.svelte
+++ b/src/lib/components/DashboardSidebar.svelte
@@ -14,6 +14,7 @@
 	import ThemeToggle from './ThemeToggle.svelte';
 	import LanguageSwitcher from './LanguageSwitcher.svelte';
 	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
 	import { useKeyboardShortcuts } from '$lib/modules/keyboard-shortcuts';
 
 	interface Props {
@@ -72,10 +73,12 @@
 			<Tooltip.Root>
 				<Tooltip.Trigger>
 					{#snippet child({ props })}
-						<button
+						<Button
 							{...props}
+							variant="ghost"
+							size="icon"
 							onclick={onToggleSidebar}
-							class="group relative flex size-9 items-center justify-center rounded-lg"
+							class="group relative"
 							aria-label="Expand sidebar"
 						>
 							<span class="transition-opacity group-hover:opacity-0">
@@ -86,7 +89,7 @@
 							>
 								<ChevronRightIcon size={14} />
 							</span>
-						</button>
+						</Button>
 					{/snippet}
 				</Tooltip.Trigger>
 				<Tooltip.Content side="right"
@@ -98,14 +101,15 @@
 				<BrandMark size={22} />
 				<span class="text-sm font-semibold tracking-tight">{m.app_name()}</span>
 			</div>
-			<button
+			<Button
+				variant="ghost"
+				size="icon-sm"
 				onclick={onToggleSidebar}
-				class="flex size-[22px] items-center justify-center rounded-[5px] text-foreground-subtle transition-colors hover:bg-surface-2 hover:text-foreground"
 				aria-label="Collapse sidebar"
 				title={m.sidebar_collapse({ shortcut: toggleSidebarBinding })}
 			>
 				<PanelLeftIcon size={14} />
-			</button>
+			</Button>
 		{/if}
 	</div>
 

--- a/src/lib/components/IssueCreateDialog.svelte
+++ b/src/lib/components/IssueCreateDialog.svelte
@@ -1,8 +1,13 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
 	import type { CreateIssueRequest } from '$lib/modules/issues';
+	import * as Dialog from '$lib/components/ui/dialog/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { Select } from '$lib/components/ui/select/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
 	import PaletteColorPicker from './PaletteColorPicker.svelte';
-	import { syncDialogVisibility, buildCreateIssueRequest } from './dialog_helpers.js';
+	import { buildCreateIssueRequest } from './dialog_helpers.js';
 
 	interface Props {
 		open: boolean;
@@ -19,12 +24,11 @@
 	let priority = $state<'low' | 'medium' | 'high' | 'top' | ''>('');
 	let color = $state('');
 	let githubIssueUrl = $state('');
-	let dialogElement: HTMLDialogElement | undefined = $state();
 
 	$effect(() => {
-		syncDialogVisibility(open, dialogElement, () => {
+		if (open) {
 			color = defaultColor;
-		});
+		}
 	});
 
 	function resetForm() {
@@ -49,70 +53,67 @@
 		resetForm();
 		onClose();
 	}
+
+	function handleOpenChange(isOpen: boolean) {
+		if (!isOpen) {
+			handleCancel();
+		}
+	}
 </script>
 
-<dialog
-	bind:this={dialogElement}
-	onclose={handleCancel}
-	class="w-full max-w-md rounded-lg border border-border bg-popover p-0 text-popover-foreground shadow-xl backdrop:bg-black/50"
->
-	<form onsubmit={handleSubmit} class="flex flex-col gap-4 p-6">
-		<h2 class="text-lg font-semibold">{m.issue_create_title()}</h2>
+<Dialog.Root {open} onOpenChange={handleOpenChange}>
+	<Dialog.Content class="max-w-md">
+		<form onsubmit={handleSubmit} class="flex flex-col gap-4">
+			<Dialog.Header>
+				<Dialog.Title>{m.issue_create_title()}</Dialog.Title>
+			</Dialog.Header>
 
-		<label class="flex flex-col gap-1">
-			<span class="text-xs text-muted-foreground">{m.issue_field_name()}</span>
-			<input
-				bind:value={name}
-				required
-				class="rounded border border-input bg-muted px-3 py-2 text-sm text-foreground outline-none focus:border-ring"
-				placeholder={m.issue_placeholder_name()}
-			/>
-		</label>
+			<Dialog.Body class="flex flex-col gap-4">
+				<div class="flex flex-col gap-1.5">
+					<Label for="issue-name">{m.issue_field_name()}</Label>
+					<Input
+						id="issue-name"
+						bind:value={name}
+						required
+						placeholder={m.issue_placeholder_name()}
+					/>
+				</div>
 
-		<label class="flex flex-col gap-1">
-			<span class="text-xs text-muted-foreground">{m.issue_field_priority()}</span>
-			<select
-				bind:value={priority}
-				class="rounded border border-input bg-muted px-3 py-2 text-sm text-foreground outline-none focus:border-ring"
-			>
-				<option value="">{m.priority_none()}</option>
-				<option value="low">{m.priority_low()}</option>
-				<option value="medium">{m.priority_medium()}</option>
-				<option value="high">{m.priority_high()}</option>
-				<option value="top">{m.priority_top()}</option>
-			</select>
-		</label>
+				<div class="flex flex-col gap-1.5">
+					<Label for="issue-priority">{m.issue_field_priority()}</Label>
+					<Select id="issue-priority" bind:value={priority}>
+						<option value="">{m.priority_none()}</option>
+						<option value="low">{m.priority_low()}</option>
+						<option value="medium">{m.priority_medium()}</option>
+						<option value="high">{m.priority_high()}</option>
+						<option value="top">{m.priority_top()}</option>
+					</Select>
+				</div>
 
-		<!-- Color picker -->
-		<PaletteColorPicker
-			colors={paletteColors}
-			selectedColor={color}
-			onSelect={(c) => (color = c)}
-		/>
+				<PaletteColorPicker
+					colors={paletteColors}
+					selectedColor={color}
+					onSelect={(c) => (color = c)}
+				/>
 
-		<label class="flex flex-col gap-1">
-			<span class="text-xs text-muted-foreground">{m.issue_field_github_url()}</span>
-			<input
-				bind:value={githubIssueUrl}
-				class="rounded border border-input bg-muted px-3 py-2 text-sm text-foreground outline-none focus:border-ring"
-				placeholder={m.issue_placeholder_github_url()}
-			/>
-		</label>
+				<div class="flex flex-col gap-1.5">
+					<Label for="issue-github-url">{m.issue_field_github_url()}</Label>
+					<Input
+						id="issue-github-url"
+						bind:value={githubIssueUrl}
+						placeholder={m.issue_placeholder_github_url()}
+					/>
+				</div>
+			</Dialog.Body>
 
-		<div class="flex justify-end gap-2 pt-2">
-			<button
-				type="button"
-				onclick={handleCancel}
-				class="rounded px-4 py-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
-			>
-				{m.btn_cancel()}
-			</button>
-			<button
-				type="submit"
-				class="rounded bg-primary px-4 py-2 text-sm text-primary-foreground transition-colors hover:bg-primary/90"
-			>
-				{m.btn_create()}
-			</button>
-		</div>
-	</form>
-</dialog>
+			<Dialog.Footer>
+				<Button variant="ghost" type="button" onclick={handleCancel}>
+					{m.btn_cancel()}
+				</Button>
+				<Button type="submit">
+					{m.btn_create()}
+				</Button>
+			</Dialog.Footer>
+		</form>
+	</Dialog.Content>
+</Dialog.Root>

--- a/src/lib/components/IssueEditDialog.svelte
+++ b/src/lib/components/IssueEditDialog.svelte
@@ -2,8 +2,13 @@
 	import * as m from '$lib/paraglide/messages.js';
 	import type { Issue, UpdateIssueRequest } from '$lib/modules/issues';
 	import { FALLBACK_ISSUE_COLOR } from '$lib/modules/board';
+	import * as Dialog from '$lib/components/ui/dialog/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { Select } from '$lib/components/ui/select/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
 	import PaletteColorPicker from './PaletteColorPicker.svelte';
-	import { syncDialogVisibility, buildUpdateIssueRequest } from './dialog_helpers.js';
+	import { buildUpdateIssueRequest } from './dialog_helpers.js';
 
 	interface Props {
 		issue: Issue | null;
@@ -18,17 +23,16 @@
 	let priority = $state<string>('');
 	let color = $state('');
 	let githubIssueUrl = $state('');
-	let dialogElement: HTMLDialogElement | undefined = $state();
+
+	const open = $derived(issue !== null);
 
 	$effect(() => {
-		syncDialogVisibility(issue !== null, dialogElement, () => {
-			if (issue !== null) {
-				name = issue.name;
-				priority = issue.priority ?? '';
-				color = issue.color ?? paletteColors[0] ?? FALLBACK_ISSUE_COLOR;
-				githubIssueUrl = issue.github_issue_url ?? '';
-			}
-		});
+		if (issue !== null) {
+			name = issue.name;
+			priority = issue.priority ?? '';
+			color = issue.color ?? paletteColors[0] ?? FALLBACK_ISSUE_COLOR;
+			githubIssueUrl = issue.github_issue_url ?? '';
+		}
 	});
 
 	function handleSubmit(event: SubmitEvent) {
@@ -46,69 +50,60 @@
 		onUpdate(request);
 		onClose();
 	}
+
+	function handleOpenChange(isOpen: boolean) {
+		if (!isOpen) {
+			onClose();
+		}
+	}
 </script>
 
-<dialog
-	bind:this={dialogElement}
-	onclose={onClose}
-	class="w-full max-w-md rounded-lg border border-border bg-popover p-0 text-popover-foreground shadow-xl backdrop:bg-black/50"
->
-	{#if issue}
-		<form onsubmit={handleSubmit} class="flex flex-col gap-4 p-6">
-			<h2 class="text-lg font-semibold">{m.issue_edit_title()}</h2>
+<Dialog.Root {open} onOpenChange={handleOpenChange}>
+	<Dialog.Content class="max-w-md">
+		{#if issue}
+			<form onsubmit={handleSubmit} class="flex flex-col gap-4">
+				<Dialog.Header>
+					<Dialog.Title>{m.issue_edit_title()}</Dialog.Title>
+				</Dialog.Header>
 
-			<label class="flex flex-col gap-1">
-				<span class="text-xs text-muted-foreground">{m.issue_field_name()}</span>
-				<input
-					bind:value={name}
-					required
-					class="rounded border border-input bg-muted px-3 py-2 text-sm text-foreground outline-none focus:border-ring"
-				/>
-			</label>
+				<Dialog.Body class="flex flex-col gap-4">
+					<div class="flex flex-col gap-1.5">
+						<Label for="edit-issue-name">{m.issue_field_name()}</Label>
+						<Input id="edit-issue-name" bind:value={name} required />
+					</div>
 
-			<label class="flex flex-col gap-1">
-				<span class="text-xs text-muted-foreground">{m.issue_field_priority()}</span>
-				<select
-					bind:value={priority}
-					class="rounded border border-input bg-muted px-3 py-2 text-sm text-foreground outline-none focus:border-ring"
-				>
-					<option value="">{m.priority_none()}</option>
-					<option value="low">{m.priority_low()}</option>
-					<option value="medium">{m.priority_medium()}</option>
-					<option value="high">{m.priority_high()}</option>
-					<option value="top">{m.priority_top()}</option>
-				</select>
-			</label>
+					<div class="flex flex-col gap-1.5">
+						<Label for="edit-issue-priority">{m.issue_field_priority()}</Label>
+						<Select id="edit-issue-priority" bind:value={priority}>
+							<option value="">{m.priority_none()}</option>
+							<option value="low">{m.priority_low()}</option>
+							<option value="medium">{m.priority_medium()}</option>
+							<option value="high">{m.priority_high()}</option>
+							<option value="top">{m.priority_top()}</option>
+						</Select>
+					</div>
 
-			<PaletteColorPicker
-				colors={paletteColors}
-				selectedColor={color}
-				onSelect={(c) => (color = c)}
-			/>
+					<PaletteColorPicker
+						colors={paletteColors}
+						selectedColor={color}
+						onSelect={(c) => (color = c)}
+					/>
 
-			<label class="flex flex-col gap-1">
-				<span class="text-xs text-muted-foreground">{m.issue_field_github_url()}</span>
-				<input
-					bind:value={githubIssueUrl}
-					class="rounded border border-input bg-muted px-3 py-2 text-sm text-foreground outline-none focus:border-ring"
-				/>
-			</label>
+					<div class="flex flex-col gap-1.5">
+						<Label for="edit-issue-github-url">{m.issue_field_github_url()}</Label>
+						<Input id="edit-issue-github-url" bind:value={githubIssueUrl} />
+					</div>
+				</Dialog.Body>
 
-			<div class="flex justify-end gap-2 pt-2">
-				<button
-					type="button"
-					onclick={onClose}
-					class="rounded px-4 py-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
-				>
-					{m.btn_cancel()}
-				</button>
-				<button
-					type="submit"
-					class="rounded bg-primary px-4 py-2 text-sm text-primary-foreground transition-colors hover:bg-primary/90"
-				>
-					{m.btn_save()}
-				</button>
-			</div>
-		</form>
-	{/if}
-</dialog>
+				<Dialog.Footer>
+					<Button variant="ghost" type="button" onclick={onClose}>
+						{m.btn_cancel()}
+					</Button>
+					<Button type="submit">
+						{m.btn_save()}
+					</Button>
+				</Dialog.Footer>
+			</form>
+		{/if}
+	</Dialog.Content>
+</Dialog.Root>

--- a/src/lib/components/LanguageSwitcher.svelte
+++ b/src/lib/components/LanguageSwitcher.svelte
@@ -2,6 +2,8 @@
 	import * as m from '$lib/paraglide/messages.js';
 	import { getLocale, setLocale, locales } from '$lib/paraglide/runtime.js';
 	import GlobeIcon from '@lucide/svelte/icons/globe';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Tabs, Tab } from '$lib/components/ui/tabs/index.js';
 
 	interface Props {
 		collapsed?: boolean;
@@ -23,27 +25,26 @@
 </script>
 
 {#if collapsed}
-	<button
+	<Button
+		variant="ghost"
+		size="icon"
+		class="w-full"
 		onclick={cycleLocale}
-		class="flex w-full items-center justify-center rounded p-2 text-sidebar-foreground transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
 		aria-label={m.lang_switcher()}
 		title={LOCALE_LABELS[getLocale()] ?? getLocale()}
 	>
 		<GlobeIcon class="size-4" />
-	</button>
+	</Button>
 {:else}
-	<div class="flex items-center gap-1 rounded-md bg-secondary p-1">
+	<Tabs>
 		{#each locales as locale (locale)}
-			<button
+			<Tab
+				active={getLocale() === locale}
 				onclick={() => setLocale(locale)}
-				class="flex flex-1 items-center justify-center gap-1.5 rounded px-2 py-1 text-xs transition-colors {getLocale() ===
-				locale
-					? 'bg-background text-foreground shadow-sm'
-					: 'text-muted-foreground hover:text-foreground'}"
 				title={LOCALE_LABELS[locale] ?? locale}
 			>
 				<span>{LOCALE_LABELS[locale] ?? locale}</span>
-			</button>
+			</Tab>
 		{/each}
-	</div>
+	</Tabs>
 {/if}

--- a/src/lib/components/PaletteColorPicker.svelte
+++ b/src/lib/components/PaletteColorPicker.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { Input } from '$lib/components/ui/input/index.js';
+
 	interface Props {
 		colors: string[];
 		selectedColor: string;
@@ -52,11 +54,10 @@
 				}}
 				class="h-8 w-8 cursor-pointer rounded border border-border bg-muted"
 			/>
-			<input
-				type="text"
+			<Input
 				bind:value={customColorInput}
 				placeholder="#ff0000"
-				class="w-24 rounded border border-input bg-muted px-2 py-1 text-xs text-foreground outline-none focus:border-ring"
+				class="w-24 text-xs"
 				onkeydown={(event) => {
 					if (event.key === 'Enter') {
 						event.preventDefault();

--- a/src/lib/components/PaletteSelector.svelte
+++ b/src/lib/components/PaletteSelector.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
 	import type { ColorPalette } from '$lib/types/generated';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import { Select } from '$lib/components/ui/select/index.js';
 
 	interface Props {
 		palettes: ColorPalette[];
@@ -15,15 +17,15 @@
 	);
 </script>
 
-<label class="flex flex-col gap-1">
-	<span class="text-xs text-muted-foreground">{m.palette_color_palette()}</span>
-	<select
+<div class="flex flex-col gap-1.5">
+	<Label for="palette-select">{m.palette_color_palette()}</Label>
+	<Select
+		id="palette-select"
 		value={selectedPaletteId ?? ''}
 		onchange={(event) => {
 			const value = event.currentTarget.value;
-			onSelect(value || null);
+			onSelect(value !== '' ? value : null);
 		}}
-		class="rounded border border-input bg-muted px-3 py-2 text-sm text-foreground outline-none focus:border-ring"
 	>
 		<option value="">{m.palette_default({ name: defaultPaletteLabel })}</option>
 		{#each palettes as palette (palette.id)}
@@ -31,5 +33,5 @@
 				{palette.name}{palette.is_built_in === true ? '' : ` ${m.palette_custom()}`}
 			</option>
 		{/each}
-	</select>
-</label>
+	</Select>
+</div>

--- a/src/lib/components/PruneWorktreesDialog.svelte
+++ b/src/lib/components/PruneWorktreesDialog.svelte
@@ -2,6 +2,9 @@
 	import * as m from '$lib/paraglide/messages.js';
 	import { SvelteSet } from 'svelte/reactivity';
 	import type { PrunableIssue } from '$lib/types/generated';
+	import * as Dialog from '$lib/components/ui/dialog/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Checkbox } from '$lib/components/ui/checkbox/index.js';
 
 	interface Props {
 		open: boolean;
@@ -15,7 +18,6 @@
 
 	let selectedIds = $state(new SvelteSet<string>());
 
-	// Reset selection when dialog opens with new data
 	$effect(() => {
 		if (open) {
 			selectedIds = new SvelteSet(prunableIssues.map((issue) => issue.issue_id));
@@ -33,96 +35,80 @@
 	function handlePrune() {
 		onPrune([...selectedIds]);
 	}
+
+	function handleOpenChange(isOpen: boolean) {
+		if (!isOpen) {
+			onClose();
+		}
+	}
 </script>
 
-{#if open}
-	<!-- svelte-ignore a11y_no_static_element_interactions -->
-	<div
-		class="fixed inset-0 z-[var(--z-modal)] flex items-center justify-center bg-black/60"
-		onkeydown={(e) => {
-			if (e.key === 'Escape') {
-				onClose();
-			}
-		}}
-	>
-		<!-- svelte-ignore a11y_click_events_have_key_events -->
-		<div class="absolute inset-0" onclick={onClose}></div>
-		<div
-			class="relative z-[var(--z-raised)] w-full max-w-lg rounded-lg border border-border bg-popover shadow-xl"
-		>
-			<div class="border-b border-border px-4 py-3">
-				<h2 class="text-sm font-semibold">{m.prune_title()}</h2>
-				<p class="mt-1 text-xs text-muted-foreground">
-					{m.prune_description()}
-				</p>
-			</div>
+<Dialog.Root {open} onOpenChange={handleOpenChange}>
+	<Dialog.Content class="max-w-lg">
+		<Dialog.Header>
+			<Dialog.Title>{m.prune_title()}</Dialog.Title>
+			<Dialog.Description>{m.prune_description()}</Dialog.Description>
+		</Dialog.Header>
 
-			<div class="max-h-64 overflow-y-auto px-4 py-3">
-				{#if prunableIssues.length === 0}
-					<p class="text-sm text-muted-foreground">{m.prune_empty()}</p>
+		<Dialog.Body class="max-h-64 overflow-y-auto">
+			{#if prunableIssues.length === 0}
+				<p class="text-sm text-muted-foreground">{m.prune_empty()}</p>
+			{:else}
+				<div class="flex flex-col gap-2">
+					{#each prunableIssues as issue (issue.issue_id)}
+						<label
+							class="flex cursor-pointer items-center gap-3 rounded px-2 py-1.5 hover:bg-accent"
+						>
+							<Checkbox
+								checked={selectedIds.has(issue.issue_id)}
+								onCheckedChange={() => toggleSelection(issue.issue_id)}
+							/>
+							<div class="min-w-0 flex-1">
+								<div class="truncate text-sm">{issue.name}</div>
+								<div class="text-xs text-muted-foreground">
+									{issue.branch_name}
+									{#if issue.worktree_folder}
+										<span class="text-muted-foreground/60">
+											— {issue.worktree_folder}
+										</span>
+									{/if}
+								</div>
+							</div>
+							<div class="flex items-center gap-1">
+								<span
+									class="rounded bg-purple-900/40 px-1.5 py-0.5 text-[10px] text-purple-400"
+								>
+									{m.prune_badge_merged()}
+								</span>
+								<span
+									class="rounded bg-red-900/40 px-1.5 py-0.5 text-[10px] text-red-400"
+								>
+									{m.prune_badge_closed()}
+								</span>
+							</div>
+						</label>
+					{/each}
+				</div>
+			{/if}
+		</Dialog.Body>
+
+		<Dialog.Footer>
+			<Button variant="ghost" onclick={onClose} disabled={removing}>
+				{m.btn_cancel()}
+			</Button>
+			<Button
+				variant="danger"
+				onclick={handlePrune}
+				disabled={selectedIds.size === 0 || removing}
+			>
+				{#if removing}
+					{m.prune_removing()}
 				{:else}
-					<div class="flex flex-col gap-2">
-						{#each prunableIssues as issue (issue.issue_id)}
-							<label
-								class="flex cursor-pointer items-center gap-3 rounded px-2 py-1.5 hover:bg-accent"
-							>
-								<input
-									type="checkbox"
-									checked={selectedIds.has(issue.issue_id)}
-									onchange={() => toggleSelection(issue.issue_id)}
-									class="rounded border-input"
-								/>
-								<div class="min-w-0 flex-1">
-									<div class="truncate text-sm">{issue.name}</div>
-									<div class="text-xs text-muted-foreground">
-										{issue.branch_name}
-										{#if issue.worktree_folder}
-											<span class="text-muted-foreground/60">
-												— {issue.worktree_folder}
-											</span>
-										{/if}
-									</div>
-								</div>
-								<div class="flex items-center gap-1">
-									<span
-										class="rounded bg-purple-900/40 px-1.5 py-0.5 text-[10px] text-purple-400"
-									>
-										{m.prune_badge_merged()}
-									</span>
-									<span
-										class="rounded bg-red-900/40 px-1.5 py-0.5 text-[10px] text-red-400"
-									>
-										{m.prune_badge_closed()}
-									</span>
-								</div>
-							</label>
-						{/each}
-					</div>
+					{selectedIds.size !== 1
+						? m.prune_remove_count_plural({ count: selectedIds.size })
+						: m.prune_remove_count({ count: selectedIds.size })}
 				{/if}
-			</div>
-
-			<div class="flex items-center justify-end gap-2 border-t border-border px-4 py-3">
-				<button
-					onclick={onClose}
-					disabled={removing}
-					class="rounded px-3 py-1.5 text-sm text-muted-foreground hover:text-foreground"
-				>
-					{m.btn_cancel()}
-				</button>
-				<button
-					onclick={handlePrune}
-					disabled={selectedIds.size === 0 || removing}
-					class="rounded bg-destructive px-3 py-1.5 text-sm text-destructive-foreground transition-colors hover:bg-destructive/90 disabled:opacity-40"
-				>
-					{#if removing}
-						{m.prune_removing()}
-					{:else}
-						{selectedIds.size !== 1
-							? m.prune_remove_count_plural({ count: selectedIds.size })
-							: m.prune_remove_count({ count: selectedIds.size })}
-					{/if}
-				</button>
-			</div>
-		</div>
-	</div>
-{/if}
+			</Button>
+		</Dialog.Footer>
+	</Dialog.Content>
+</Dialog.Root>

--- a/src/lib/components/SessionChatView.svelte
+++ b/src/lib/components/SessionChatView.svelte
@@ -4,6 +4,8 @@
 	import { useSessions } from '$lib/modules/sessions';
 	import { listen, type UnlistenFn } from '$lib/tauri.js';
 	import { onMount, onDestroy } from 'svelte';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
 
 	interface Props {
 		session: Session;
@@ -210,30 +212,27 @@
 	<div class="border-t border-border p-3">
 		<div class="flex items-center gap-2">
 			{#if session.state === 'running'}
-				<button
-					class="shrink-0 rounded-md bg-amber-600 px-3 py-2 text-sm font-medium text-white hover:bg-amber-500"
+				<Button
+					variant="secondary"
+					size="sm"
+					class="shrink-0 bg-amber-600 text-white hover:bg-amber-500"
 					onclick={handleInterrupt}
 				>
 					{m.chat_interrupt()}
-				</button>
+				</Button>
 			{/if}
 
-			<input
-				type="text"
-				class="flex-1 rounded-md border border-input bg-muted px-3 py-2 text-sm text-foreground placeholder-muted-foreground focus:border-ring focus:outline-none"
+			<Input
+				class="flex-1"
 				placeholder={isActive ? m.chat_placeholder_active() : m.chat_placeholder_ended()}
 				bind:value={promptInput}
 				onkeydown={handleKeydown}
 				disabled={!isActive}
 			/>
 
-			<button
-				class="shrink-0 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
-				onclick={handleSend}
-				disabled={!canSend}
-			>
+			<Button class="shrink-0" onclick={handleSend} disabled={!canSend}>
 				{m.chat_send()}
-			</button>
+			</Button>
 		</div>
 	</div>
 </div>

--- a/src/lib/components/ThemeToggle.svelte
+++ b/src/lib/components/ThemeToggle.svelte
@@ -4,6 +4,8 @@
 	import Sun from '@lucide/svelte/icons/sun';
 	import Moon from '@lucide/svelte/icons/moon';
 	import Monitor from '@lucide/svelte/icons/monitor';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Tabs, Tab } from '$lib/components/ui/tabs/index.js';
 
 	interface Props {
 		collapsed?: boolean;
@@ -35,28 +37,27 @@
 </script>
 
 {#if collapsed}
-	<button
+	<Button
+		variant="ghost"
+		size="icon"
+		class="w-full"
 		onclick={cycleMode}
-		class="flex w-full items-center justify-center rounded p-2 text-sidebar-foreground transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
 		aria-label="{MODE_LABELS[currentMode.labelKey]()} theme"
 		title="{MODE_LABELS[currentMode.labelKey]()} mode"
 	>
 		<currentMode.Icon class="size-4" />
-	</button>
+	</Button>
 {:else}
-	<div class="flex items-center gap-1 rounded-md bg-secondary p-1">
+	<Tabs>
 		{#each modes as { value, Icon, labelKey } (value)}
-			<button
+			<Tab
+				active={theme.mode === value}
 				onclick={() => (theme.mode = value)}
-				class="flex flex-1 items-center justify-center gap-1.5 rounded px-2 py-1 text-xs transition-colors {theme.mode ===
-				value
-					? 'bg-background text-foreground shadow-sm'
-					: 'text-muted-foreground hover:text-foreground'}"
 				title="{MODE_LABELS[labelKey]()} mode"
 			>
 				<Icon class="size-3.5" />
 				<span>{MODE_LABELS[labelKey]()}</span>
-			</button>
+			</Tab>
 		{/each}
-	</div>
+	</Tabs>
 {/if}

--- a/src/lib/components/TopBar.svelte
+++ b/src/lib/components/TopBar.svelte
@@ -13,6 +13,8 @@
 	import TreesIcon from '@lucide/svelte/icons/trees';
 	import type { ViewMode } from '$lib/modules/board';
 	import { useKeyboardShortcuts } from '$lib/modules/keyboard-shortcuts';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Tabs, Tab } from '$lib/components/ui/tabs/index.js';
 
 	type TopBarControl =
 		| 'search'
@@ -72,6 +74,12 @@
 		{ value: 'kanban' as const, Icon: KanbanIcon, labelKey: 'kanban' as const },
 		{ value: 'forest' as const, Icon: TreesIcon, labelKey: 'forest' as const },
 	];
+
+	const glassClass = $derived(
+		transparent
+			? 'backdrop-blur-sm bg-[color-mix(in_oklch,var(--surface)_60%,transparent)]'
+			: '',
+	);
 </script>
 
 <div
@@ -95,91 +103,87 @@
 	<!-- Right: controls -->
 	<div class="flex shrink-0 items-center gap-1.5">
 		{#if has('search')}
-			<button class="topbar-search" class:topbar-glass={transparent} onclick={onSearch}>
+			<Button
+				variant="ghost"
+				size="sm"
+				class="w-[200px] justify-start {glassClass}"
+				onclick={onSearch}
+			>
 				<SearchIcon size={12} class="pointer-events-none text-foreground-subtle" />
 				<span class="text-foreground-subtle">{m.topbar_search()}</span>
 				{#if searchBinding}
 					<kbd class="topbar-kbd">{searchBinding}</kbd>
 				{/if}
-			</button>
+			</Button>
 		{/if}
 
 		{#if has('filter')}
-			<button class="topbar-btn" class:topbar-glass={transparent} title={m.topbar_filter()}>
+			<Button variant="ghost" size="sm" class={glassClass} title={m.topbar_filter()}>
 				<FilterIcon size={12} />
 				<span>{m.topbar_filter()}</span>
-			</button>
+			</Button>
 		{/if}
 
 		{#if has('sort')}
-			<button class="topbar-btn" class:topbar-glass={transparent} title={m.topbar_sort()}>
+			<Button variant="ghost" size="sm" class={glassClass} title={m.topbar_sort()}>
 				<LayersIcon size={12} />
 				<span>{m.topbar_sort()}</span>
-			</button>
+			</Button>
 		{/if}
 
 		{#if has('sync')}
-			<button
-				class="topbar-btn topbar-btn-icon"
-				class:topbar-glass={transparent}
+			<Button
+				variant="ghost"
+				size="icon-sm"
+				class={glassClass}
 				title={m.topbar_sync()}
 				disabled={syncing}
 				onclick={onSync}
 			>
 				<RefreshCwIcon size={13} class={syncing ? 'animate-spin' : ''} />
-			</button>
+			</Button>
 		{/if}
 
 		{#if has('legend')}
-			<button
-				class="topbar-btn topbar-btn-icon"
-				class:topbar-glass={transparent}
-				title={m.topbar_legend()}
-			>
+			<Button variant="ghost" size="icon-sm" class={glassClass} title={m.topbar_legend()}>
 				<SparklesIcon size={13} />
-			</button>
+			</Button>
 		{/if}
 
 		{#if has('notifications')}
-			<button
-				class="topbar-btn topbar-btn-icon relative"
-				class:topbar-glass={transparent}
+			<Button
+				variant="ghost"
+				size="icon-sm"
+				class="relative {glassClass}"
 				title={m.topbar_notifications()}
 			>
 				<BellIcon size={13} />
 				{#if hasNotifications}
 					<span class="absolute top-1 right-1 size-1.5 rounded-full bg-accent"></span>
 				{/if}
-			</button>
+			</Button>
 		{/if}
 
 		{#if has('view') && viewMode !== undefined && onViewModeChange}
-			<div
-				class="flex items-center gap-0.5 rounded-md border border-border bg-muted/40 p-0.5"
-				class:topbar-glass={transparent}
-			>
+			<Tabs class={glassClass}>
 				{#each viewTabs as tab (tab.value)}
-					<button
-						class="inline-flex items-center gap-1 rounded px-2 py-1 text-[11px] transition-colors"
-						class:bg-background={viewMode === tab.value}
-						class:text-foreground={viewMode === tab.value}
-						class:shadow-sm={viewMode === tab.value}
-						class:text-muted-foreground={viewMode !== tab.value}
+					<Tab
+						active={viewMode === tab.value}
 						title={VIEW_LABELS[tab.labelKey]()}
 						onclick={() => onViewModeChange(tab.value)}
 					>
 						<tab.Icon size={11} />
 						<span>{VIEW_LABELS[tab.labelKey]()}</span>
-					</button>
+					</Tab>
 				{/each}
-			</div>
+			</Tabs>
 		{/if}
 
 		{#if has('plant')}
-			<button class="topbar-btn-primary" title={m.topbar_plant_title()} onclick={onPlant}>
+			<Button variant="primary" size="sm" title={m.topbar_plant_title()} onclick={onPlant}>
 				<PlusIcon size={12} />
 				<span>{m.topbar_plant()}</span>
-			</button>
+			</Button>
 		{/if}
 
 		{#if children}
@@ -205,27 +209,6 @@
 		backdrop-filter: blur(8px);
 	}
 
-	.topbar-search {
-		position: relative;
-		display: flex;
-		align-items: center;
-		gap: 6px;
-		width: 200px;
-		height: 30px;
-		padding: 0 8px;
-		border: 1px solid var(--border);
-		border-radius: var(--radius);
-		background: transparent;
-		font-size: 12.5px;
-		font-family: inherit;
-		cursor: pointer;
-		transition: border-color 120ms;
-	}
-
-	.topbar-search:hover {
-		border-color: var(--border-strong);
-	}
-
 	.topbar-kbd {
 		margin-left: auto;
 		padding: 1px 5px;
@@ -234,60 +217,5 @@
 		border-radius: 4px;
 		background: var(--surface-2);
 		color: var(--foreground-subtle);
-	}
-
-	.topbar-btn {
-		display: inline-flex;
-		align-items: center;
-		gap: 4px;
-		padding: 5px 10px;
-		border: 1px solid var(--border);
-		border-radius: var(--radius);
-		background: transparent;
-		font-size: 12px;
-		font-family: inherit;
-		color: var(--foreground-muted);
-		cursor: pointer;
-		transition:
-			border-color 120ms,
-			color 120ms;
-	}
-
-	.topbar-btn:hover {
-		border-color: var(--border-strong);
-		color: var(--foreground);
-	}
-
-	.topbar-btn:disabled {
-		opacity: 0.4;
-		cursor: not-allowed;
-	}
-
-	.topbar-btn-icon {
-		padding: 5px 6px;
-	}
-
-	.topbar-btn-primary {
-		display: inline-flex;
-		align-items: center;
-		gap: 4px;
-		padding: 5px 12px;
-		border: none;
-		border-radius: var(--radius);
-		background: var(--primary);
-		color: var(--primary-foreground);
-		font-size: 12px;
-		font-family: inherit;
-		cursor: pointer;
-		transition: opacity 120ms;
-	}
-
-	.topbar-btn-primary:hover {
-		opacity: 0.9;
-	}
-
-	.topbar-glass {
-		background: color-mix(in oklch, var(--surface) 60%, transparent);
-		backdrop-filter: blur(8px);
 	}
 </style>

--- a/src/lib/components/UserAvatar.svelte
+++ b/src/lib/components/UserAvatar.svelte
@@ -2,6 +2,7 @@
 	import * as m from '$lib/paraglide/messages.js';
 	import ChevronUpIcon from '@lucide/svelte/icons/chevron-up';
 	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
 
 	interface Props {
 		username: string;
@@ -37,9 +38,7 @@
 		</Tooltip.Root>
 	</div>
 {:else}
-	<button
-		class="flex w-full items-center gap-2 rounded-lg p-2.5 transition-colors hover:bg-surface-2"
-	>
+	<Button variant="ghost" class="w-full justify-start gap-2 p-2.5">
 		<div
 			class="flex size-[26px] items-center justify-center rounded-full bg-[var(--moss-600)] text-[11px] font-semibold text-white"
 		>
@@ -52,5 +51,5 @@
 			</div>
 		</div>
 		<ChevronUpIcon size={13} class="text-foreground-subtle" />
-	</button>
+	</Button>
 {/if}

--- a/src/lib/components/WorkspaceSelector.svelte
+++ b/src/lib/components/WorkspaceSelector.svelte
@@ -2,6 +2,7 @@
 	import FolderIcon from '@lucide/svelte/icons/folder';
 	import ChevronDownIcon from '@lucide/svelte/icons/chevron-down';
 	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
 
 	interface Props {
 		name: string;
@@ -16,23 +17,18 @@
 		<Tooltip.Root>
 			<Tooltip.Trigger>
 				{#snippet child({ props })}
-					<button
-						{...props}
-						class="flex size-9 items-center justify-center rounded-lg transition-colors hover:bg-surface-2"
-					>
+					<Button {...props} variant="ghost" size="icon">
 						<FolderIcon size={14} class="text-primary" />
-					</button>
+					</Button>
 				{/snippet}
 			</Tooltip.Trigger>
 			<Tooltip.Content side="right">{name}</Tooltip.Content>
 		</Tooltip.Root>
 	</div>
 {:else}
-	<button
-		class="flex w-full items-center gap-2 rounded-md bg-surface-2 px-2 py-1.5 text-left transition-colors hover:bg-surface-3"
-	>
+	<Button variant="ghost" class="w-full justify-start gap-2 bg-surface-2 hover:bg-surface-3">
 		<FolderIcon size={13} class="text-primary" />
 		<span class="flex-1 truncate text-[12.5px] font-medium">{name}</span>
 		<ChevronDownIcon size={12} class="text-foreground-subtle" />
-	</button>
+	</Button>
 {/if}

--- a/src/lib/components/dialog_helpers.ts
+++ b/src/lib/components/dialog_helpers.ts
@@ -1,19 +1,6 @@
 import type { CreateIssueRequest, UpdateIssueRequest, IssuePriority } from '$lib/modules/issues';
 import type { CreateDashboardRequest, UpdateDashboardRequest } from '$lib/modules/board';
 
-export function syncDialogVisibility(
-	triggerOpen: boolean,
-	dialogElement: HTMLDialogElement | undefined,
-	onOpen?: () => void,
-): void {
-	if (triggerOpen && dialogElement !== undefined && !dialogElement.open) {
-		onOpen?.();
-		dialogElement.showModal();
-	} else if (!triggerOpen && dialogElement?.open === true) {
-		dialogElement.close();
-	}
-}
-
 function trimOrNull(value: string): string | null {
 	const trimmed = value.trim();
 	return trimmed || null;

--- a/src/routes/sessions/+page.svelte
+++ b/src/routes/sessions/+page.svelte
@@ -7,6 +7,8 @@
 	import SessionCard from '$lib/components/SessionCard.svelte';
 	import DiscoveredSessionCard from '$lib/components/DiscoveredSessionCard.svelte';
 	import SessionChatView from '$lib/components/SessionChatView.svelte';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
 
 	const store = useSessions();
 	const notificationStore = useNotifications();
@@ -16,7 +18,6 @@
 	let spawnWorkingDirectory = $state('');
 	let spawning = $state(false);
 
-	// Derive live session from store so state updates are always reflected
 	const selectedSession = $derived(
 		selectedSessionId !== null
 			? (store.sessions.find((s) => s.id === selectedSessionId) ?? null)
@@ -85,12 +86,9 @@
 	<!-- Chat view for selected session -->
 	<div class="flex h-full flex-col">
 		<div class="flex items-center gap-3 border-b border-border px-4 py-3">
-			<button
-				class="text-sm text-muted-foreground hover:text-foreground"
-				onclick={handleBack}
-			>
+			<Button variant="ghost" size="sm" onclick={handleBack}>
 				{m.session_back()}
-			</button>
+			</Button>
 			<h2 class="truncate text-sm font-medium text-foreground">
 				{selectedSession.original_intent ?? m.session_fallback_title()}
 			</h2>
@@ -109,16 +107,13 @@
 		<!-- Spawn form -->
 		<div class="space-y-2 rounded-lg border border-border bg-muted/50 p-4">
 			<h3 class="text-sm font-medium text-foreground">{m.session_new()}</h3>
-			<input
-				type="text"
-				class="w-full rounded-md border border-input bg-muted px-3 py-2 text-sm text-foreground placeholder-muted-foreground focus:border-ring focus:outline-none"
+			<Input
 				placeholder={m.session_placeholder_working_dir()}
 				bind:value={spawnWorkingDirectory}
 			/>
 			<div class="flex gap-2">
-				<input
-					type="text"
-					class="flex-1 rounded-md border border-input bg-muted px-3 py-2 text-sm text-foreground placeholder-muted-foreground focus:border-ring focus:outline-none"
+				<Input
+					class="flex-1"
 					placeholder={m.session_placeholder_prompt()}
 					bind:value={spawnPrompt}
 					onkeydown={(e) => {
@@ -127,13 +122,13 @@
 						}
 					}}
 				/>
-				<button
-					class="shrink-0 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+				<Button
+					class="shrink-0"
 					onclick={handleSpawn}
 					disabled={spawning || !spawnPrompt.trim() || !spawnWorkingDirectory.trim()}
 				>
 					{spawning ? m.session_spawning() : m.session_spawn()}
-				</button>
+				</Button>
 			</div>
 		</div>
 

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -3,7 +3,10 @@
 	import NotificationSettingsPanel from '$lib/components/NotificationSettingsPanel.svelte';
 	import ShortcutSettingsPanel from '$lib/components/ShortcutSettingsPanel.svelte';
 	import { useBoard, ACCENT_COLORS, type CreateColorPaletteRequest } from '$lib/modules/board';
+	import { Button } from '$lib/components/ui/button/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
+	import { Textarea } from '$lib/components/ui/textarea/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
 	import type { ColorPalette } from '$lib/types/generated';
 	import { Persisted, stringSerde } from '$lib/reactivity/persisted.svelte.js';
 	import { GLOW_COLORS } from '$lib/modules/visualization/constants.js';
@@ -147,9 +150,7 @@
 		</p>
 		<div class="flex flex-col gap-3 sm:flex-row sm:items-end">
 			<div class="flex-1 space-y-1">
-				<label for="username-input" class="text-xs text-muted-foreground"
-					>{m.settings_username_label()}</label
-				>
+				<Label for="username-input">{m.settings_username_label()}</Label>
 				<Input
 					id="username-input"
 					bind:value={editUsername}
@@ -159,9 +160,7 @@
 				/>
 			</div>
 			<div class="w-24 space-y-1">
-				<label for="initials-input" class="text-xs text-muted-foreground"
-					>{m.settings_initials_label()}</label
-				>
+				<Label for="initials-input">{m.settings_initials_label()}</Label>
 				<Input
 					id="initials-input"
 					bind:value={editInitials}
@@ -184,22 +183,22 @@
 		</p>
 		<div class="flex flex-wrap gap-3">
 			{#each ACCENT_COLORS as color (color)}
-				<button
-					type="button"
+				<Button
+					variant="secondary"
+					size="sm"
 					onclick={() => {
 						boardStore.theme.accent = color;
 					}}
-					class="flex items-center gap-2 rounded-lg border px-3 py-2 text-sm capitalize transition-all {boardStore
-						.theme.accent === color
+					class="capitalize {boardStore.theme.accent === color
 						? 'border-primary bg-surface-2 font-medium'
-						: 'border-border hover:border-border-strong hover:bg-surface-2'}"
+						: ''}"
 				>
 					<div
 						class="size-4 rounded-full"
 						style:background-color="var(--{color}-500)"
 					></div>
 					{color}
-				</button>
+				</Button>
 			{/each}
 		</div>
 	</section>
@@ -212,9 +211,7 @@
 		</p>
 		<div class="flex flex-wrap gap-6">
 			<div class="space-y-1">
-				<label for="hover-glow-color" class="text-xs text-muted-foreground"
-					>Hover Glow</label
-				>
+				<Label for="hover-glow-color">Hover Glow</Label>
 				<div class="flex items-center gap-2">
 					<input
 						id="hover-glow-color"
@@ -231,9 +228,7 @@
 				</div>
 			</div>
 			<div class="space-y-1">
-				<label for="selected-glow-color" class="text-xs text-muted-foreground"
-					>Selected Glow</label
-				>
+				<Label for="selected-glow-color">Selected Glow</Label>
 				<div class="flex items-center gap-2">
 					<input
 						id="selected-glow-color"
@@ -294,35 +289,27 @@
 				{#if editingPaletteId === palette.id}
 					<!-- Edit mode -->
 					<div class="space-y-2">
-						<input
-							bind:value={editName}
-							class="w-full rounded border border-input bg-muted px-2 py-1 text-sm text-foreground outline-none focus:border-ring"
-							placeholder={m.palette_placeholder_name()}
-						/>
-						<textarea
+						<Input bind:value={editName} placeholder={m.palette_placeholder_name()} />
+						<Textarea
 							bind:value={editColorsInput}
-							rows="2"
-							class="w-full rounded border border-input bg-muted px-2 py-1 text-xs text-foreground outline-none focus:border-ring"
+							rows={2}
+							class="text-xs"
 							placeholder={m.palette_placeholder_colors()}
-						></textarea>
+						/>
 						<div class="flex gap-2">
-							<button
-								type="button"
-								onclick={handleSaveEdit}
-								class="rounded bg-primary px-3 py-1 text-xs text-primary-foreground hover:bg-primary/90"
-							>
+							<Button size="sm" onclick={handleSaveEdit}>
 								{m.btn_save()}
-							</button>
-							<button
-								type="button"
+							</Button>
+							<Button
+								variant="ghost"
+								size="sm"
 								onclick={() => {
 									editingPaletteId = null;
 									operationError = null;
 								}}
-								class="rounded px-3 py-1 text-xs text-muted-foreground hover:text-foreground"
 							>
 								{m.btn_cancel()}
-							</button>
+							</Button>
 						</div>
 					</div>
 				{:else}
@@ -330,20 +317,16 @@
 					<div class="mb-2 flex items-center justify-between">
 						<span class="text-sm font-medium">{palette.name}</span>
 						<div class="flex gap-2">
-							<button
-								type="button"
-								onclick={() => startEditing(palette)}
-								class="text-xs text-muted-foreground hover:text-foreground"
-							>
+							<Button variant="ghost" size="sm" onclick={() => startEditing(palette)}>
 								{m.issue_card_edit()}
-							</button>
-							<button
-								type="button"
+							</Button>
+							<Button
+								variant="danger"
+								size="sm"
 								onclick={() => handleDelete(palette.id)}
-								class="text-xs text-destructive hover:text-destructive/80"
 							>
 								{m.btn_delete()}
-							</button>
+							</Button>
 						</div>
 					</div>
 					<div class="flex flex-wrap gap-1">
@@ -363,49 +346,40 @@
 		{#if creating}
 			<div class="rounded border border-dashed border-input p-3">
 				<div class="space-y-2">
-					<input
-						bind:value={newPaletteName}
-						class="w-full rounded border border-input bg-muted px-2 py-1 text-sm text-foreground outline-none focus:border-ring"
-						placeholder={m.palette_placeholder_name()}
-					/>
-					<textarea
+					<Input bind:value={newPaletteName} placeholder={m.palette_placeholder_name()} />
+					<Textarea
 						bind:value={newPaletteColorsInput}
-						rows="3"
-						class="w-full rounded border border-input bg-muted px-2 py-1 text-xs text-foreground outline-none focus:border-ring"
+						rows={3}
+						class="text-xs"
 						placeholder={m.palette_placeholder_colors_long()}
-					></textarea>
+					/>
 					<div class="flex gap-2">
-						<button
-							type="button"
-							onclick={handleCreate}
-							class="rounded bg-primary px-3 py-1 text-xs text-primary-foreground hover:bg-primary/90"
-						>
+						<Button size="sm" onclick={handleCreate}>
 							{m.palette_create()}
-						</button>
-						<button
-							type="button"
+						</Button>
+						<Button
+							variant="ghost"
+							size="sm"
 							onclick={() => {
 								creating = false;
 								operationError = null;
 							}}
-							class="rounded px-3 py-1 text-xs text-muted-foreground hover:text-foreground"
 						>
 							{m.btn_cancel()}
-						</button>
+						</Button>
 					</div>
 				</div>
 			</div>
 		{:else}
-			<button
-				type="button"
+			<Button
+				variant="secondary"
 				onclick={() => {
 					creating = true;
 					operationError = null;
 				}}
-				class="rounded border border-dashed border-input px-4 py-2 text-sm text-muted-foreground transition-colors hover:border-border hover:text-foreground"
 			>
 				{m.palette_add_custom()}
-			</button>
+			</Button>
 		{/if}
 	</section>
 
@@ -429,22 +403,20 @@
 			{/if}
 
 			<div class="flex flex-wrap gap-3">
-				<button
-					type="button"
+				<Button
+					variant="secondary"
 					disabled={seedStatus !== 'idle'}
 					onclick={handleSeedDemo}
-					class="rounded border border-border bg-surface-2 px-4 py-2 text-sm transition-colors hover:bg-surface-3 disabled:opacity-50"
 				>
 					{seedStatus === 'seeding' ? 'Seeding...' : 'Seed Demo Workspace'}
-				</button>
-				<button
-					type="button"
+				</Button>
+				<Button
+					variant="danger"
 					disabled={seedStatus !== 'idle'}
 					onclick={handleDeleteDemo}
-					class="rounded border border-destructive/50 px-4 py-2 text-sm text-destructive transition-colors hover:bg-destructive/10 disabled:opacity-50"
 				>
 					{seedStatus === 'deleting' ? 'Deleting...' : 'Delete Demo Workspace'}
-				</button>
+				</Button>
 			</div>
 		</section>
 	{/if}


### PR DESCRIPTION
## Description

Completed comprehensive migration of raw HTML form elements to the component library across 18 files.

- **Dialogs (5):** native `<dialog>` + `syncDialogVisibility()` → `Dialog.Root` (bits-ui) with `bind:open`, Dialog.Header/Body/Footer/Title/Description
- **Buttons (~30):** raw `<button>` → `Button` with variants (ghost, primary, secondary, danger)
- **Inputs (~20):** raw `<input>` → `Input` component
- **Selects (3):** raw `<select>` → `Select` component
- **Textareas (2):** raw `<textarea>` → `Textarea` component
- **Labels (~19):** raw `<label>` → `Label` (bits-ui)
- **Checkboxes (3):** raw `<input type="checkbox">` → `Checkbox` (bits-ui)
- **View mode toggle (1):** custom button group → `Tabs` + `Tab` components
- **ThemeToggle + LanguageSwitcher:** raw buttons → `Tabs` (expanded) / `Button` (collapsed)
- **TopBar:** removed custom CSS classes (.topbar-btn, .topbar-btn-primary, .topbar-btn-icon)
- **DashboardSidebar:** migrated collapse/expand buttons to Button component
- **Removed `syncDialogVisibility`** from dialog_helpers.ts (Dialog.Root handles open/close via props)
- **Fixed dialog centering bug** (Dialog.Content uses fixed centering with translate)
- **Native `<input type="color">`** kept as-is (no library equivalent)

**Net result:** 18 files changed, -150 lines

## Resolves

Closes #128

## Notes

Unresolved items for future work:
- WorkspaceSelector Popover dropdown (clicking still does nothing — requires workspace list data plumbing)
- UserAvatar Popover menu (requires user menu content design)