### PR TITLE
#137 fix(ui): dashboard layout restructure, forest rendering, and visual consistency

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -8,6 +8,7 @@
 	--color-surface: var(--surface);
 	--color-surface-2: var(--surface-2);
 	--color-surface-3: var(--surface-3);
+	--color-surface-hover: var(--surface-hover);
 	--color-foreground-muted: var(--foreground-muted);
 	--color-foreground-subtle: var(--foreground-subtle);
 	--color-primary: var(--primary);
@@ -190,6 +191,7 @@
 	--background: oklch(0.985 0.005 130);
 	--surface: oklch(1 0 0);
 	--surface-2: oklch(0.965 0.008 130);
+	--surface-hover: oklch(0.94 0.012 130);
 	--surface-3: oklch(0.94 0.012 130);
 	--foreground: oklch(0.205 0.015 145);
 	--foreground-muted: oklch(0.46 0.015 145);
@@ -208,6 +210,7 @@
 	--sky-top: var(--sky-light-top);
 	--sky-bot: var(--sky-light-bot);
 	--ground-color: oklch(0.55 0.09 135);
+	--ground-dark: oklch(0.38 0.06 55);
 }
 
 [data-theme='dark'] {
@@ -216,6 +219,7 @@
 	--background: oklch(0.155 0.018 150);
 	--surface: oklch(0.19 0.02 150);
 	--surface-2: oklch(0.225 0.022 150);
+	--surface-hover: oklch(0.265 0.024 150);
 	--surface-3: oklch(0.265 0.024 150);
 	--foreground: oklch(0.965 0.01 130);
 	--foreground-muted: oklch(0.73 0.018 135);
@@ -234,6 +238,7 @@
 	--sky-top: var(--sky-dark-top);
 	--sky-bot: var(--sky-dark-bot);
 	--ground-color: oklch(0.3 0.06 140);
+	--ground-dark: oklch(0.18 0.04 50);
 }
 
 /* ── Accent color overrides ─────────────────────────────────────────────── */

--- a/src/lib/components/CommandPalette.svelte
+++ b/src/lib/components/CommandPalette.svelte
@@ -56,7 +56,7 @@
 			<SearchIcon size={14} class="shrink-0 text-foreground-subtle" />
 			<Input
 				bind:ref={searchInputElement}
-				class="h-6 flex-1 border-none bg-transparent p-0 text-sm shadow-none outline-none placeholder:text-foreground-subtle"
+				class="h-6 flex-1 border-none bg-transparent py-0 pl-1 text-sm shadow-none outline-none placeholder:text-foreground-subtle"
 				placeholder={m.command_palette_placeholder()}
 				value={paletteCtx.query}
 				oninput={(event) => {

--- a/src/lib/components/DashboardSidebar.svelte
+++ b/src/lib/components/DashboardSidebar.svelte
@@ -24,6 +24,7 @@
 		activeSessionCount?: number;
 		collapsed: boolean;
 		onToggleSidebar: () => void;
+		onEditWorkspace?: () => void;
 	}
 
 	let {
@@ -33,6 +34,7 @@
 		activeSessionCount = 0,
 		collapsed,
 		onToggleSidebar,
+		onEditWorkspace,
 	}: Props = $props();
 
 	const NAV_LABELS = {
@@ -122,7 +124,7 @@
 				{m.nav_workspace()}
 			</div>
 		{/if}
-		<WorkspaceSelector name={workspaceName} {collapsed} />
+		<WorkspaceSelector name={workspaceName} {collapsed} onclick={onEditWorkspace} />
 	</div>
 
 	<!-- Navigation -->

--- a/src/lib/components/ForestContextMenu.svelte
+++ b/src/lib/components/ForestContextMenu.svelte
@@ -9,6 +9,7 @@
 	import PlayIcon from '@lucide/svelte/icons/play';
 	import ArchiveIcon from '@lucide/svelte/icons/archive';
 	import PaletteIcon from '@lucide/svelte/icons/palette';
+	import ScissorsIcon from '@lucide/svelte/icons/scissors';
 
 	interface Props {
 		x: number;
@@ -35,6 +36,11 @@
 		{ action: TREE_CONTEXT_MENU_ACTIONS.startSession, label: 'Start Session', icon: PlayIcon },
 		{ action: TREE_CONTEXT_MENU_ACTIONS.archive, label: 'Archive', icon: ArchiveIcon },
 		{ action: TREE_CONTEXT_MENU_ACTIONS.changeColor, label: 'Change Color', icon: PaletteIcon },
+		{
+			action: TREE_CONTEXT_MENU_ACTIONS.pruneWorktree,
+			label: 'Prune Worktree',
+			icon: ScissorsIcon,
+		},
 	];
 
 	function handleItemClick(action: TreeContextMenuAction) {

--- a/src/lib/components/ForestView.svelte
+++ b/src/lib/components/ForestView.svelte
@@ -36,12 +36,12 @@
 
 	let { issues, getGitStatus, getSessionsForIssue, onAddIssue }: Props = $props();
 
-	const TREE_NATURAL_WIDTH = 100;
-	const TREE_NATURAL_HEIGHT = 100;
-	const OAK_NATURAL_WIDTH = 140;
-	const OAK_NATURAL_HEIGHT = 140;
-	const POTTED_NATURAL_WIDTH = 60;
-	const POTTED_NATURAL_HEIGHT = 90;
+	const TREE_NATURAL_WIDTH = 320;
+	const TREE_NATURAL_HEIGHT = 320;
+	const OAK_NATURAL_WIDTH = 448;
+	const OAK_NATURAL_HEIGHT = 448;
+	const POTTED_NATURAL_WIDTH = 192;
+	const POTTED_NATURAL_HEIGHT = 288;
 
 	let viewportWidth = $state(0);
 	let viewportHeight = $state(0);
@@ -303,9 +303,9 @@
 	{/if}
 	<button
 		type="button"
-		class="absolute bottom-0 left-0 right-0 cursor-default border-0 p-0"
+		class="absolute inset-x-0 bottom-0 cursor-default border-0 p-0"
 		style:height="{groundStripHeight}px"
-		style:background="var(--ground-color)"
+		style:background="linear-gradient(to top, var(--ground-dark), var(--ground-color))"
 		style:z-index="1"
 		onclick={handleGroundClick}
 		tabindex="-1"

--- a/src/lib/components/LanguageSwitcher.svelte
+++ b/src/lib/components/LanguageSwitcher.svelte
@@ -36,7 +36,7 @@
 		<GlobeIcon class="size-4" />
 	</Button>
 {:else}
-	<Tabs>
+	<Tabs class="w-full">
 		{#each locales as locale (locale)}
 			<Tab
 				active={getLocale() === locale}

--- a/src/lib/components/SidebarNavItem.svelte
+++ b/src/lib/components/SidebarNavItem.svelte
@@ -85,7 +85,7 @@
 	}
 
 	.sb-item:hover {
-		background: var(--surface-2);
+		background: var(--surface-hover);
 	}
 
 	.sb-item.is-active {
@@ -140,7 +140,7 @@
 	}
 
 	.sb-item-collapsed:hover {
-		background: var(--surface-2);
+		background: var(--surface-hover);
 	}
 
 	.sb-item-collapsed.is-active {

--- a/src/lib/components/ThemeToggle.svelte
+++ b/src/lib/components/ThemeToggle.svelte
@@ -48,7 +48,7 @@
 		<currentMode.Icon class="size-4" />
 	</Button>
 {:else}
-	<Tabs>
+	<Tabs class="w-full">
 		{#each modes as { value, Icon, labelKey } (value)}
 			<Tab
 				active={theme.mode === value}

--- a/src/lib/components/TopBar.svelte
+++ b/src/lib/components/TopBar.svelte
@@ -1,99 +1,40 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
 	import type { Snippet } from 'svelte';
-	import SearchIcon from '@lucide/svelte/icons/search';
-	import FilterIcon from '@lucide/svelte/icons/filter';
-	import LayersIcon from '@lucide/svelte/icons/layers';
 	import RefreshCwIcon from '@lucide/svelte/icons/refresh-cw';
-	import SparklesIcon from '@lucide/svelte/icons/sparkles';
 	import BellIcon from '@lucide/svelte/icons/bell';
 	import PlusIcon from '@lucide/svelte/icons/plus';
-	import ListIcon from '@lucide/svelte/icons/list';
-	import KanbanIcon from '@lucide/svelte/icons/kanban';
 	import TreesIcon from '@lucide/svelte/icons/trees';
-	import type { ViewMode } from '$lib/modules/board';
-	import { useKeyboardShortcuts } from '$lib/modules/keyboard-shortcuts';
 	import { Button } from '$lib/components/ui/button/index.js';
-	import { Tabs, Tab } from '$lib/components/ui/tabs/index.js';
-
-	type TopBarControl =
-		| 'search'
-		| 'filter'
-		| 'sort'
-		| 'sync'
-		| 'legend'
-		| 'notifications'
-		| 'view'
-		| 'plant';
 
 	interface Props {
 		title: string;
 		subtitle?: string;
-		controls?: TopBarControl[];
-		transparent?: boolean;
-		viewMode?: ViewMode;
 		hasNotifications?: boolean;
 		syncing?: boolean;
-		onViewModeChange?: (mode: ViewMode) => void;
+		forestCollapsed?: boolean;
 		onSync?: () => void;
 		onPlant?: () => void;
-		onSearch?: () => void;
+		onToggleForest?: () => void;
 		children?: Snippet;
 	}
 
 	let {
 		title,
 		subtitle,
-		controls = ['search', 'filter', 'sort', 'sync', 'notifications', 'view', 'plant'],
-		transparent = false,
-		viewMode,
 		hasNotifications = false,
 		syncing = false,
-		onViewModeChange,
+		forestCollapsed = false,
 		onSync,
 		onPlant,
-		onSearch,
+		onToggleForest,
 		children,
 	}: Props = $props();
-
-	const shortcutsCtx = useKeyboardShortcuts();
-	const searchBinding = $derived(shortcutsCtx.getBindingForDisplay('command-palette'));
-
-	function has(control: TopBarControl): boolean {
-		return controls.includes(control);
-	}
-
-	const VIEW_LABELS = {
-		list: () => m.view_list(),
-		kanban: () => m.view_kanban(),
-		forest: () => m.view_forest(),
-	} as const;
-
-	const viewTabs = [
-		{ value: 'list' as const, Icon: ListIcon, labelKey: 'list' as const },
-		{ value: 'kanban' as const, Icon: KanbanIcon, labelKey: 'kanban' as const },
-		{ value: 'forest' as const, Icon: TreesIcon, labelKey: 'forest' as const },
-	];
-
-	const glassClass = $derived(
-		transparent
-			? 'backdrop-blur-sm bg-[color-mix(in_oklch,var(--surface)_60%,transparent)]'
-			: '',
-	);
 </script>
 
-<div
-	class="flex items-center justify-between gap-3"
-	class:topbar-default={!transparent}
-	class:topbar-transparent={transparent}
->
+<div class="flex items-center justify-between gap-3 border-b border-border px-5 py-3">
 	<!-- Left: title -->
 	<div class="min-w-0">
-		{#if transparent}
-			<div class="text-[10px] font-semibold uppercase tracking-wider text-foreground-subtle">
-				{m.topbar_the_grove()}
-			</div>
-		{/if}
 		<h1 class="truncate text-[17px] font-semibold leading-tight">{title}</h1>
 		{#if subtitle}
 			<div class="mt-0.5 font-mono text-[10px] text-foreground-subtle">{subtitle}</div>
@@ -102,40 +43,10 @@
 
 	<!-- Right: controls -->
 	<div class="flex shrink-0 items-center gap-1.5">
-		{#if has('search')}
-			<Button
-				variant="ghost"
-				size="sm"
-				class="w-[200px] justify-start {glassClass}"
-				onclick={onSearch}
-			>
-				<SearchIcon size={12} class="pointer-events-none text-foreground-subtle" />
-				<span class="text-foreground-subtle">{m.topbar_search()}</span>
-				{#if searchBinding}
-					<kbd class="topbar-kbd">{searchBinding}</kbd>
-				{/if}
-			</Button>
-		{/if}
-
-		{#if has('filter')}
-			<Button variant="ghost" size="sm" class={glassClass} title={m.topbar_filter()}>
-				<FilterIcon size={12} />
-				<span>{m.topbar_filter()}</span>
-			</Button>
-		{/if}
-
-		{#if has('sort')}
-			<Button variant="ghost" size="sm" class={glassClass} title={m.topbar_sort()}>
-				<LayersIcon size={12} />
-				<span>{m.topbar_sort()}</span>
-			</Button>
-		{/if}
-
-		{#if has('sync')}
+		{#if onSync}
 			<Button
 				variant="ghost"
 				size="icon-sm"
-				class={glassClass}
 				title={m.topbar_sync()}
 				disabled={syncing}
 				onclick={onSync}
@@ -144,42 +55,25 @@
 			</Button>
 		{/if}
 
-		{#if has('legend')}
-			<Button variant="ghost" size="icon-sm" class={glassClass} title={m.topbar_legend()}>
-				<SparklesIcon size={13} />
-			</Button>
-		{/if}
+		<Button variant="ghost" size="icon-sm" class="relative" title={m.topbar_notifications()}>
+			<BellIcon size={13} />
+			{#if hasNotifications}
+				<span class="absolute top-1 right-1 size-1.5 rounded-full bg-accent"></span>
+			{/if}
+		</Button>
 
-		{#if has('notifications')}
+		{#if onToggleForest}
 			<Button
-				variant="ghost"
+				variant={forestCollapsed ? 'ghost' : 'secondary'}
 				size="icon-sm"
-				class="relative {glassClass}"
-				title={m.topbar_notifications()}
+				title={forestCollapsed ? 'Show forest' : 'Hide forest'}
+				onclick={onToggleForest}
 			>
-				<BellIcon size={13} />
-				{#if hasNotifications}
-					<span class="absolute top-1 right-1 size-1.5 rounded-full bg-accent"></span>
-				{/if}
+				<TreesIcon size={13} />
 			</Button>
 		{/if}
 
-		{#if has('view') && viewMode !== undefined && onViewModeChange}
-			<Tabs class={glassClass}>
-				{#each viewTabs as tab (tab.value)}
-					<Tab
-						active={viewMode === tab.value}
-						title={VIEW_LABELS[tab.labelKey]()}
-						onclick={() => onViewModeChange(tab.value)}
-					>
-						<tab.Icon size={11} />
-						<span>{VIEW_LABELS[tab.labelKey]()}</span>
-					</Tab>
-				{/each}
-			</Tabs>
-		{/if}
-
-		{#if has('plant')}
+		{#if onPlant}
 			<Button variant="primary" size="sm" title={m.topbar_plant_title()} onclick={onPlant}>
 				<PlusIcon size={12} />
 				<span>{m.topbar_plant()}</span>
@@ -191,31 +85,3 @@
 		{/if}
 	</div>
 </div>
-
-<style>
-	.topbar-default {
-		padding: 12px 20px;
-		border-bottom: 1px solid var(--border);
-	}
-
-	.topbar-transparent {
-		position: absolute;
-		top: 0;
-		left: 0;
-		right: 0;
-		z-index: var(--z-raised);
-		padding: 14px 24px;
-		background: color-mix(in oklch, var(--surface) 60%, transparent);
-		backdrop-filter: blur(8px);
-	}
-
-	.topbar-kbd {
-		margin-left: auto;
-		padding: 1px 5px;
-		font-size: 10px;
-		font-family: inherit;
-		border-radius: 4px;
-		background: var(--surface-2);
-		color: var(--foreground-subtle);
-	}
-</style>

--- a/src/lib/components/UserAvatar.svelte
+++ b/src/lib/components/UserAvatar.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
-	import ChevronUpIcon from '@lucide/svelte/icons/chevron-up';
 	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
-	import { Button } from '$lib/components/ui/button/index.js';
 
 	interface Props {
 		username: string;
@@ -38,7 +36,7 @@
 		</Tooltip.Root>
 	</div>
 {:else}
-	<Button variant="ghost" class="w-full justify-start gap-2 p-2.5">
+	<div class="flex w-full items-center gap-2 p-2.5">
 		<div
 			class="flex size-[26px] items-center justify-center rounded-full bg-[var(--moss-600)] text-[11px] font-semibold text-white"
 		>
@@ -50,6 +48,5 @@
 				{m.active_count({ count: String(activeCount) })}
 			</div>
 		</div>
-		<ChevronUpIcon size={13} class="text-foreground-subtle" />
-	</Button>
+	</div>
 {/if}

--- a/src/lib/components/WorkspaceBottomPanel.svelte
+++ b/src/lib/components/WorkspaceBottomPanel.svelte
@@ -1,6 +1,13 @@
 <script lang="ts">
-	import type { Issue } from '$lib/modules/issues';
-	import type { IssueDependency } from '$lib/types/generated';
+	import * as m from '$lib/paraglide/messages.js';
+	import type { Issue, IssueCardCallbacks } from '$lib/modules/issues';
+	import type {
+		Action,
+		GitStatusCache,
+		IssueDependency,
+		GhCliAvailability,
+		AssignedIssue,
+	} from '$lib/types/generated';
 	import type { TreeVisualization } from '$lib/modules/visualization';
 	import {
 		useSelection,
@@ -12,14 +19,62 @@
 	import * as Tabs from '$lib/components/ui/tabs/index.js';
 	import PrdOverview from './PrdOverview.svelte';
 	import DependencyGraphView from './DependencyGraphView.svelte';
+	import IssueCardList from './IssueCardList.svelte';
+	import GhSetupBanner from './GhSetupBanner.svelte';
+	import AssignedIssuesPanel from './AssignedIssuesPanel.svelte';
+	import ScissorsIcon from '@lucide/svelte/icons/scissors';
+	import { Button } from '$lib/components/ui/button/index.js';
 
-	interface Props {
+	interface Props extends IssueCardCallbacks {
 		issues: readonly Issue[];
+		parentIssues: Issue[];
+		archivedIssues: Issue[];
+		showArchived: boolean;
+		isPortfolio: boolean;
+		actions?: Action[];
+		forceExpanded?: boolean;
+		cacheMap?: Map<string, GitStatusCache>;
+		ghAvailable?: boolean;
 		dependencies: readonly IssueDependency[];
+		ghSetupBanner?: boolean;
+		ghAvailability?: GhCliAvailability;
+		assignedIssues?: AssignedIssue[];
+		isGhAvailable?: boolean;
 		getVisualization: (issueId: string) => TreeVisualization | undefined;
+		getChildren: (parentId: string) => Issue[];
+		getNotificationDotColor?: (issueId: string) => string | null;
+		getProgressLines?: (issueId: string) => readonly string[];
+		onPrune?: () => void;
 	}
 
-	let { issues, dependencies, getVisualization }: Props = $props();
+	let {
+		issues,
+		parentIssues,
+		archivedIssues,
+		showArchived,
+		isPortfolio,
+		actions = [],
+		forceExpanded,
+		cacheMap = new Map(),
+		ghAvailable = false,
+		dependencies,
+		ghSetupBanner = false,
+		ghAvailability,
+		assignedIssues = [],
+		isGhAvailable = false,
+		getVisualization,
+		getChildren,
+		getNotificationDotColor,
+		getProgressLines,
+		onArchive,
+		onUnarchive,
+		onEdit,
+		onDelete,
+		onSetupWorktree,
+		onRemoveWorktree,
+		onExecuteAction,
+		onPrune,
+	}: Props = $props();
 
 	const selection = useSelection();
 
@@ -69,13 +124,15 @@
 			? (issues.find((issue) => issue.id === selection.selectedIssueId) ?? null)
 			: null,
 	);
+
+	const defaultTab = $derived(selection.activeTab ?? BOTTOM_PANEL_TABS.issues);
 </script>
 
 <div class="flex h-full flex-col">
 	<div class="shrink-0 border-b border-border px-2 pt-1">
 		<Tabs.Root>
 			{#each tabValues as tab (tab)}
-				<Tabs.Tab active={selection.activeTab === tab} onclick={() => handleTabClick(tab)}>
+				<Tabs.Tab active={defaultTab === tab} onclick={() => handleTabClick(tab)}>
 					{BOTTOM_PANEL_TAB_LABELS[tab]}
 				</Tabs.Tab>
 			{/each}
@@ -83,14 +140,67 @@
 	</div>
 
 	<div class="flex-1 overflow-auto">
-		{#if selection.showPrdOverview}
+		{#if selection.showPrdOverview && defaultTab !== BOTTOM_PANEL_TABS.issues && defaultTab !== BOTTOM_PANEL_TABS.kanban}
 			<PrdOverview
 				title={prdIssue?.name ?? 'Workspace'}
 				completionRatio={prdVisualization?.completionRatio ?? 0}
 				issueCount={prdVisualization?.issueCount ?? issues.length}
 				{stageCounts}
 			/>
-		{:else if selection.activeTab === BOTTOM_PANEL_TABS.issueDetail}
+		{:else if defaultTab === BOTTOM_PANEL_TABS.issues}
+			<div class="flex flex-col gap-4 p-5">
+				{#if ghSetupBanner && ghAvailability}
+					<GhSetupBanner availability={ghAvailability} />
+				{/if}
+
+				<div class="flex items-center justify-between">
+					<div></div>
+					{#if onPrune}
+						<Button
+							variant="ghost"
+							size="sm"
+							title={m.topbar_prune_title()}
+							onclick={onPrune}
+						>
+							<ScissorsIcon size={12} />
+							<span>{m.topbar_prune()}</span>
+						</Button>
+					{/if}
+				</div>
+
+				<IssueCardList
+					{parentIssues}
+					{archivedIssues}
+					{showArchived}
+					{isPortfolio}
+					{actions}
+					{forceExpanded}
+					{cacheMap}
+					{ghAvailable}
+					{getChildren}
+					{getNotificationDotColor}
+					{getProgressLines}
+					{onArchive}
+					{onUnarchive}
+					{onEdit}
+					{onDelete}
+					{onSetupWorktree}
+					{onRemoveWorktree}
+					{onExecuteAction}
+				/>
+
+				{#if assignedIssues.length > 0}
+					<AssignedIssuesPanel
+						issues={assignedIssues}
+						disabled={isGhAvailable !== true}
+					/>
+				{/if}
+			</div>
+		{:else if defaultTab === BOTTOM_PANEL_TABS.kanban}
+			<div class="p-4">
+				<p class="text-sm text-muted-foreground">{m.kanban_coming_soon()}</p>
+			</div>
+		{:else if defaultTab === BOTTOM_PANEL_TABS.issueDetail}
 			<div class="p-4">
 				{#if selectedIssue}
 					<div class="flex flex-col gap-2">
@@ -104,13 +214,13 @@
 					<p class="text-sm text-muted-foreground">Select an issue to view details</p>
 				{/if}
 			</div>
-		{:else if selection.activeTab === BOTTOM_PANEL_TABS.dependencies}
+		{:else if defaultTab === BOTTOM_PANEL_TABS.dependencies}
 			<DependencyGraphView {issues} {dependencies} {getVisualization} />
-		{:else if selection.activeTab === BOTTOM_PANEL_TABS.activity}
+		{:else if defaultTab === BOTTOM_PANEL_TABS.activity}
 			<div class="p-4">
 				<p class="text-sm text-muted-foreground">Activity feed coming soon</p>
 			</div>
-		{:else if selection.activeTab === BOTTOM_PANEL_TABS.session}
+		{:else if defaultTab === BOTTOM_PANEL_TABS.session}
 			<div class="p-4">
 				<p class="text-sm text-muted-foreground">Session view coming soon</p>
 			</div>

--- a/src/lib/components/WorkspaceSelector.svelte
+++ b/src/lib/components/WorkspaceSelector.svelte
@@ -7,9 +7,10 @@
 	interface Props {
 		name: string;
 		collapsed?: boolean;
+		onclick?: () => void;
 	}
 
-	let { name, collapsed = false }: Props = $props();
+	let { name, collapsed = false, onclick }: Props = $props();
 </script>
 
 {#if collapsed}
@@ -26,7 +27,11 @@
 		</Tooltip.Root>
 	</div>
 {:else}
-	<Button variant="ghost" class="w-full justify-start gap-2 bg-surface-2 hover:bg-surface-3">
+	<Button
+		variant="ghost"
+		class="w-full justify-start gap-2 bg-surface-2 hover:bg-surface-3"
+		{onclick}
+	>
 		<FolderIcon size={13} class="text-primary" />
 		<span class="flex-1 truncate text-[12.5px] font-medium">{name}</span>
 		<ChevronDownIcon size={12} class="text-foreground-subtle" />

--- a/src/lib/components/ui/tabs/tabs-variants.ts
+++ b/src/lib/components/ui/tabs/tabs-variants.ts
@@ -8,10 +8,10 @@ export const tabsContainerVariants = tv({
 });
 
 export const tabVariants = tv({
-	base: 'px-3 py-[5px] text-xs font-medium rounded-[6px] text-foreground-muted cursor-pointer transition-all duration-[120ms] ease-[ease] border-none bg-transparent hover:text-foreground hover:bg-[color-mix(in_oklch,var(--foreground)_4%,transparent)] focus-visible:outline-2 focus-visible:outline-ring focus-visible:outline-offset-2 disabled:opacity-40 disabled:cursor-not-allowed',
+	base: 'inline-flex items-center gap-1.5 px-3 py-[5px] text-xs font-medium rounded-[6px] text-foreground-muted cursor-pointer transition-all duration-[120ms] ease-[ease] border-none bg-transparent hover:text-foreground hover:bg-[color-mix(in_oklch,var(--foreground)_4%,transparent)] focus-visible:outline-2 focus-visible:outline-ring focus-visible:outline-offset-2 disabled:opacity-40 disabled:cursor-not-allowed active:scale-[0.97] active:bg-[color-mix(in_oklch,var(--foreground)_8%,transparent)]',
 	variants: {
 		active: {
-			true: 'bg-surface text-foreground shadow-sm',
+			true: 'bg-surface text-foreground shadow-sm hover:bg-surface-hover',
 			false: '',
 		},
 	},

--- a/src/lib/modules/board/board.context.svelte.ts
+++ b/src/lib/modules/board/board.context.svelte.ts
@@ -15,14 +15,12 @@ import type {
 	CreateColorPaletteRequest,
 	UpdateColorPaletteRequest,
 	AddRepoToPortfolioRequest,
-	ViewMode,
 	ThemeMode,
 	AccentColor,
 } from './types.js';
 import {
 	isThemeMode,
 	isAccentColor,
-	isViewMode,
 	findPaletteForDashboard,
 	selectActiveDashboardId,
 	resolveActiveDashboardId,
@@ -111,13 +109,6 @@ function createBoardContext() {
 			document.documentElement.dataset.theme = isDark ? 'dark' : 'light';
 			document.documentElement.dataset.accent = accentColor.current;
 		}
-	});
-
-	// ── View preference state ──────────────────────────────────────────────
-	const viewMode = new Persisted<ViewMode>({
-		key: 'grovekeeper_view_mode',
-		serde: stringSerde(isViewMode),
-		defaultValue: 'list',
 	});
 
 	// ── Public interface ───────────────────────────────────────────────────
@@ -336,14 +327,6 @@ function createBoardContext() {
 		},
 		set userInitials(value: string) {
 			userInitials.current = value;
-		},
-
-		// View preference
-		get viewMode() {
-			return viewMode.current;
-		},
-		set viewMode(value: ViewMode) {
-			viewMode.current = value;
 		},
 	};
 }

--- a/src/lib/modules/board/board.test.ts
+++ b/src/lib/modules/board/board.test.ts
@@ -3,7 +3,6 @@ import {
 	findPaletteForDashboard,
 	selectActiveDashboardId,
 	resolveActiveDashboardId,
-	isViewMode,
 } from './types.js';
 import type { ColorPalette } from '$lib/types/generated';
 
@@ -77,29 +76,5 @@ describe('resolveActiveDashboardId', () => {
 
 	it('returns null when dashboards is empty', () => {
 		expect(resolveActiveDashboardId([], 'dash-1')).toBeNull();
-	});
-});
-
-describe('isViewMode', () => {
-	it('accepts list', () => {
-		expect(isViewMode('list')).toBe(true);
-	});
-
-	it('accepts kanban', () => {
-		expect(isViewMode('kanban')).toBe(true);
-	});
-
-	it('accepts forest', () => {
-		expect(isViewMode('forest')).toBe(true);
-	});
-
-	it('rejects the old cards value', () => {
-		expect(isViewMode('cards')).toBe(false);
-	});
-
-	it('rejects non-string values', () => {
-		expect(isViewMode(42)).toBe(false);
-		expect(isViewMode(null)).toBe(false);
-		expect(isViewMode(undefined)).toBe(false);
 	});
 });

--- a/src/lib/modules/board/index.ts
+++ b/src/lib/modules/board/index.ts
@@ -10,7 +10,6 @@ export type {
 	CreateColorPaletteRequest,
 	UpdateColorPaletteRequest,
 	AddRepoToPortfolioRequest,
-	ViewMode,
 	ThemeMode,
 	AccentColor,
 } from './types.js';

--- a/src/lib/modules/board/selection.test.ts
+++ b/src/lib/modules/board/selection.test.ts
@@ -9,18 +9,28 @@ import {
 } from './selection.js';
 
 describe('BOTTOM_PANEL_TABS', () => {
-	it('has exactly 4 entries with correct values', () => {
+	it('has exactly 6 entries with correct values', () => {
 		expect(BOTTOM_PANEL_TABS).toEqual({
+			issues: 'issues',
+			kanban: 'kanban',
 			issueDetail: 'issue-detail',
 			dependencies: 'dependencies',
 			activity: 'activity',
 			session: 'session',
 		});
-		expect(Object.keys(BOTTOM_PANEL_TABS)).toHaveLength(4);
+		expect(Object.keys(BOTTOM_PANEL_TABS)).toHaveLength(6);
 	});
 });
 
 describe('TAB_BEHAVIOR_MAP', () => {
+	it('maps issues to replace', () => {
+		expect(TAB_BEHAVIOR_MAP['issues']).toBe('replace');
+	});
+
+	it('maps kanban to replace', () => {
+		expect(TAB_BEHAVIOR_MAP['kanban']).toBe('replace');
+	});
+
 	it('maps issue-detail to replace', () => {
 		expect(TAB_BEHAVIOR_MAP['issue-detail']).toBe('replace');
 	});
@@ -71,6 +81,8 @@ describe('shouldShowPrdOverview', () => {
 
 describe('BOTTOM_PANEL_TAB_LABELS', () => {
 	it('maps each tab to correct display label', () => {
+		expect(BOTTOM_PANEL_TAB_LABELS['issues']).toBe('Issues');
+		expect(BOTTOM_PANEL_TAB_LABELS['kanban']).toBe('Kanban');
 		expect(BOTTOM_PANEL_TAB_LABELS['issue-detail']).toBe('Issue Detail');
 		expect(BOTTOM_PANEL_TAB_LABELS['dependencies']).toBe('Dependencies');
 		expect(BOTTOM_PANEL_TAB_LABELS['activity']).toBe('Activity');
@@ -133,6 +145,8 @@ describe('computeStageCounts', () => {
 
 describe('isBottomPanelTab', () => {
 	it('returns true for valid tab values', () => {
+		expect(isBottomPanelTab('issues')).toBe(true);
+		expect(isBottomPanelTab('kanban')).toBe(true);
 		expect(isBottomPanelTab('issue-detail')).toBe(true);
 		expect(isBottomPanelTab('dependencies')).toBe(true);
 		expect(isBottomPanelTab('activity')).toBe(true);

--- a/src/lib/modules/board/selection.ts
+++ b/src/lib/modules/board/selection.ts
@@ -1,6 +1,8 @@
 // ─── Bottom Panel Tab Constants ──────────────────────────────────────────
 
 export const BOTTOM_PANEL_TABS = {
+	issues: 'issues',
+	kanban: 'kanban',
 	issueDetail: 'issue-detail',
 	dependencies: 'dependencies',
 	activity: 'activity',
@@ -14,6 +16,8 @@ export type BottomPanelTab = (typeof BOTTOM_PANEL_TABS)[keyof typeof BOTTOM_PANE
 export type TabBehavior = 'replace' | 'filter' | 'highlight';
 
 export const TAB_BEHAVIOR_MAP = {
+	issues: 'replace',
+	kanban: 'replace',
 	'issue-detail': 'replace',
 	dependencies: 'highlight',
 	activity: 'filter',
@@ -23,6 +27,8 @@ export const TAB_BEHAVIOR_MAP = {
 // ─── Tab Labels ──────────────────────────────────────────────────────────
 
 export const BOTTOM_PANEL_TAB_LABELS = {
+	issues: 'Issues',
+	kanban: 'Kanban',
 	'issue-detail': 'Issue Detail',
 	dependencies: 'Dependencies',
 	activity: 'Activity',

--- a/src/lib/modules/board/types.ts
+++ b/src/lib/modules/board/types.ts
@@ -46,7 +46,6 @@ export interface AddRepoToPortfolioRequest {
 
 // ─── Frontend-only value types ────────────────────────────────────────────
 
-export type ViewMode = 'list' | 'kanban' | 'forest';
 /** @public */
 export type ThemeMode = 'dark' | 'light' | 'system';
 
@@ -62,10 +61,6 @@ export function isThemeMode(value: unknown): value is ThemeMode {
 
 export function isAccentColor(value: unknown): value is AccentColor {
 	return typeof value === 'string' && ACCENT_COLORS.includes(value as AccentColor);
-}
-
-export function isViewMode(value: unknown): value is ViewMode {
-	return value === 'list' || value === 'kanban' || value === 'forest';
 }
 
 export function findPaletteForDashboard(

--- a/src/lib/modules/visualization/forest_interaction.test.ts
+++ b/src/lib/modules/visualization/forest_interaction.test.ts
@@ -38,8 +38,8 @@ function createParams(overrides: Partial<ResolveGlowOverlayParams> = {}): Resolv
 // ════════════════════════════════════════════════════════════════════════
 
 describe('TREE_CONTEXT_MENU_ACTIONS', () => {
-	it('has exactly 5 entries', () => {
-		expect(Object.keys(TREE_CONTEXT_MENU_ACTIONS)).toHaveLength(5);
+	it('has exactly 6 entries', () => {
+		expect(Object.keys(TREE_CONTEXT_MENU_ACTIONS)).toHaveLength(6);
 	});
 
 	it('contains all expected keys', () => {
@@ -48,6 +48,7 @@ describe('TREE_CONTEXT_MENU_ACTIONS', () => {
 		expect(TREE_CONTEXT_MENU_ACTIONS.startSession).toBe('start-session');
 		expect(TREE_CONTEXT_MENU_ACTIONS.archive).toBe('archive');
 		expect(TREE_CONTEXT_MENU_ACTIONS.changeColor).toBe('change-color');
+		expect(TREE_CONTEXT_MENU_ACTIONS.pruneWorktree).toBe('prune-worktree');
 	});
 
 	it('type can be assigned from constant values', () => {

--- a/src/lib/modules/visualization/forest_layout.ts
+++ b/src/lib/modules/visualization/forest_layout.ts
@@ -69,29 +69,23 @@ function getDepthRow(item: ForestLayoutItem): number {
 
 // ─── Row Placement ──────────────────────────────────────────────────────────
 
-/**
- * Compute the x-position for an item using left-right alternation from a row center.
- * Index 0 -> left (1 unit), index 1 -> right (1 unit),
- * index 2 -> left (2 units), index 3 -> right (2 units), etc.
- */
-function computeAlternatingX(itemIndex: number, rowCenterX: number, treeSpacing: number): number {
-	const spacingUnits = Math.ceil((itemIndex + 1) / 2);
-	const isLeft = itemIndex % 2 === 0;
-	if (isLeft) {
-		return rowCenterX - spacingUnits * treeSpacing;
-	}
-	return rowCenterX + spacingUnits * treeSpacing;
+function computeEquidistantX(
+	itemIndex: number,
+	itemCount: number,
+	viewportWidth: number,
+	rowOffsetX: number,
+): number {
+	return rowOffsetX + (viewportWidth * (itemIndex + 1)) / (itemCount + 1);
 }
 
 function placeRowItems(
 	items: readonly ForestLayoutItem[],
 	depthRow: number,
-	viewportCenterX: number,
 	groundY: number,
-	treeSpacing: number,
+	viewportWidth: number,
 	viewportHeight: number,
 ): PositionedForestItem[] {
-	const rowCenterX = viewportCenterX + depthRow * treeSpacing * ROW_X_OFFSET_FRACTION;
+	const rowOffsetX = depthRow * viewportWidth * TREE_SPACING_FRACTION * ROW_X_OFFSET_FRACTION;
 	const rowY = groundY - depthRow * viewportHeight * ROW_SPACING_Y_FRACTION;
 	const scale = ROW_SCALE_FACTOR ** depthRow;
 	const opacity = ROW_OPACITY_FACTOR ** depthRow;
@@ -99,7 +93,7 @@ function placeRowItems(
 
 	return items.map((item, index) => ({
 		id: item.id,
-		x: computeAlternatingX(index, rowCenterX, treeSpacing),
+		x: computeEquidistantX(index, items.length, viewportWidth, rowOffsetX),
 		y: rowY,
 		scale,
 		opacity,
@@ -184,7 +178,6 @@ export function computeForestLayout(
 	}
 
 	const centerX = viewport.width / 2;
-	const treeSpacing = viewport.width * TREE_SPACING_FRACTION;
 
 	// Separate oak from the rest
 	let oak: ForestLayoutItemOak | null = null;
@@ -244,9 +237,8 @@ export function computeForestLayout(
 		const positioned = placeRowItems(
 			rowItems,
 			depthRow,
-			centerX,
 			groundY,
-			treeSpacing,
+			viewport.width,
 			viewport.height,
 		);
 		allPositioned.push(...positioned);

--- a/src/lib/modules/visualization/types.ts
+++ b/src/lib/modules/visualization/types.ts
@@ -175,6 +175,7 @@ export const TREE_CONTEXT_MENU_ACTIONS = {
 	startSession: 'start-session',
 	archive: 'archive',
 	changeColor: 'change-color',
+	pruneWorktree: 'prune-worktree',
 } as const;
 
 export type TreeContextMenuAction =

--- a/src/lib/modules/visualization/visualization.test.ts
+++ b/src/lib/modules/visualization/visualization.test.ts
@@ -1419,11 +1419,9 @@ describe('computeForestLayout — oak absent', () => {
 
 // ─── Row 0 Left-Right Alternation ────────────────────────────────────────
 
-describe('computeForestLayout — row 0 left-right alternation', () => {
-	it('alternates trees left-right from center — 4 trees + oak', () => {
+describe('computeForestLayout — row 0 equidistant placement', () => {
+	it('distributes 4 trees equidistantly across viewport width', () => {
 		const viewport = createViewport({ width: 1200, height: 800 });
-		const centerX = viewport.width / 2;
-		const treeSpacing = viewport.width * TREE_SPACING_FRACTION;
 
 		const items: ForestLayoutItem[] = [
 			createOak(),
@@ -1434,28 +1432,24 @@ describe('computeForestLayout — row 0 left-right alternation', () => {
 		];
 		const result = computeForestLayout(items, viewport);
 
+		// 4 non-oak trees → equidistant at width*(i+1)/5
 		const t0 = findItem(result.items, 't0');
 		const t1 = findItem(result.items, 't1');
 		const t2 = findItem(result.items, 't2');
 		const t3 = findItem(result.items, 't3');
 
-		// t0 = index 0 → LEFT of center (1 spacing unit)
-		expect(t0.x).toBeCloseTo(centerX - treeSpacing, 0);
-		// t1 = index 1 → RIGHT of center (1 spacing unit)
-		expect(t1.x).toBeCloseTo(centerX + treeSpacing, 0);
-		// t2 = index 2 → LEFT (2 spacing units)
-		expect(t2.x).toBeCloseTo(centerX - 2 * treeSpacing, 0);
-		// t3 = index 3 → RIGHT (2 spacing units)
-		expect(t3.x).toBeCloseTo(centerX + 2 * treeSpacing, 0);
+		expect(t0.x).toBeCloseTo(1200 * (1 / 5), 0);
+		expect(t1.x).toBeCloseTo(1200 * (2 / 5), 0);
+		expect(t2.x).toBeCloseTo(1200 * (3 / 5), 0);
+		expect(t3.x).toBeCloseTo(1200 * (4 / 5), 0);
 	});
 });
 
 // ─── Equidistant Spacing ────────────────────────────────────────────────
 
 describe('computeForestLayout — equidistant spacing', () => {
-	it('all row-0 items have equal horizontal spacing between consecutive positions', () => {
+	it('non-oak row-0 items have equal horizontal spacing between consecutive positions', () => {
 		const viewport = createViewport({ width: 1200, height: 800 });
-		const treeSpacing = viewport.width * TREE_SPACING_FRACTION;
 
 		const items: ForestLayoutItem[] = [
 			createOak(),
@@ -1466,13 +1460,15 @@ describe('computeForestLayout — equidistant spacing', () => {
 		];
 		const result = computeForestLayout(items, viewport);
 
-		// Collect all row-0 x positions (oak + trees), sorted
-		const row0Items = result.items.filter((item) => item.rowIndex === 0);
-		const xValues = row0Items.map((item) => item.x).sort((a, b) => a - b);
+		// Collect non-oak row-0 x positions, sorted
+		const nonOakRow0 = result.items
+			.filter((item) => item.rowIndex === 0 && item.id !== 'oak-1')
+			.sort((a, b) => a.x - b.x);
 
-		// Consecutive x-values should differ by treeSpacing
-		for (let i = 1; i < xValues.length; i++) {
-			expect(xValues[i] - xValues[i - 1]).toBeCloseTo(treeSpacing, 0);
+		// Consecutive positions should have equal spacing: width / (count + 1)
+		const expectedSpacing = viewport.width / (nonOakRow0.length + 1);
+		for (let i = 1; i < nonOakRow0.length; i++) {
+			expect(nonOakRow0[i].x - nonOakRow0[i - 1].x).toBeCloseTo(expectedSpacing, 0);
 		}
 	});
 });
@@ -1480,9 +1476,8 @@ describe('computeForestLayout — equidistant spacing', () => {
 // ─── Priority Sorting Within Row ────────────────────────────────────────
 
 describe('computeForestLayout — priority sorting within row', () => {
-	it('higher priority trees placed closer to center', () => {
+	it('higher priority trees are placed first (leftmost) in equidistant distribution', () => {
 		const viewport = createViewport({ width: 1200, height: 800 });
-		const centerX = viewport.width / 2;
 
 		const items: ForestLayoutItem[] = [
 			createOak(),
@@ -1494,11 +1489,14 @@ describe('computeForestLayout — priority sorting within row', () => {
 		const result = computeForestLayout(items, viewport);
 
 		const topPos = findItem(result.items, 'top');
+		const highPos = findItem(result.items, 'high');
+		const medPos = findItem(result.items, 'med');
 		const lowPos = findItem(result.items, 'low');
 
-		const topDistFromCenter = Math.abs(topPos.x - centerX);
-		const lowDistFromCenter = Math.abs(lowPos.x - centerX);
-		expect(topDistFromCenter).toBeLessThan(lowDistFromCenter);
+		// Priority order: top < high < med < low in x position
+		expect(topPos.x).toBeLessThan(highPos.x);
+		expect(highPos.x).toBeLessThan(medPos.x);
+		expect(medPos.x).toBeLessThan(lowPos.x);
 	});
 });
 
@@ -1542,19 +1540,17 @@ describe('computeForestLayout — back-row perspective row 2', () => {
 // ─── Back-Row X-Offset ─────────────────────────────────────────────────
 
 describe('computeForestLayout — back-row x-offset', () => {
-	it('row 1+ trees have center offset by ROW_X_OFFSET_FRACTION', () => {
+	it('row 1+ trees are offset by ROW_X_OFFSET_FRACTION', () => {
 		const viewport = createViewport({ width: 1200, height: 800 });
-		const centerX = viewport.width / 2;
-		const treeSpacing = viewport.width * TREE_SPACING_FRACTION;
 
-		// Single tree in row 1 — should be at offset center (left alternation first)
+		// Single tree in row 1 — equidistant with 1 item: width*(1)/(1+1) + offset
 		const items: ForestLayoutItem[] = [createOak(), createTree('r1', { depthRow: 1 })];
 		const result = computeForestLayout(items, viewport);
 
 		const r1 = findItem(result.items, 'r1');
-		const expectedRowCenter = centerX + 1 * treeSpacing * ROW_X_OFFSET_FRACTION;
-		// Single item in row goes LEFT of row-center (index 0 → left, 1 unit)
-		expect(r1.x).toBeCloseTo(expectedRowCenter - treeSpacing, 0);
+		const rowOffset = 1 * viewport.width * TREE_SPACING_FRACTION * ROW_X_OFFSET_FRACTION;
+		const expectedX = rowOffset + (viewport.width * 1) / 2;
+		expect(r1.x).toBeCloseTo(expectedX, 0);
 	});
 });
 
@@ -1605,9 +1601,9 @@ describe('computeForestLayout — minimum spacing', () => {
 	it('enforces minimum spacing between all items', () => {
 		const items: ForestLayoutItem[] = [
 			createOak(),
-			...Array.from({ length: 15 }, (_, i) => createTree(`t${i}`)),
+			...Array.from({ length: 8 }, (_, i) => createTree(`t${i}`)),
 		];
-		const viewport = createViewport({ width: 800, height: 600 });
+		const viewport = createViewport({ width: 1200, height: 800 });
 		const result = computeForestLayout(items, viewport);
 
 		for (let i = 0; i < result.items.length; i++) {
@@ -1622,9 +1618,8 @@ describe('computeForestLayout — minimum spacing', () => {
 // ─── Many Items Row 0 ──────────────────────────────────────────────────
 
 describe('computeForestLayout — many items row 0', () => {
-	it('15 trees all depthRow=0 are all positioned alternating left-right', () => {
+	it('15 trees all depthRow=0 are all positioned equidistantly', () => {
 		const viewport = createViewport({ width: 1200, height: 800 });
-		const centerX = viewport.width / 2;
 
 		const items: ForestLayoutItem[] = [
 			createOak(),
@@ -1634,17 +1629,17 @@ describe('computeForestLayout — many items row 0', () => {
 		];
 		const result = computeForestLayout(items, viewport);
 
-		// All 16 items should be positioned
+		// All 16 items should be positioned (15 trees + 1 oak)
 		expect(result.items).toHaveLength(16);
 
-		// Non-oak items should alternate: even-indexed (0,2,4,...) left, odd-indexed (1,3,5,...) right
-		const nonOakItems = result.items.filter((item) => item.id !== 'oak-1');
-		const leftItems = nonOakItems.filter((item) => item.x < centerX);
-		const rightItems = nonOakItems.filter((item) => item.x > centerX);
+		// Non-oak items should be equidistantly distributed
+		const nonOakItems = result.items
+			.filter((item) => item.id !== 'oak-1')
+			.sort((a, b) => a.x - b.x);
 
-		// With 15 trees: 8 left (indices 0,2,4,6,8,10,12,14), 7 right (indices 1,3,5,7,9,11,13)
-		expect(leftItems.length).toBe(8);
-		expect(rightItems.length).toBe(7);
+		expect(nonOakItems).toHaveLength(15);
+		// First item should be at width / 16
+		expect(nonOakItems[0].x).toBeCloseTo(viewport.width / 16, 0);
 	});
 });
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -138,6 +138,9 @@
 				{activeSessionCount}
 				collapsed={boardStore.sidebarCollapsed}
 				onToggleSidebar={() => boardStore.toggleSidebar()}
+				onEditWorkspace={() => {
+					editingDashboard = boardStore.activeDashboard ?? null;
+				}}
 			/>
 
 			<main class="flex min-w-0 flex-1 flex-col overflow-auto">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -15,7 +15,6 @@
 	import OnboardingCard from '$lib/components/OnboardingCard.svelte';
 	import EmptyIssueState from '$lib/components/EmptyIssueState.svelte';
 	import TopBar from '$lib/components/TopBar.svelte';
-	import IssueCardList from '$lib/components/IssueCardList.svelte';
 	import ForestView from '$lib/components/ForestView.svelte';
 	import WorkspaceDashboardLayout from '$lib/components/WorkspaceDashboardLayout.svelte';
 	import WorkspaceBottomPanel from '$lib/components/WorkspaceBottomPanel.svelte';
@@ -23,20 +22,14 @@
 	import type { TreeVisualization } from '$lib/modules/visualization';
 	import IssueCreateDialog from '$lib/components/IssueCreateDialog.svelte';
 	import IssueEditDialog from '$lib/components/IssueEditDialog.svelte';
-	import GhSetupBanner from '$lib/components/GhSetupBanner.svelte';
-	import AssignedIssuesPanel from '$lib/components/AssignedIssuesPanel.svelte';
 	import PruneWorktreesDialog from '$lib/components/PruneWorktreesDialog.svelte';
-	import ScissorsIcon from '@lucide/svelte/icons/scissors';
 	import type { PrunableIssue } from '$lib/types/generated';
-	import { useCommandPalette } from '$lib/modules/command-palette';
-
 	const boardStore = useBoard();
 	const issueStore = useIssues();
 	const versionControlStore = useVersionControl();
 	const actionStore = useActions();
 	const notificationStore = useNotifications();
 	const sessionStore = useSessions();
-	const commandPaletteCtx = useCommandPalette();
 	const selection = useSelection();
 
 	function getNotificationDotColor(issueId: string): string | null {
@@ -60,8 +53,6 @@
 	let prunableIssues = $state<PrunableIssue[]>([]);
 	let pruneRemoving = $state(false);
 
-	// Forest view combines active issues (always) with archived issues when showArchived toggled.
-	// Archived issues render as stumps via tree state engine.
 	const forestIssues = $derived.by(() =>
 		issueStore.showArchived
 			? [...issueStore.activeIssues, ...issueStore.archivedIssues]
@@ -74,7 +65,6 @@
 		return palette?.colors ?? [];
 	});
 
-	// Parse "owner/repo" from dashboard's github_repo field
 	const githubRepoParts = $derived.by(() => {
 		const githubRepo: string | null | undefined = boardStore.activeDashboard?.github_repo;
 		if (githubRepo == null) {
@@ -87,12 +77,10 @@
 		return { owner: parts[0], repo: parts[1] };
 	});
 
-	// Check gh availability on mount
 	onMount(() => {
 		versionControlStore.checkAvailability();
 	});
 
-	// Load issues and version control state when active dashboard changes
 	$effect(() => {
 		const dashboardId = boardStore.activeDashboardId;
 		if (dashboardId === null) {
@@ -284,7 +272,7 @@
 	}
 
 	function handlePageKeydown(event: KeyboardEvent) {
-		if (event.key === 'Escape' && boardStore.viewMode === 'forest') {
+		if (event.key === 'Escape') {
 			selection.deselect();
 		}
 	}
@@ -306,24 +294,12 @@
 	<TopBar
 		title={boardStore.activeDashboard.name}
 		subtitle="{boardStore.activeDashboard.type} · {issueStore.activeIssues.length} issues"
-		controls={['search', 'filter', 'sort', 'sync', 'notifications', 'view', 'plant']}
-		transparent={boardStore.viewMode === 'forest'}
-		viewMode={boardStore.viewMode}
+		forestCollapsed={selection.forestCollapsed}
 		syncing={versionControlStore.syncing}
-		onViewModeChange={(mode) => (boardStore.viewMode = mode)}
 		onSync={githubRepoParts ? handleSyncAll : undefined}
 		onPlant={openCreateDialog}
-		onSearch={() => commandPaletteCtx.toggle()}
-	>
-		<button
-			class="inline-flex items-center gap-1 rounded-md border border-border px-2.5 py-1 text-xs text-muted-foreground transition-colors hover:border-border-strong hover:text-foreground"
-			title={m.topbar_prune_title()}
-			onclick={handleOpenPruneDialog}
-		>
-			<ScissorsIcon size={12} />
-			{m.topbar_prune()}
-		</button>
-	</TopBar>
+		onToggleForest={() => selection.toggleForestCollapsed()}
+	/>
 
 	{#if issueStore.loading}
 		<div class="p-5">
@@ -337,11 +313,7 @@
 		<div class="p-5">
 			<EmptyIssueState onAddIssue={openCreateDialog} />
 		</div>
-	{:else if boardStore.viewMode === 'kanban'}
-		<div class="p-5">
-			<p class="text-muted-foreground">{m.kanban_coming_soon()}</p>
-		</div>
-	{:else if boardStore.viewMode === 'forest'}
+	{:else}
 		<div class="flex-1 overflow-hidden">
 			<WorkspaceDashboardLayout>
 				{#snippet forestPanel()}
@@ -356,48 +328,38 @@
 				{#snippet bottomPanel()}
 					<WorkspaceBottomPanel
 						issues={forestIssues}
+						parentIssues={issueStore.parentIssues}
+						archivedIssues={issueStore.archivedIssues}
+						showArchived={issueStore.showArchived}
+						isPortfolio={boardStore.activeDashboard?.type === 'portfolio'}
+						actions={actionStore.visibleActions}
+						forceExpanded={allExpanded ? true : undefined}
+						cacheMap={versionControlStore.stateMap}
+						ghAvailable={versionControlStore.isGhAvailable}
 						dependencies={issueStore.dependencies}
+						ghSetupBanner={githubRepoParts !== null &&
+							versionControlStore.ghAvailability !== 'available'}
+						ghAvailability={versionControlStore.ghAvailability}
+						assignedIssues={versionControlStore.assignedIssues}
+						isGhAvailable={versionControlStore.isGhAvailable}
 						{getVisualization}
+						getChildren={issueStore.getChildren}
+						{getNotificationDotColor}
+						getProgressLines={(issueId) => issueStore.getProgressLines(issueId)}
+						onArchive={handleArchiveIssue}
+						onUnarchive={handleUnarchiveIssue}
+						onEdit={async (issue) => {
+							await loadUsedColors();
+							editingIssue = issue;
+						}}
+						onDelete={handleDeleteIssue}
+						onSetupWorktree={handleSetupWorktree}
+						onRemoveWorktree={handleRemoveWorktree}
+						onExecuteAction={handleExecuteAction}
+						onPrune={handleOpenPruneDialog}
 					/>
 				{/snippet}
 			</WorkspaceDashboardLayout>
-		</div>
-	{:else}
-		<div class="flex flex-col gap-4 p-5">
-			{#if githubRepoParts && versionControlStore.ghAvailability !== 'available'}
-				<GhSetupBanner availability={versionControlStore.ghAvailability} />
-			{/if}
-
-			<IssueCardList
-				parentIssues={issueStore.parentIssues}
-				archivedIssues={issueStore.archivedIssues}
-				showArchived={issueStore.showArchived}
-				isPortfolio={boardStore.activeDashboard.type === 'portfolio'}
-				actions={actionStore.visibleActions}
-				forceExpanded={allExpanded ? true : undefined}
-				cacheMap={versionControlStore.stateMap}
-				ghAvailable={versionControlStore.isGhAvailable}
-				getChildren={issueStore.getChildren}
-				{getNotificationDotColor}
-				getProgressLines={(issueId) => issueStore.getProgressLines(issueId)}
-				onArchive={handleArchiveIssue}
-				onUnarchive={handleUnarchiveIssue}
-				onEdit={async (issue) => {
-					await loadUsedColors();
-					editingIssue = issue;
-				}}
-				onDelete={handleDeleteIssue}
-				onSetupWorktree={handleSetupWorktree}
-				onRemoveWorktree={handleRemoveWorktree}
-				onExecuteAction={handleExecuteAction}
-			/>
-
-			{#if versionControlStore.assignedIssues.length > 0}
-				<AssignedIssuesPanel
-					issues={versionControlStore.assignedIssues}
-					disabled={versionControlStore.isGhAvailable !== true}
-				/>
-			{/if}
 		</div>
 	{/if}
 


### PR DESCRIPTION
## Summary

Comprehensive UI overhaul aligning the workspace dashboard with requirements architecture:

- **Architecture (A1-A4):** Remove ViewMode switcher — forest is now a persistent collapsible panel, not a view mode. Unify TopBar (remove transparent/overlay mode). Restructure toolbar to Sync | Notifications | Forest Toggle | Plant. Move IssueCardList into bottom panel "Issues" tab with "Kanban" tab stub. Relocate Prune to bottom panel toolbar and forest context menu.
- **Forest rendering (F1-F3):** Increase tree sizes to 320px (matching library demo). Add brown-to-green ground gradient. Switch from alternating left-right placement to equidistant tree spacing.
- **Component fixes (C1-C8):** Tab component inline-flex layout with click feedback. Command palette search padding. Sidebar switchers fill parent width. Surface hover token for light mode. Workspace selector opens edit dialog. Remove UserAvatar false interactivity.

Fixes #137

## Test plan

- [x] All 509 unit tests pass
- [x] `pnpm check:all` passes (format, lint, fallow, typecheck, eslint)
- [x] ViewMode type and isViewMode tests removed
- [x] Bottom panel tab tests updated for issues/kanban entries
- [x] Forest layout tests updated for equidistant spacing
- [x] Context menu action tests updated for prune-worktree
- [ ] Visual: forest panel renders below header, not overlaying
- [ ] Visual: trees render at larger size with ground gradient
- [ ] Visual: tabs show icons beside text (not stacked)
- [ ] Visual: sidebar switchers fill width