### PR TITLE
#132 feat(issues): priority migration and issue lifecycle dialogs

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -83,6 +83,7 @@
 	"issue_placeholder_github_url": "https://github.com/owner/repo/issues/42",
 
 	"priority_none": "None",
+	"priority_lowest": "Lowest",
 	"priority_low": "Low",
 	"priority_medium": "Medium",
 	"priority_high": "High",
@@ -169,6 +170,8 @@
 	"issue_card_archive": "Archive",
 	"issue_card_unarchive": "Unarchive",
 	"issue_card_delete": "Delete",
+	"issue_card_rename": "Rename",
+	"issue_card_priority": "Priority",
 	"issue_card_status": "Status:",
 	"issue_card_worktree_label": "Worktree:",
 	"issue_card_priority_label": "Priority:",
@@ -179,6 +182,19 @@
 	"issue_card_pending_notification": "Pending notification",
 	"issue_card_child_count": "{count} child",
 	"issue_card_children_count": "{count} children",
+
+	"archive_confirm_title": "Archive Issue",
+	"archive_confirm_body": "Are you sure you want to archive \"{name}\"?",
+	"archive_unfinished_sessions": "{count} unfinished session(s)",
+	"archive_open_prs": "{count} open PR(s)",
+	"archive_remove_worktree": "Also remove worktree",
+
+	"delete_confirm_title": "Delete Issue",
+	"delete_confirm_body": "This will permanently delete \"{name}\". This action cannot be undone.",
+	"delete_remove_worktree": "Also remove worktree",
+
+	"rename_title": "Rename Issue",
+	"rename_field_name": "Name",
 
 	"prune_title": "Prune Worktrees",
 	"prune_description": "These issues have merged PRs and closed GitHub issues. Select which worktrees to remove.",

--- a/src-tauri/src/commands/dependency_commands.rs
+++ b/src-tauri/src/commands/dependency_commands.rs
@@ -34,6 +34,7 @@ pub fn get_dependencies_for_dashboard_with_connection(
     Ok(results)
 }
 
+#[cfg(test)]
 pub fn upsert_dependency(
     connection: &Connection,
     blocker_issue_id: &str,

--- a/src-tauri/src/database/migrations.rs
+++ b/src-tauri/src/database/migrations.rs
@@ -2,11 +2,11 @@ use rusqlite::Connection;
 
 use super::schema;
 
-pub(crate) const CURRENT_VERSION: i32 = 1;
+pub(crate) const CURRENT_VERSION: i32 = 2;
 
 type MigrationFunction = fn(&Connection) -> Result<(), rusqlite::Error>;
 
-static MIGRATIONS: &[MigrationFunction] = &[migrate_v1];
+static MIGRATIONS: &[MigrationFunction] = &[migrate_v1, migrate_v2];
 
 fn migrate_v1(connection: &Connection) -> Result<(), rusqlite::Error> {
     schema::create_tables(connection)?;
@@ -39,6 +39,51 @@ fn migrate_v1(connection: &Connection) -> Result<(), rusqlite::Error> {
         "INSERT OR IGNORE INTO app_settings (key, value) VALUES ('startup_behavior', 'overview');",
     )?;
 
+    Ok(())
+}
+
+fn migrate_v2(connection: &Connection) -> Result<(), rusqlite::Error> {
+    // SQLite cannot ALTER CHECK constraints, so we recreate the issues table
+    // with the updated priority constraint that includes 'lowest'.
+    connection.execute_batch("PRAGMA foreign_keys=OFF;")?;
+    connection.execute_batch(
+        "
+        BEGIN;
+
+        CREATE TABLE issues_new (
+            id TEXT PRIMARY KEY,
+            dashboard_id TEXT NOT NULL REFERENCES dashboards(id) ON DELETE CASCADE,
+            name TEXT NOT NULL,
+            priority TEXT CHECK (priority IN ('lowest', 'low', 'medium', 'high', 'top')),
+            color TEXT,
+            status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'archived')),
+            github_issue_url TEXT,
+            github_issue_number INTEGER,
+            branch_name TEXT,
+            base_branch TEXT,
+            worktree_folder TEXT,
+            worktree_state TEXT DEFAULT 'none' CHECK (worktree_state IN ('none', 'pending', 'active', 'failed', 'removing', 'removed')),
+            parent_issue_id TEXT REFERENCES issues_new(id) ON DELETE SET NULL,
+            editor_folder TEXT,
+            dev_server_command TEXT,
+            dev_server_port INTEGER,
+            dev_server_pid INTEGER,
+            browser_url TEXT,
+            labels TEXT,
+            sort_order INTEGER NOT NULL DEFAULT 0,
+            created_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+
+        INSERT INTO issues_new SELECT * FROM issues;
+        DROP TABLE issues;
+        ALTER TABLE issues_new RENAME TO issues;
+
+        CREATE INDEX IF NOT EXISTS idx_issues_dashboard_id ON issues(dashboard_id);
+
+        COMMIT;
+        ",
+    )?;
+    connection.execute_batch("PRAGMA foreign_keys=ON;")?;
     Ok(())
 }
 
@@ -165,6 +210,71 @@ mod tests {
             )
             .unwrap();
         assert_eq!(value, "overview");
+    }
+
+    #[test]
+    fn migration_v2_allows_lowest_priority() {
+        let connection = fresh_db();
+        run_migrations(&connection).unwrap();
+
+        // Create dashboard first (FK requirement)
+        connection
+            .execute(
+                "INSERT INTO dashboards (id, name, type) VALUES ('d1', 'Test', 'repo')",
+                [],
+            )
+            .unwrap();
+
+        // Insert issue with 'lowest' priority — should succeed after migration
+        connection
+            .execute(
+                "INSERT INTO issues (id, dashboard_id, name, priority) VALUES ('i1', 'd1', 'Test Issue', 'lowest')",
+                [],
+            )
+            .unwrap();
+
+        let priority: String = connection
+            .query_row("SELECT priority FROM issues WHERE id = 'i1'", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(priority, "lowest");
+    }
+
+    #[test]
+    fn migration_v2_preserves_existing_issues() {
+        let connection = fresh_db();
+        // Run v1 only
+        migrate_v1(&connection).unwrap();
+        set_schema_version(&connection, 1).unwrap();
+
+        // Create dashboard and issue with old priority
+        connection
+            .execute(
+                "INSERT INTO dashboards (id, name, type) VALUES ('d1', 'Test', 'repo')",
+                [],
+            )
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO issues (id, dashboard_id, name, priority) VALUES ('i1', 'd1', 'Old Issue', 'high')",
+                [],
+            )
+            .unwrap();
+
+        // Now run v2
+        run_migrations(&connection).unwrap();
+
+        // Verify the issue survived
+        let (name, priority): (String, String) = connection
+            .query_row(
+                "SELECT name, priority FROM issues WHERE id = 'i1'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(name, "Old Issue");
+        assert_eq!(priority, "high");
     }
 
     #[test]

--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -28,7 +28,7 @@ pub fn create_tables(connection: &Connection) -> Result<(), rusqlite::Error> {
             id TEXT PRIMARY KEY,
             dashboard_id TEXT NOT NULL REFERENCES dashboards(id) ON DELETE CASCADE,
             name TEXT NOT NULL,
-            priority TEXT CHECK (priority IN ('low', 'medium', 'high', 'top')),
+            priority TEXT CHECK (priority IN ('lowest', 'low', 'medium', 'high', 'top')),
             color TEXT,
             status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'archived')),
             github_issue_url TEXT,

--- a/src/lib/components/ArchiveConfirmDialog.svelte
+++ b/src/lib/components/ArchiveConfirmDialog.svelte
@@ -1,0 +1,89 @@
+<script lang="ts">
+	import * as m from '$lib/paraglide/messages.js';
+	import type { Issue } from '$lib/modules/issues';
+	import * as Dialog from '$lib/components/ui/dialog/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Checkbox } from '$lib/components/ui/checkbox/index.js';
+
+	interface Props {
+		issue: Issue | null;
+		unfinishedSessionCount: number;
+		openPrCount: number;
+		hasActiveWorktree: boolean;
+		onClose: () => void;
+		onConfirm: (removeWorktree: boolean) => void;
+	}
+
+	let {
+		issue,
+		unfinishedSessionCount,
+		openPrCount,
+		hasActiveWorktree,
+		onClose,
+		onConfirm,
+	}: Props = $props();
+
+	let removeWorktree = $state(false);
+	const open = $derived(issue !== null);
+
+	$effect(() => {
+		if (issue !== null) {
+			removeWorktree = false;
+		}
+	});
+
+	function handleOpenChange(isOpen: boolean) {
+		if (!isOpen) {
+			onClose();
+		}
+	}
+</script>
+
+<Dialog.Root {open} onOpenChange={handleOpenChange}>
+	<Dialog.Content class="max-w-sm">
+		{#if issue}
+			<Dialog.Header>
+				<Dialog.Title>{m.archive_confirm_title()}</Dialog.Title>
+				<Dialog.Description>
+					{m.archive_confirm_body({ name: issue.name })}
+				</Dialog.Description>
+			</Dialog.Header>
+
+			<Dialog.Body>
+				{#if unfinishedSessionCount > 0 || openPrCount > 0}
+					<div class="flex flex-col gap-1">
+						{#if unfinishedSessionCount > 0}
+							<p class="text-sm font-medium text-destructive">
+								{m.archive_unfinished_sessions({ count: unfinishedSessionCount })}
+							</p>
+						{/if}
+						{#if openPrCount > 0}
+							<p class="text-sm font-medium text-destructive">
+								{m.archive_open_prs({ count: openPrCount })}
+							</p>
+						{/if}
+					</div>
+				{/if}
+
+				{#if hasActiveWorktree}
+					<label class="mt-3 flex items-center gap-2">
+						<Checkbox
+							checked={removeWorktree}
+							onCheckedChange={(checked) => (removeWorktree = checked === true)}
+						/>
+						<span class="text-sm">{m.archive_remove_worktree()}</span>
+					</label>
+				{/if}
+			</Dialog.Body>
+
+			<Dialog.Footer>
+				<Button variant="ghost" onclick={onClose}>
+					{m.btn_cancel()}
+				</Button>
+				<Button onclick={() => onConfirm(removeWorktree)}>
+					{m.issue_card_archive()}
+				</Button>
+			</Dialog.Footer>
+		{/if}
+	</Dialog.Content>
+</Dialog.Root>

--- a/src/lib/components/DeleteConfirmDialog.svelte
+++ b/src/lib/components/DeleteConfirmDialog.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+	import * as m from '$lib/paraglide/messages.js';
+	import type { Issue } from '$lib/modules/issues';
+	import * as Dialog from '$lib/components/ui/dialog/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Checkbox } from '$lib/components/ui/checkbox/index.js';
+
+	interface Props {
+		issue: Issue | null;
+		hasActiveWorktree: boolean;
+		onClose: () => void;
+		onConfirm: (removeWorktree: boolean) => void;
+	}
+
+	let { issue, hasActiveWorktree, onClose, onConfirm }: Props = $props();
+
+	let removeWorktree = $state(false);
+	const open = $derived(issue !== null);
+
+	$effect(() => {
+		if (issue !== null) {
+			removeWorktree = false;
+		}
+	});
+
+	function handleOpenChange(isOpen: boolean) {
+		if (!isOpen) {
+			onClose();
+		}
+	}
+</script>
+
+<Dialog.Root {open} onOpenChange={handleOpenChange}>
+	<Dialog.Content class="max-w-sm">
+		{#if issue}
+			<Dialog.Header>
+				<Dialog.Title>{m.delete_confirm_title()}</Dialog.Title>
+				<Dialog.Description>
+					{m.delete_confirm_body({ name: issue.name })}
+				</Dialog.Description>
+			</Dialog.Header>
+
+			<Dialog.Body>
+				{#if hasActiveWorktree}
+					<label class="flex items-center gap-2">
+						<Checkbox
+							checked={removeWorktree}
+							onCheckedChange={(checked) => (removeWorktree = checked === true)}
+						/>
+						<span class="text-sm">{m.delete_remove_worktree()}</span>
+					</label>
+				{/if}
+			</Dialog.Body>
+
+			<Dialog.Footer>
+				<Button variant="ghost" onclick={onClose}>
+					{m.btn_cancel()}
+				</Button>
+				<Button variant="danger" onclick={() => onConfirm(removeWorktree)}>
+					{m.btn_confirm_delete()}
+				</Button>
+			</Dialog.Footer>
+		{/if}
+	</Dialog.Content>
+</Dialog.Root>

--- a/src/lib/components/IssueCard.svelte
+++ b/src/lib/components/IssueCard.svelte
@@ -11,6 +11,30 @@
 	import ActionButtonGroup from './ActionButtonGroup.svelte';
 	import { clickOutside } from '$lib/actions/click_outside';
 
+	const PRIORITY_OPTIONS: { value: IssuePriority | null; label: () => string }[] = [
+		{ value: 'top', label: () => m.priority_top() },
+		{ value: 'high', label: () => m.priority_high() },
+		{ value: 'medium', label: () => m.priority_medium() },
+		{ value: 'low', label: () => m.priority_low() },
+		{ value: 'lowest', label: () => m.priority_lowest() },
+		{ value: null, label: () => m.priority_none() },
+	];
+
+	const PRIORITY_BORDER_CLASSES = {
+		top: 'border-l-red-500',
+		high: 'border-l-orange-400',
+		medium: 'border-l-yellow-400',
+		low: 'border-l-blue-400',
+		lowest: 'border-l-gray-400',
+	} as const satisfies Record<IssuePriority, string>;
+
+	const PRIORITY_BADGE_CLASSES: Partial<Record<IssuePriority, string>> = {
+		top: 'bg-red-900/40 text-red-400',
+		high: 'bg-orange-900/40 text-orange-400',
+		low: 'bg-blue-900/40 text-blue-400',
+		lowest: 'bg-gray-800/40 text-gray-400',
+	};
+
 	interface Props extends IssueCardCallbacks {
 		issue: Issue;
 		actions?: Action[];
@@ -39,20 +63,23 @@
 		onUnarchive,
 		onEdit,
 		onDelete,
+		onChangePriority,
+		onRename,
 		onSetupWorktree,
 		onRemoveWorktree,
 		onExecuteAction,
 	}: Props = $props();
 
 	let localExpanded = $state(false);
-	// Auto-expand when worktree is being set up so progress is visible
 	const expanded = $derived(
 		forceExpanded ?? (issue.worktree_state === 'pending' || localExpanded),
 	);
 	let showOverflow = $state(false);
+	let showPrioritySubmenu = $state(false);
 
 	const color = $derived(issue.color ?? '#525252');
 	const isArchived = $derived(issue.status === 'archived');
+	const isStandalone = $derived(issue.github_issue_url === null);
 
 	const worktreeBadge = $derived.by(() => {
 		switch (issue.worktree_state) {
@@ -70,16 +97,18 @@
 		}
 	});
 
-	const PRIORITY_BORDER_CLASSES = {
-		top: 'border-l-red-500',
-		high: 'border-l-orange-400',
-		medium: 'border-l-yellow-400',
-		low: 'border-l-blue-400',
-	} as const satisfies Record<IssuePriority, string>;
-
 	const priorityBorderClass = $derived(
 		issue.priority !== null ? PRIORITY_BORDER_CLASSES[issue.priority] : 'border-l-transparent',
 	);
+
+	const priorityBadgeClass = $derived(
+		issue.priority !== null ? (PRIORITY_BADGE_CLASSES[issue.priority] ?? null) : null,
+	);
+
+	function closeOverflow() {
+		showOverflow = false;
+		showPrioritySubmenu = false;
+	}
 </script>
 
 <div
@@ -89,7 +118,6 @@
 	style={isArchived ? 'filter: grayscale(0.8) opacity(0.7)' : undefined}
 	class:ml-6={indented}
 >
-	<!-- Tree connector for nested children -->
 	{#if indented}
 		<div class="relative -ml-6 w-6 shrink-0">
 			<div
@@ -100,7 +128,6 @@
 		</div>
 	{/if}
 
-	<!-- Color identity strip -->
 	<div class="w-10 shrink-0 rounded-l" style="background-color: {color}">
 		<div class="flex h-full items-start justify-center pt-3">
 			{#if notificationDotColor}
@@ -117,9 +144,7 @@
 		</div>
 	</div>
 
-	<!-- Content area -->
 	<div class="flex min-w-0 flex-1 flex-col">
-		<!-- Header -->
 		<div class="flex items-center gap-2 px-3 py-2">
 			<button
 				onclick={() => (localExpanded = !localExpanded)}
@@ -132,7 +157,16 @@
 			</button>
 
 			<div class="min-w-0 flex-1">
-				<span class="truncate text-sm font-medium">{issue.name}</span>
+				<div class="flex items-center gap-1.5">
+					<span class="truncate text-sm font-medium">{issue.name}</span>
+					{#if priorityBadgeClass}
+						<span
+							class="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium leading-3 {priorityBadgeClass}"
+						>
+							{issue.priority}
+						</span>
+					{/if}
+				</div>
 				{#if issue.labels.length > 0}
 					<div class="mt-0.5 flex flex-wrap gap-1">
 						{#each issue.labels as label (label.name)}
@@ -148,7 +182,6 @@
 				{/if}
 			</div>
 
-			<!-- Child count for parent issues -->
 			{#if childCount > 0}
 				<span class="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
 					{childCount > 1
@@ -157,7 +190,6 @@
 				</span>
 			{/if}
 
-			<!-- GitHub & git badges -->
 			<div class="flex items-center gap-1">
 				{#if cache?.github_issue_state}
 					<GitHubIssueBadge
@@ -196,7 +228,6 @@
 				{/if}
 			</div>
 
-			<!-- Action buttons -->
 			{#if actions.length > 0 && onExecuteAction && !isArchived}
 				<div class="opacity-0 transition-opacity group-hover:opacity-100">
 					<ActionButtonGroup
@@ -218,22 +249,67 @@
 				{#if showOverflow}
 					<div
 						class="absolute right-0 z-[var(--z-dropdown)] mt-1 min-w-35 rounded border border-border bg-popover py-1 shadow-lg"
-						use:clickOutside={() => (showOverflow = false)}
+						use:clickOutside={closeOverflow}
 					>
 						<button
 							onclick={() => {
 								onEdit(issue);
-								showOverflow = false;
+								closeOverflow();
 							}}
 							class="w-full px-3 py-1.5 text-left text-sm text-popover-foreground hover:bg-accent"
 						>
 							{m.issue_card_edit()}
 						</button>
+						{#if isStandalone && onRename}
+							<button
+								onclick={() => {
+									onRename(issue);
+									closeOverflow();
+								}}
+								class="w-full px-3 py-1.5 text-left text-sm text-popover-foreground hover:bg-accent"
+							>
+								{m.issue_card_rename()}
+							</button>
+						{/if}
+
+						<!-- Priority submenu -->
+						{#if !isArchived}
+							<div class="relative">
+								<button
+									onclick={() => (showPrioritySubmenu = !showPrioritySubmenu)}
+									class="flex w-full items-center justify-between px-3 py-1.5 text-left text-sm text-popover-foreground hover:bg-accent"
+								>
+									{m.issue_card_priority()}
+									<span class="text-xs text-muted-foreground">▸</span>
+								</button>
+								{#if showPrioritySubmenu}
+									<div
+										class="absolute top-0 left-full z-[var(--z-dropdown)] ml-1 min-w-28 rounded border border-border bg-popover py-1 shadow-lg"
+									>
+										{#each PRIORITY_OPTIONS as option (option.value)}
+											<button
+												onclick={() => {
+													onChangePriority(issue.id, option.value);
+													closeOverflow();
+												}}
+												class="w-full px-3 py-1.5 text-left text-sm hover:bg-accent {issue.priority ===
+												option.value
+													? 'text-foreground font-medium'
+													: 'text-popover-foreground'}"
+											>
+												{option.label()}
+											</button>
+										{/each}
+									</div>
+								{/if}
+							</div>
+						{/if}
+
 						{#if onSetupWorktree && issue.branch_name !== null && (issue.worktree_state === 'none' || issue.worktree_state === 'failed')}
 							<button
 								onclick={() => {
 									onSetupWorktree(issue);
-									showOverflow = false;
+									closeOverflow();
 								}}
 								class="w-full px-3 py-1.5 text-left text-sm text-green-400 hover:bg-accent"
 							>
@@ -246,7 +322,7 @@
 							<button
 								onclick={() => {
 									onRemoveWorktree(issue);
-									showOverflow = false;
+									closeOverflow();
 								}}
 								class="w-full px-3 py-1.5 text-left text-sm text-orange-400 hover:bg-accent"
 							>
@@ -257,7 +333,7 @@
 							<button
 								onclick={() => {
 									onUnarchive(issue.id);
-									showOverflow = false;
+									closeOverflow();
 								}}
 								class="w-full px-3 py-1.5 text-left text-sm text-popover-foreground hover:bg-accent"
 							>
@@ -266,8 +342,8 @@
 						{:else}
 							<button
 								onclick={() => {
-									onArchive(issue.id);
-									showOverflow = false;
+									onArchive(issue);
+									closeOverflow();
 								}}
 								class="w-full px-3 py-1.5 text-left text-sm text-popover-foreground hover:bg-accent"
 							>
@@ -276,8 +352,8 @@
 						{/if}
 						<button
 							onclick={() => {
-								onDelete(issue.id);
-								showOverflow = false;
+								onDelete(issue);
+								closeOverflow();
 							}}
 							class="w-full px-3 py-1.5 text-left text-sm text-destructive hover:bg-accent"
 						>
@@ -288,7 +364,6 @@
 			</div>
 		</div>
 
-		<!-- Expanded section -->
 		{#if expanded}
 			<div class="border-t border-border px-3 py-3 text-xs text-muted-foreground">
 				<div class="grid grid-cols-2 gap-2">

--- a/src/lib/components/IssueCardList.svelte
+++ b/src/lib/components/IssueCardList.svelte
@@ -34,6 +34,8 @@
 		onUnarchive,
 		onEdit,
 		onDelete,
+		onChangePriority,
+		onRename,
 		onSetupWorktree,
 		onRemoveWorktree,
 		onExecuteAction,
@@ -57,12 +59,13 @@
 			{onUnarchive}
 			{onEdit}
 			{onDelete}
+			{onChangePriority}
+			{onRename}
 			{onSetupWorktree}
 			{onRemoveWorktree}
 			{onExecuteAction}
 		/>
 
-		<!-- Nested children for portfolio dashboards -->
 		{#if isPortfolio && children.length > 0}
 			{#each children as child, index (child.id)}
 				<IssueCard
@@ -79,6 +82,8 @@
 					{onUnarchive}
 					{onEdit}
 					{onDelete}
+					{onChangePriority}
+					{onRename}
 					{onSetupWorktree}
 					{onRemoveWorktree}
 					{onExecuteAction}
@@ -87,7 +92,6 @@
 		{/if}
 	{/each}
 
-	<!-- Archived section -->
 	{#if showArchived && archivedIssues.length > 0}
 		<div class="mt-4 border-t border-border pt-4">
 			<h3
@@ -105,6 +109,7 @@
 						{onUnarchive}
 						{onEdit}
 						{onDelete}
+						{onChangePriority}
 					/>
 				{/each}
 			</div>

--- a/src/lib/components/IssueCreateDialog.svelte
+++ b/src/lib/components/IssueCreateDialog.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
-	import type { CreateIssueRequest } from '$lib/modules/issues';
+	import type { CreateIssueRequest, IssuePriority } from '$lib/modules/issues';
 	import * as Dialog from '$lib/components/ui/dialog/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
@@ -32,7 +32,7 @@
 	}: Props = $props();
 
 	let name = $state('');
-	let priority = $state<'low' | 'medium' | 'high' | 'top' | ''>('');
+	let priority = $state<IssuePriority | ''>('');
 	let color = $state('');
 	let githubIssueUrl = $state('');
 
@@ -94,6 +94,7 @@
 					<Label for="issue-priority">{m.issue_field_priority()}</Label>
 					<Select id="issue-priority" bind:value={priority}>
 						<option value="">{m.priority_none()}</option>
+						<option value="lowest">{m.priority_lowest()}</option>
 						<option value="low">{m.priority_low()}</option>
 						<option value="medium">{m.priority_medium()}</option>
 						<option value="high">{m.priority_high()}</option>

--- a/src/lib/components/IssueEditDialog.svelte
+++ b/src/lib/components/IssueEditDialog.svelte
@@ -91,6 +91,7 @@
 						<Label for="edit-issue-priority">{m.issue_field_priority()}</Label>
 						<Select id="edit-issue-priority" bind:value={priority}>
 							<option value="">{m.priority_none()}</option>
+							<option value="lowest">{m.priority_lowest()}</option>
 							<option value="low">{m.priority_low()}</option>
 							<option value="medium">{m.priority_medium()}</option>
 							<option value="high">{m.priority_high()}</option>

--- a/src/lib/components/IssueRenameDialog.svelte
+++ b/src/lib/components/IssueRenameDialog.svelte
@@ -1,0 +1,69 @@
+<script lang="ts">
+	import * as m from '$lib/paraglide/messages.js';
+	import type { Issue } from '$lib/modules/issues';
+	import * as Dialog from '$lib/components/ui/dialog/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+
+	interface Props {
+		issue: Issue | null;
+		onClose: () => void;
+		onRename: (id: string, name: string) => void;
+	}
+
+	let { issue, onClose, onRename }: Props = $props();
+
+	let name = $state('');
+	const open = $derived(issue !== null);
+
+	$effect(() => {
+		if (issue !== null) {
+			name = issue.name;
+		}
+	});
+
+	function handleSubmit(event: SubmitEvent) {
+		event.preventDefault();
+		const trimmed = name.trim();
+		if (issue === null || !trimmed) {
+			return;
+		}
+		onRename(issue.id, trimmed);
+		onClose();
+	}
+
+	function handleOpenChange(isOpen: boolean) {
+		if (!isOpen) {
+			onClose();
+		}
+	}
+</script>
+
+<Dialog.Root {open} onOpenChange={handleOpenChange}>
+	<Dialog.Content class="max-w-sm">
+		{#if issue}
+			<form onsubmit={handleSubmit} class="flex flex-col gap-4">
+				<Dialog.Header>
+					<Dialog.Title>{m.rename_title()}</Dialog.Title>
+				</Dialog.Header>
+
+				<Dialog.Body>
+					<div class="flex flex-col gap-1.5">
+						<Label for="rename-name">{m.rename_field_name()}</Label>
+						<Input id="rename-name" bind:value={name} required />
+					</div>
+				</Dialog.Body>
+
+				<Dialog.Footer>
+					<Button variant="ghost" type="button" onclick={onClose}>
+						{m.btn_cancel()}
+					</Button>
+					<Button type="submit">
+						{m.btn_save()}
+					</Button>
+				</Dialog.Footer>
+			</form>
+		{/if}
+	</Dialog.Content>
+</Dialog.Root>

--- a/src/lib/components/dialog_helpers.test.ts
+++ b/src/lib/components/dialog_helpers.test.ts
@@ -54,6 +54,11 @@ describe('buildCreateIssueRequest', () => {
 		expect(result?.github_issue_number).toBe(7);
 	});
 
+	it('includes lowest priority when provided', () => {
+		const result = buildCreateIssueRequest('dash-1', 'Fix bug', '#ff0000', 'lowest', '');
+		expect(result?.priority).toBe('lowest');
+	});
+
 	it('returns null for empty name', () => {
 		expect(buildCreateIssueRequest('dash-1', '  ', '#ff0000', '', '')).toBeNull();
 	});

--- a/src/lib/modules/issues/index.ts
+++ b/src/lib/modules/issues/index.ts
@@ -1,4 +1,5 @@
 export { setIssuesContext, useIssues } from './issues.context.svelte.js';
+export { PRIORITY_ORDER, PRIORITY_ORDER_NONE, priorityRank } from './priority.js';
 export type {
 	WorktreeState,
 	SortMode,

--- a/src/lib/modules/issues/issues.context.svelte.ts
+++ b/src/lib/modules/issues/issues.context.svelte.ts
@@ -17,6 +17,7 @@ import type {
 	SetupWorktreeRequest,
 	RemoveWorktreeRequest,
 } from './types.js';
+import { PRIORITY_ORDER, PRIORITY_ORDER_NONE } from './priority.js';
 import { serializeLabels, toIssue } from './serialization.js';
 
 // ─── Context ───────────────────────────────────────────────────────────────
@@ -45,16 +46,14 @@ function createIssuesContext() {
 	let currentDashboardId = $state<string | null>(null);
 	const worktreeProgress = new SvelteMap<string, string[]>();
 
-	const priorityOrder: Record<string, number> = { top: 0, high: 1, medium: 2, low: 3 };
-
 	const sortedIssues = $derived.by(() => {
 		const list = [...issues];
 		switch (sortMode) {
 			case 'priority':
 				return list.sort(
 					(a, b) =>
-						(priorityOrder[a.priority ?? 'low'] ?? 4) -
-						(priorityOrder[b.priority ?? 'low'] ?? 4),
+						(a.priority !== null ? PRIORITY_ORDER[a.priority] : PRIORITY_ORDER_NONE) -
+						(b.priority !== null ? PRIORITY_ORDER[b.priority] : PRIORITY_ORDER_NONE),
 				);
 			case 'name':
 				return list.sort((a, b) => a.name.localeCompare(b.name));

--- a/src/lib/modules/issues/priority.test.ts
+++ b/src/lib/modules/issues/priority.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { PRIORITY_ORDER } from './priority.js';
+
+describe('priorityOrder', () => {
+	it('covers all 5 priority levels', () => {
+		expect(Object.keys(PRIORITY_ORDER)).toHaveLength(5);
+		expect(PRIORITY_ORDER).toHaveProperty('lowest');
+		expect(PRIORITY_ORDER).toHaveProperty('low');
+		expect(PRIORITY_ORDER).toHaveProperty('medium');
+		expect(PRIORITY_ORDER).toHaveProperty('high');
+		expect(PRIORITY_ORDER).toHaveProperty('top');
+	});
+
+	it('assigns lower order values to higher priorities (top > high > medium > low > lowest)', () => {
+		expect(PRIORITY_ORDER.top).toBeLessThan(PRIORITY_ORDER.high);
+		expect(PRIORITY_ORDER.high).toBeLessThan(PRIORITY_ORDER.medium);
+		expect(PRIORITY_ORDER.medium).toBeLessThan(PRIORITY_ORDER.low);
+		expect(PRIORITY_ORDER.low).toBeLessThan(PRIORITY_ORDER.lowest);
+	});
+});

--- a/src/lib/modules/issues/priority.ts
+++ b/src/lib/modules/issues/priority.ts
@@ -1,0 +1,15 @@
+import type { IssuePriority } from './types.js';
+
+export const PRIORITY_ORDER = {
+	top: 0,
+	high: 1,
+	medium: 2,
+	low: 3,
+	lowest: 4,
+} as const satisfies Record<IssuePriority, number>;
+
+export const PRIORITY_ORDER_NONE = 5;
+
+export function priorityRank(priority: IssuePriority | null): number {
+	return priority !== null ? PRIORITY_ORDER[priority] : PRIORITY_ORDER_NONE;
+}

--- a/src/lib/modules/issues/types.ts
+++ b/src/lib/modules/issues/types.ts
@@ -5,7 +5,7 @@ export type WorktreeState = 'none' | 'pending' | 'active' | 'failed' | 'removing
 export type SortMode = 'priority' | 'name' | 'date';
 
 /** @public */
-export type IssuePriority = 'low' | 'medium' | 'high' | 'top';
+export type IssuePriority = 'lowest' | 'low' | 'medium' | 'high' | 'top';
 
 /** @public */
 export type IssueStatus = 'active' | 'archived';
@@ -30,7 +30,7 @@ export interface Issue extends Omit<
 export interface CreateIssueRequest {
 	dashboard_id: string;
 	name: string;
-	priority?: 'low' | 'medium' | 'high' | 'top' | null;
+	priority?: IssuePriority | null;
 	color?: string | null;
 	github_issue_url?: string | null;
 	github_issue_number?: number | null;
@@ -41,7 +41,7 @@ export interface CreateIssueRequest {
 export interface UpdateIssueRequest {
 	id: string;
 	name?: string;
-	priority?: 'low' | 'medium' | 'high' | 'top' | null;
+	priority?: IssuePriority | null;
 	color?: string | null;
 	github_issue_url?: string | null;
 	github_issue_number?: number | null;
@@ -71,10 +71,12 @@ export interface RemoveWorktreeRequest {
 }
 
 export interface IssueCardCallbacks {
-	onArchive: (id: string) => void;
+	onArchive: (issue: Issue) => void;
 	onUnarchive: (id: string) => void;
 	onEdit: (issue: Issue) => void;
-	onDelete: (id: string) => void;
+	onDelete: (issue: Issue) => void;
+	onChangePriority: (id: string, priority: IssuePriority | null) => void;
+	onRename?: (issue: Issue) => void;
 	onSetupWorktree?: (issue: Issue) => void;
 	onRemoveWorktree?: (issue: Issue) => void;
 	onExecuteAction?: (actionId: string, issueId: string) => void;

--- a/src/lib/modules/visualization/forest_layout.ts
+++ b/src/lib/modules/visualization/forest_layout.ts
@@ -15,6 +15,7 @@ import {
 	ROW_X_OFFSET_FRACTION,
 	GROUND_Y_FRACTION,
 } from './constants.js';
+import { priorityRank } from '$lib/modules/issues/priority.js';
 
 // ─── Constants ──────────────────────────────────────────────────────────────
 
@@ -22,27 +23,6 @@ const Z_OAK = 100;
 const Z_ROW_BASE = 50;
 const Z_ROW_STEP = 5;
 const MAX_RELAXATION_PASSES = 10;
-
-// ─── Internal Types ─────────────────────────────────────────────────────────
-
-type IssuePriority = ForestLayoutItem['priority'];
-
-// ─── Priority Sorting ───────────────────────────────────────────────────────
-
-function priorityRank(priority: IssuePriority): number {
-	switch (priority) {
-		case 'top':
-			return 0;
-		case 'high':
-			return 1;
-		case 'medium':
-			return 2;
-		case 'low':
-			return 3;
-		case null:
-			return 4;
-	}
-}
 
 function sortByPriorityThenOrder(items: readonly ForestLayoutItem[]): ForestLayoutItem[] {
 	return [...items].sort((a, b) => {

--- a/src/lib/modules/visualization/types.ts
+++ b/src/lib/modules/visualization/types.ts
@@ -7,7 +7,7 @@ import type {
 	TreeStage,
 } from 'low-poly-2d-trees';
 import type { ExecutionPhase, SessionState } from '$lib/types/generated';
-import type { WorktreeState } from '$lib/modules/issues/index.js';
+import type { WorktreeState, IssuePriority } from '$lib/modules/issues/index.js';
 
 // ─── GitHub Label -> Tree Shape Mapping ─────────────────────────────────────
 
@@ -114,8 +114,6 @@ export interface SessionForMapping {
 
 // ─── Forest Layout Types ─────────────────────────────────────────────────────
 
-type IssuePriority = 'low' | 'medium' | 'high' | 'top' | null;
-
 export interface Viewport {
 	readonly width: number;
 	readonly height: number;
@@ -124,7 +122,7 @@ export interface Viewport {
 export interface ForestLayoutItemOak {
 	readonly id: string;
 	readonly kind: 'oak';
-	readonly priority: IssuePriority;
+	readonly priority: IssuePriority | null;
 	readonly sortOrder: number;
 }
 
@@ -132,7 +130,7 @@ export interface ForestLayoutItemTree {
 	readonly id: string;
 	readonly kind: 'tree';
 	readonly stage: TreeStage;
-	readonly priority: IssuePriority;
+	readonly priority: IssuePriority | null;
 	readonly sortOrder: number;
 	readonly depthRow: number;
 }
@@ -141,7 +139,7 @@ export interface ForestLayoutItemPottedPlant {
 	readonly id: string;
 	readonly kind: 'potted-plant';
 	readonly stage: PottedPlantStage;
-	readonly priority: IssuePriority;
+	readonly priority: IssuePriority | null;
 	readonly sortOrder: number;
 	readonly depthRow: number;
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -11,7 +11,12 @@
 		findNotificationDotColor,
 	} from '$lib/modules/notifications';
 	import { useSessions } from '$lib/modules/sessions';
-	import type { Issue, CreateIssueRequest, UpdateIssueRequest } from '$lib/modules/issues';
+	import type {
+		Issue,
+		IssuePriority,
+		CreateIssueRequest,
+		UpdateIssueRequest,
+	} from '$lib/modules/issues';
 	import OnboardingCard from '$lib/components/OnboardingCard.svelte';
 	import EmptyIssueState from '$lib/components/EmptyIssueState.svelte';
 	import TopBar from '$lib/components/TopBar.svelte';
@@ -23,6 +28,9 @@
 	import type { TreeVisualization } from '$lib/modules/visualization';
 	import IssueCreateDialog from '$lib/components/IssueCreateDialog.svelte';
 	import IssueEditDialog from '$lib/components/IssueEditDialog.svelte';
+	import ArchiveConfirmDialog from '$lib/components/ArchiveConfirmDialog.svelte';
+	import DeleteConfirmDialog from '$lib/components/DeleteConfirmDialog.svelte';
+	import IssueRenameDialog from '$lib/components/IssueRenameDialog.svelte';
 	import GhSetupBanner from '$lib/components/GhSetupBanner.svelte';
 	import AssignedIssuesPanel from '$lib/components/AssignedIssuesPanel.svelte';
 	import PruneWorktreesDialog from '$lib/components/PruneWorktreesDialog.svelte';
@@ -60,8 +68,33 @@
 	let prunableIssues = $state<PrunableIssue[]>([]);
 	let pruneRemoving = $state(false);
 
-	// Forest view combines active issues (always) with archived issues when showArchived toggled.
-	// Archived issues render as stumps via tree state engine.
+	let archiveTargetIssue = $state<Issue | null>(null);
+	let deleteTargetIssue = $state<Issue | null>(null);
+	let renameTargetIssue = $state<Issue | null>(null);
+
+	const archiveUnfinishedSessionCount = $derived.by(() => {
+		if (archiveTargetIssue === null) {
+			return 0;
+		}
+		const sessions = sessionStore.sessionsByIssueId.get(archiveTargetIssue.id);
+		if (sessions === undefined) {
+			return 0;
+		}
+		return sessions.filter((s) => s.state !== 'finished' && s.state !== 'errored').length;
+	});
+
+	const archiveOpenPrCount = $derived.by(() => {
+		if (archiveTargetIssue === null) {
+			return 0;
+		}
+		const gitState = versionControlStore.getState(archiveTargetIssue.id);
+		if (gitState?.pr_state == null) {
+			return 0;
+		}
+		const closedStates = ['merged', 'closed'];
+		return closedStates.includes(gitState.pr_state) ? 0 : 1;
+	});
+
 	const forestIssues = $derived.by(() =>
 		issueStore.showArchived
 			? [...issueStore.activeIssues, ...issueStore.archivedIssues]
@@ -74,7 +107,6 @@
 		return palette?.colors ?? [];
 	});
 
-	// Parse "owner/repo" from dashboard's github_repo field
 	const githubRepoParts = $derived.by(() => {
 		const githubRepo: string | null | undefined = boardStore.activeDashboard?.github_repo;
 		if (githubRepo == null) {
@@ -87,12 +119,10 @@
 		return { owner: parts[0], repo: parts[1] };
 	});
 
-	// Check gh availability on mount
 	onMount(() => {
 		versionControlStore.checkAvailability();
 	});
 
-	// Load issues and version control state when active dashboard changes
 	$effect(() => {
 		const dashboardId = boardStore.activeDashboardId;
 		if (dashboardId === null) {
@@ -163,10 +193,6 @@
 		await handleAction('create issue', () => issueStore.addIssue(request));
 	}
 
-	async function handleArchiveIssue(id: string) {
-		await handleAction('archive issue', () => issueStore.archiveIssue(id));
-	}
-
 	async function handleUnarchiveIssue(id: string) {
 		await handleAction('unarchive issue', () => issueStore.unarchiveIssue(id));
 	}
@@ -175,8 +201,55 @@
 		await handleAction('update issue', () => issueStore.updateIssue(request));
 	}
 
-	async function handleDeleteIssue(id: string) {
-		await handleAction('delete issue', () => issueStore.removeIssue(id));
+	async function handleChangePriority(id: string, priority: IssuePriority | null) {
+		await handleAction('change priority', () => issueStore.updateIssue({ id, priority }));
+	}
+
+	async function handleArchiveConfirm(removeWorktree: boolean) {
+		const issue = archiveTargetIssue;
+		if (issue === null) {
+			return;
+		}
+		archiveTargetIssue = null;
+
+		if (removeWorktree) {
+			await handleRemoveWorktreeForIssue(issue);
+		}
+		await handleAction('archive issue', () => issueStore.archiveIssue(issue.id));
+	}
+
+	async function handleDeleteConfirm(removeWorktree: boolean) {
+		const issue = deleteTargetIssue;
+		if (issue === null) {
+			return;
+		}
+		deleteTargetIssue = null;
+
+		if (removeWorktree) {
+			await handleRemoveWorktreeForIssue(issue);
+		}
+		await handleAction('delete issue', () => issueStore.removeIssue(issue.id));
+	}
+
+	async function handleRename(id: string, name: string) {
+		await handleAction('rename issue', () => issueStore.updateIssue({ id, name }));
+	}
+
+	async function handleRemoveWorktreeForIssue(issue: Issue) {
+		const dashboard = boardStore.activeDashboard;
+		if (dashboard?.local_folder == null || issue.branch_name == null) {
+			return;
+		}
+		await handleAction(
+			'remove worktree',
+			() =>
+				issueStore.removeWorktree({
+					issue_id: issue.id,
+					branch_name: issue.branch_name!,
+					working_directory: dashboard.local_folder!,
+				}),
+			false,
+		);
 	}
 
 	async function handleSetupWorktree(issue: Issue) {
@@ -380,13 +453,15 @@
 				getChildren={issueStore.getChildren}
 				{getNotificationDotColor}
 				getProgressLines={(issueId) => issueStore.getProgressLines(issueId)}
-				onArchive={handleArchiveIssue}
+				onArchive={(issue) => (archiveTargetIssue = issue)}
 				onUnarchive={handleUnarchiveIssue}
 				onEdit={async (issue) => {
 					await loadUsedColors();
 					editingIssue = issue;
 				}}
-				onDelete={handleDeleteIssue}
+				onDelete={(issue) => (deleteTargetIssue = issue)}
+				onChangePriority={handleChangePriority}
+				onRename={(issue) => (renameTargetIssue = issue)}
 				onSetupWorktree={handleSetupWorktree}
 				onRemoveWorktree={handleRemoveWorktree}
 				onExecuteAction={handleExecuteAction}
@@ -419,6 +494,28 @@
 		isDarkMode={boardStore.theme.isDark}
 		onClose={() => (editingIssue = null)}
 		onUpdate={handleUpdateIssue}
+	/>
+
+	<ArchiveConfirmDialog
+		issue={archiveTargetIssue}
+		unfinishedSessionCount={archiveUnfinishedSessionCount}
+		openPrCount={archiveOpenPrCount}
+		hasActiveWorktree={archiveTargetIssue?.worktree_state === 'active'}
+		onClose={() => (archiveTargetIssue = null)}
+		onConfirm={handleArchiveConfirm}
+	/>
+
+	<DeleteConfirmDialog
+		issue={deleteTargetIssue}
+		hasActiveWorktree={deleteTargetIssue?.worktree_state === 'active'}
+		onClose={() => (deleteTargetIssue = null)}
+		onConfirm={handleDeleteConfirm}
+	/>
+
+	<IssueRenameDialog
+		issue={renameTargetIssue}
+		onClose={() => (renameTargetIssue = null)}
+		onRename={handleRename}
 	/>
 
 	<PruneWorktreesDialog


### PR DESCRIPTION
## Description
- Adds 5th priority level ('lowest') with 5-level CHECK constraint in DB migration v2
- Archive confirmation dialog showing unfinished session/PR count in red
- Delete confirmation dialog with optional worktree removal checkbox
- Priority change submenu in issue card overflow menu
- Standalone issue rename dialog (hidden for GitHub-linked issues)
- Priority badge on issue cards (hidden for medium, visible for others)
- Shared PRIORITY_ORDER constant and IssuePriority type updates
- Wires all new callbacks through IssueCardList into +page.svelte

## Resolves
Closes #132

## Testing
- Unit tests for priority order and constants
- Dialog integration with issue card callbacks
- DB migration validation against 5-level constraint