### PR TITLE
#136 feat(requirements): quick ideas capture modal

### DIFF
--- a/messages/cs.json
+++ b/messages/cs.json
@@ -269,5 +269,15 @@
 	"settings_user_title": "User Profile",
 	"settings_user_description": "Set your display name and initials.",
 	"settings_username_label": "Display Name",
-	"settings_initials_label": "Initials"
+	"settings_initials_label": "Initials",
+
+	"raw_requirements_title": "Rychlé nápady",
+	"raw_requirements_placeholder": "Zachyťte nový nápad nebo požadavek…",
+	"raw_requirements_save": "Uložit",
+	"raw_requirements_edit": "Upravit",
+	"raw_requirements_cancel_edit": "Zrušit",
+	"raw_requirements_save_edit": "Uložit",
+	"raw_requirements_process": "Zpracovat požadavky",
+	"raw_requirements_empty": "Zatím žádné nápady. Začněte psát níže.",
+	"raw_requirements_processed": "zpracováno"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -269,5 +269,15 @@
 	"settings_user_title": "User Profile",
 	"settings_user_description": "Set your display name and initials.",
 	"settings_username_label": "Display Name",
-	"settings_initials_label": "Initials"
+	"settings_initials_label": "Initials",
+
+	"raw_requirements_title": "Quick Ideas",
+	"raw_requirements_placeholder": "Capture a new idea or requirement…",
+	"raw_requirements_save": "Save",
+	"raw_requirements_edit": "Edit",
+	"raw_requirements_cancel_edit": "Cancel",
+	"raw_requirements_save_edit": "Save",
+	"raw_requirements_process": "Process Requirements",
+	"raw_requirements_empty": "No ideas captured yet. Start typing below.",
+	"raw_requirements_processed": "processed"
 }

--- a/src-tauri/src/commands/dependency_commands.rs
+++ b/src-tauri/src/commands/dependency_commands.rs
@@ -34,6 +34,7 @@ pub fn get_dependencies_for_dashboard_with_connection(
     Ok(results)
 }
 
+#[cfg(test)]
 pub fn upsert_dependency(
     connection: &Connection,
     blocker_issue_id: &str,

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -9,6 +9,7 @@ pub mod keyboard_shortcut_commands;
 pub mod label_shape_mapping_commands;
 pub mod notification_commands;
 pub mod portfolio_commands;
+pub mod raw_requirements_commands;
 pub mod seed_commands;
 pub mod session_commands;
 pub mod shared;

--- a/src-tauri/src/commands/raw_requirements_commands.rs
+++ b/src-tauri/src/commands/raw_requirements_commands.rs
@@ -1,0 +1,87 @@
+use std::fs;
+use std::path::PathBuf;
+
+fn raw_requirements_path(local_folder: &str) -> PathBuf {
+    PathBuf::from(local_folder)
+        .join(".mpx")
+        .join("RAW_REQUIREMENTS.md")
+}
+
+#[tauri::command]
+pub fn read_raw_requirements(local_folder: String) -> Result<String, String> {
+    let path = raw_requirements_path(&local_folder);
+    if !path.exists() {
+        return Ok(String::new());
+    }
+    fs::read_to_string(&path).map_err(|error| format!("Failed to read RAW_REQUIREMENTS.md: {error}"))
+}
+
+#[tauri::command]
+pub fn write_raw_requirements(local_folder: String, content: String) -> Result<(), String> {
+    let path = raw_requirements_path(&local_folder);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|error| format!("Failed to create .mpx directory: {error}"))?;
+    }
+    fs::write(&path, content).map_err(|error| format!("Failed to write RAW_REQUIREMENTS.md: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    static TEST_COUNTER: AtomicU32 = AtomicU32::new(0);
+
+    fn temp_dir() -> PathBuf {
+        let unique = TEST_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "grovekeeper_raw_req_{}_{unique}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn read_returns_empty_string_when_file_missing() {
+        let dir = temp_dir();
+        let result = read_raw_requirements(dir.to_string_lossy().to_string());
+        assert_eq!(result.unwrap(), "");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn write_creates_mpx_directory_and_file() {
+        let dir = temp_dir();
+        let content = "## 2026-05-01 14:30\nTest note\n";
+        write_raw_requirements(dir.to_string_lossy().to_string(), content.to_string()).unwrap();
+
+        let path = dir.join(".mpx").join("RAW_REQUIREMENTS.md");
+        assert!(path.exists());
+        assert_eq!(fs::read_to_string(&path).unwrap(), content);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn round_trip_write_then_read() {
+        let dir = temp_dir();
+        let content = "## 2026-05-01 14:30\nFirst note\n---\n## 2026-05-01 13:15\nSecond note\n";
+        write_raw_requirements(dir.to_string_lossy().to_string(), content.to_string()).unwrap();
+        let result = read_raw_requirements(dir.to_string_lossy().to_string()).unwrap();
+        assert_eq!(result, content);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn write_overwrites_existing_content() {
+        let dir = temp_dir();
+        write_raw_requirements(dir.to_string_lossy().to_string(), "old".to_string()).unwrap();
+        write_raw_requirements(dir.to_string_lossy().to_string(), "new".to_string()).unwrap();
+        let result = read_raw_requirements(dir.to_string_lossy().to_string()).unwrap();
+        assert_eq!(result, "new");
+        let _ = fs::remove_dir_all(&dir);
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,8 +11,9 @@ mod window_manager;
 use commands::{
     action_commands, color_palette_commands, dashboard_commands, dependency_commands,
     git_status_commands, github_commands, issue_commands, keyboard_shortcut_commands,
-    label_shape_mapping_commands, notification_commands, portfolio_commands, seed_commands,
-    session_commands, terminal_commands, window_commands, worktree_commands,
+    label_shape_mapping_commands, notification_commands, portfolio_commands,
+    raw_requirements_commands, seed_commands, session_commands, terminal_commands,
+    window_commands, worktree_commands,
 };
 use database::connection::DatabaseState;
 use git::fetch_coordinator::FetchCoordinator;
@@ -179,6 +180,8 @@ pub fn run() {
             window_commands::get_app_setting,
             window_commands::set_app_setting,
             dependency_commands::get_issue_dependencies,
+            raw_requirements_commands::read_raw_requirements,
+            raw_requirements_commands::write_raw_requirements,
             seed_commands::seed_demo_workspace,
             seed_commands::delete_demo_workspace,
         ])

--- a/src/lib/components/RawRequirementsModal.svelte
+++ b/src/lib/components/RawRequirementsModal.svelte
@@ -1,0 +1,184 @@
+<script lang="ts">
+	import * as m from '$lib/paraglide/messages.js';
+	import PencilIcon from '@lucide/svelte/icons/pencil';
+	import CheckIcon from '@lucide/svelte/icons/check';
+	import XIcon from '@lucide/svelte/icons/x';
+	import SparklesIcon from '@lucide/svelte/icons/sparkles';
+	import * as Dialog from '$lib/components/ui/dialog/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Textarea } from '$lib/components/ui/textarea/index.js';
+	import { Badge } from '$lib/components/ui/badge/index.js';
+	import { useRawRequirements } from '$lib/modules/raw-requirements/index.js';
+
+	const rawRequirementsCtx = useRawRequirements();
+
+	let newNoteContent = $state('');
+	let editContent = $state('');
+	let newNoteTextareaElement = $state<HTMLTextAreaElement | null>(null);
+	let notesContainerElement = $state<HTMLDivElement | null>(null);
+
+	function handleDialogOpenChange(isOpen: boolean) {
+		rawRequirementsCtx.open = isOpen;
+		if (isOpen) {
+			newNoteContent = '';
+			requestAnimationFrame(() => {
+				newNoteTextareaElement?.focus();
+				if (notesContainerElement) {
+					notesContainerElement.scrollTop = notesContainerElement.scrollHeight;
+				}
+			});
+		}
+	}
+
+	function handleNewNoteKeydown(event: KeyboardEvent) {
+		if (event.key === 'Enter' && !event.shiftKey) {
+			event.preventDefault();
+			void submitNewNote();
+		}
+	}
+
+	async function submitNewNote() {
+		if (newNoteContent.trim() === '') {
+			return;
+		}
+		await rawRequirementsCtx.addNote(newNoteContent);
+		newNoteContent = '';
+		requestAnimationFrame(() => {
+			if (notesContainerElement) {
+				notesContainerElement.scrollTop = notesContainerElement.scrollHeight;
+			}
+		});
+	}
+
+	function startEditing(index: number) {
+		rawRequirementsCtx.editingIndex = index;
+		editContent = rawRequirementsCtx.notes[index].content;
+	}
+
+	function cancelEditing() {
+		rawRequirementsCtx.editingIndex = null;
+		editContent = '';
+	}
+
+	async function saveEdit(index: number) {
+		await rawRequirementsCtx.updateNote(index, editContent);
+		editContent = '';
+	}
+
+	function handleEditKeydown(event: KeyboardEvent, index: number) {
+		if (event.key === 'Enter' && !event.shiftKey) {
+			event.preventDefault();
+			void saveEdit(index);
+		} else if (event.key === 'Escape') {
+			event.preventDefault();
+			cancelEditing();
+		}
+	}
+</script>
+
+<Dialog.Root open={rawRequirementsCtx.open} onOpenChange={handleDialogOpenChange}>
+	<Dialog.Content class="max-w-[700px] h-[90vh] flex flex-col p-0">
+		<Dialog.Header>
+			<Dialog.Title>{m.raw_requirements_title()}</Dialog.Title>
+		</Dialog.Header>
+
+		<Dialog.Body bind:ref={notesContainerElement} class="flex-1 overflow-y-auto">
+			{#if rawRequirementsCtx.notes.length === 0}
+				<p class="text-sm text-muted-foreground">{m.raw_requirements_empty()}</p>
+			{:else}
+				<div class="flex flex-col gap-3">
+					{#each rawRequirementsCtx.notes as note, index (note.timestamp + index)}
+						<div class="group rounded-lg border border-border p-3">
+							<div class="mb-1 flex items-center justify-between">
+								<span class="text-xs text-muted-foreground">
+									{note.timestamp}
+								</span>
+								<div class="flex items-center gap-1">
+									{#if note.processed}
+										<Badge
+											variant="default"
+											class="text-[length:var(--text-2xs)]"
+										>
+											{m.raw_requirements_processed()}
+										</Badge>
+									{/if}
+									{#if rawRequirementsCtx.editingIndex !== index}
+										<Button
+											variant="ghost"
+											size="icon-sm"
+											class="opacity-0 group-hover:opacity-100 transition-opacity"
+											onclick={() => startEditing(index)}
+										>
+											<PencilIcon />
+											<span class="sr-only">{m.raw_requirements_edit()}</span>
+										</Button>
+									{/if}
+								</div>
+							</div>
+
+							{#if rawRequirementsCtx.editingIndex === index}
+								<Textarea
+									class="min-h-[60px] text-sm"
+									value={editContent}
+									oninput={(event) => {
+										editContent = event.currentTarget.value;
+									}}
+									onkeydown={(event) => handleEditKeydown(event, index)}
+								/>
+								<div class="mt-2 flex justify-end gap-1">
+									<Button variant="ghost" size="sm" onclick={cancelEditing}>
+										<XIcon />
+										{m.raw_requirements_cancel_edit()}
+									</Button>
+									<Button
+										variant="primary"
+										size="sm"
+										onclick={() => void saveEdit(index)}
+									>
+										<CheckIcon />
+										{m.raw_requirements_save_edit()}
+									</Button>
+								</div>
+							{:else}
+								<p class="whitespace-pre-wrap text-sm text-muted-foreground">
+									{note.content}
+								</p>
+							{/if}
+						</div>
+					{/each}
+				</div>
+			{/if}
+		</Dialog.Body>
+
+		<div class="border-t border-border px-5 py-4">
+			<Textarea
+				bind:ref={newNoteTextareaElement}
+				class="min-h-[80px] text-sm"
+				placeholder={m.raw_requirements_placeholder()}
+				value={newNoteContent}
+				oninput={(event) => {
+					newNoteContent = event.currentTarget.value;
+				}}
+				onkeydown={handleNewNoteKeydown}
+			/>
+			<div class="mt-3 flex items-center justify-between">
+				<div>
+					{#if rawRequirementsCtx.hasNotes}
+						<Button variant="secondary" size="sm">
+							<SparklesIcon />
+							{m.raw_requirements_process()}
+						</Button>
+					{/if}
+				</div>
+				<Button
+					variant="primary"
+					size="sm"
+					disabled={newNoteContent.trim() === ''}
+					onclick={() => void submitNewNote()}
+				>
+					{m.raw_requirements_save()}
+				</Button>
+			</div>
+		</div>
+	</Dialog.Content>
+</Dialog.Root>

--- a/src/lib/modules/keyboard-shortcuts/keyboard_shortcuts.context.svelte.ts
+++ b/src/lib/modules/keyboard-shortcuts/keyboard_shortcuts.context.svelte.ts
@@ -116,11 +116,12 @@ function createKeyboardShortcutsContext() {
 		},
 
 		handleKeydown(event: KeyboardEvent): void {
-			if (isEditableElement(event.target)) {
-				return;
-			}
+			const isEditable = isEditableElement(event.target);
 
 			for (const [, action] of registeredActions) {
+				if (isEditable && action.allowFromEditable !== true) {
+					continue;
+				}
 				const effectiveBinding = customBindings.get(action.id) ?? action.defaultBinding;
 				const combo = parseBinding(effectiveBinding);
 				if (matchesKeyEvent(combo, event)) {

--- a/src/lib/modules/keyboard-shortcuts/types.ts
+++ b/src/lib/modules/keyboard-shortcuts/types.ts
@@ -13,6 +13,7 @@ export interface ShortcutAction {
 	label: string;
 	defaultBinding: string;
 	callback: () => void;
+	allowFromEditable?: boolean;
 }
 
 export interface ShortcutBinding {

--- a/src/lib/modules/raw-requirements/index.ts
+++ b/src/lib/modules/raw-requirements/index.ts
@@ -1,0 +1,6 @@
+export { parseRawRequirements, serializeRawRequirements, formatTimestamp } from './parser.js';
+export {
+	useRawRequirements,
+	setRawRequirementsContext,
+} from './raw_requirements.context.svelte.js';
+export type { RawRequirementNote } from './types.js';

--- a/src/lib/modules/raw-requirements/parser.test.ts
+++ b/src/lib/modules/raw-requirements/parser.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { parseRawRequirements, serializeRawRequirements, formatTimestamp } from './parser.js';
+
+// ─── parseRawRequirements ────────────────────────────────────────────────────
+
+describe('parseRawRequirements', () => {
+	it('returns an empty array for an empty string', () => {
+		expect(parseRawRequirements('')).toEqual([]);
+	});
+
+	it('parses a single note with timestamp header', () => {
+		const input =
+			'## 2026-05-01 14:30\nBuild a notification sound pack browser with preview playback\n';
+		expect(parseRawRequirements(input)).toEqual([
+			{
+				timestamp: '2026-05-01 14:30',
+				content: 'Build a notification sound pack browser with preview playback',
+				processed: false,
+			},
+		]);
+	});
+
+	it('parses multiple notes separated by --- delimiters', () => {
+		const input = '## 2026-05-01 14:30\nFirst note\n---\n## 2026-05-01 13:15\nSecond note\n';
+		expect(parseRawRequirements(input)).toEqual([
+			{ timestamp: '2026-05-01 14:30', content: 'First note', processed: false },
+			{ timestamp: '2026-05-01 13:15', content: 'Second note', processed: false },
+		]);
+	});
+
+	it('parses multi-line content within a note', () => {
+		const input = '## 2026-05-01 14:30\nLine one\nLine two\nLine three\n';
+		expect(parseRawRequirements(input)).toEqual([
+			{
+				timestamp: '2026-05-01 14:30',
+				content: 'Line one\nLine two\nLine three',
+				processed: false,
+			},
+		]);
+	});
+
+	it('handles processed marker [processed] after timestamp', () => {
+		const input = '## 2026-05-01 14:30 [processed]\nA processed note\n';
+		expect(parseRawRequirements(input)).toEqual([
+			{ timestamp: '2026-05-01 14:30', content: 'A processed note', processed: true },
+		]);
+	});
+
+	it('returns an empty array for whitespace-only or malformed input', () => {
+		expect(parseRawRequirements('   \n\n  ')).toEqual([]);
+	});
+});
+
+// ─── serializeRawRequirements ────────────────────────────────────────────────
+
+describe('serializeRawRequirements', () => {
+	it('returns an empty string for an empty array', () => {
+		expect(serializeRawRequirements([])).toBe('');
+	});
+
+	it('serializes a single note into correct markdown', () => {
+		const input = [{ timestamp: '2026-05-01 14:30', content: 'Test note', processed: false }];
+		expect(serializeRawRequirements(input)).toBe('## 2026-05-01 14:30\nTest note\n');
+	});
+
+	it('serializes multiple notes separated by ---', () => {
+		const input = [
+			{ timestamp: '2026-05-01 14:30', content: 'First', processed: false },
+			{ timestamp: '2026-05-01 13:15', content: 'Second', processed: false },
+		];
+		expect(serializeRawRequirements(input)).toBe(
+			'## 2026-05-01 14:30\nFirst\n---\n## 2026-05-01 13:15\nSecond\n',
+		);
+	});
+
+	it('includes [processed] marker for processed notes', () => {
+		const input = [{ timestamp: '2026-05-01 14:30', content: 'Done note', processed: true }];
+		expect(serializeRawRequirements(input)).toBe(
+			'## 2026-05-01 14:30 [processed]\nDone note\n',
+		);
+	});
+});
+
+// ─── round-trip ──────────────────────────────────────────────────────────────
+
+describe('round-trip', () => {
+	it('preserves content when parsing then serializing', () => {
+		const input = '## 2026-05-01 14:30\nFirst note\n---\n## 2026-05-01 13:15\nSecond note\n';
+		expect(serializeRawRequirements(parseRawRequirements(input))).toBe(input);
+	});
+});
+
+// ─── formatTimestamp ─────────────────────────────────────────────────────────
+
+describe('formatTimestamp', () => {
+	it('produces a string matching YYYY-MM-DD HH:mm format', () => {
+		expect(formatTimestamp()).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}$/);
+	});
+
+	it('formats a specific date correctly', () => {
+		const date = new Date(2026, 0, 5, 9, 3);
+		expect(formatTimestamp(date)).toBe('2026-01-05 09:03');
+	});
+});

--- a/src/lib/modules/raw-requirements/parser.ts
+++ b/src/lib/modules/raw-requirements/parser.ts
@@ -1,0 +1,61 @@
+import type { RawRequirementNote } from './types.js';
+
+const TIMESTAMP_HEADER_REGEX = /^## (\d{4}-\d{2}-\d{2} \d{2}:\d{2})( \[processed\])?$/;
+const SECTION_DELIMITER = '---';
+
+export function parseRawRequirements(markdown: string): RawRequirementNote[] {
+	if (markdown.trim() === '') {
+		return [];
+	}
+
+	const sections = markdown.split(`\n${SECTION_DELIMITER}\n`);
+	const notes: RawRequirementNote[] = [];
+
+	for (const section of sections) {
+		const lines = section.split('\n');
+		const headerLine = lines[0];
+		const headerMatch = TIMESTAMP_HEADER_REGEX.exec(headerLine);
+
+		if (!headerMatch) {
+			continue;
+		}
+
+		const timestamp = headerMatch[1];
+		const processed = headerMatch[2] !== undefined;
+		const contentLines = lines.slice(1);
+		const content = contentLines.join('\n').replace(/\n$/, '');
+
+		if (content.length === 0) {
+			continue;
+		}
+
+		notes.push({ timestamp, content, processed });
+	}
+
+	return notes;
+}
+
+export function serializeRawRequirements(notes: readonly RawRequirementNote[]): string {
+	if (notes.length === 0) {
+		return '';
+	}
+
+	return notes
+		.map((note) => {
+			const processedMarker = note.processed ? ' [processed]' : '';
+			return `## ${note.timestamp}${processedMarker}\n${note.content}\n`;
+		})
+		.join(`${SECTION_DELIMITER}\n`);
+}
+
+export function formatTimestamp(date?: Date): string {
+	const targetDate = date ?? new Date();
+
+	const year = targetDate.getFullYear();
+	const month = String(targetDate.getMonth() + 1).padStart(2, '0');
+	const day = String(targetDate.getDate()).padStart(2, '0');
+	const hours = String(targetDate.getHours()).padStart(2, '0');
+	const minutes = String(targetDate.getMinutes()).padStart(2, '0');
+
+	return `${year}-${month}-${day} ${hours}:${minutes}`;
+}

--- a/src/lib/modules/raw-requirements/raw_requirements.context.svelte.ts
+++ b/src/lib/modules/raw-requirements/raw_requirements.context.svelte.ts
@@ -1,0 +1,157 @@
+import { createContext } from 'svelte';
+import { StateRaw } from '$lib/reactivity/state.svelte.js';
+import { invoke, isTauri } from '$lib/tauri.js';
+import { useBoard } from '$lib/modules/board/index.js';
+import { useWindow } from '$lib/modules/window/index.js';
+import { parseRawRequirements, serializeRawRequirements, formatTimestamp } from './parser.js';
+import type { RawRequirementNote } from './types.js';
+
+// ─── Context ──────────────────────────────────────────────────────────────────
+
+type RawRequirementsContext = ReturnType<typeof createRawRequirementsContext>;
+
+const [useRawRequirements, setRawRequirementsInternal] = createContext<RawRequirementsContext>();
+export { useRawRequirements };
+
+export function setRawRequirementsContext() {
+	const ctx = createRawRequirementsContext();
+	setRawRequirementsInternal(ctx);
+	return ctx;
+}
+
+// ─── Factory ──────────────────────────────────────────────────────────────────
+
+function createRawRequirementsContext() {
+	const boardStore = useBoard();
+	const windowCtx = useWindow();
+
+	const notes = new StateRaw<RawRequirementNote[]>([]);
+	const open = new StateRaw(false);
+	const loading = new StateRaw(false);
+	const editingIndex = new StateRaw<number | null>(null);
+
+	function getLocalFolder(): string | null {
+		return boardStore.activeDashboard?.local_folder ?? null;
+	}
+
+	async function load(): Promise<void> {
+		const localFolder = getLocalFolder();
+		if (localFolder === null || !isTauri()) {
+			notes.current = [];
+			return;
+		}
+		try {
+			loading.current = true;
+			const content = await invoke<string>('read_raw_requirements', {
+				localFolder,
+			});
+			notes.current = parseRawRequirements(content);
+		} catch (error) {
+			console.error('Failed to load raw requirements:', error);
+			notes.current = [];
+		} finally {
+			loading.current = false;
+		}
+	}
+
+	async function save(): Promise<void> {
+		const localFolder = getLocalFolder();
+		if (localFolder === null || !isTauri()) {
+			return;
+		}
+		try {
+			const content = serializeRawRequirements(notes.current);
+			await invoke('write_raw_requirements', { localFolder, content });
+		} catch (error) {
+			console.error('Failed to save raw requirements:', error);
+		}
+	}
+
+	async function addNote(content: string): Promise<void> {
+		const trimmed = content.trim();
+		if (trimmed === '') {
+			return;
+		}
+		const newNote: RawRequirementNote = {
+			timestamp: formatTimestamp(),
+			content: trimmed,
+			processed: false,
+		};
+		notes.current = [...notes.current, newNote];
+		await save();
+	}
+
+	async function updateNote(index: number, content: string): Promise<void> {
+		const trimmed = content.trim();
+		if (trimmed === '' || index < 0 || index >= notes.current.length) {
+			return;
+		}
+		const updated = [...notes.current];
+		updated[index] = { ...updated[index], content: trimmed };
+		notes.current = updated;
+		editingIndex.current = null;
+		await save();
+	}
+
+	async function toggleProcessed(index: number): Promise<void> {
+		if (index < 0 || index >= notes.current.length) {
+			return;
+		}
+		const updated = [...notes.current];
+		updated[index] = { ...updated[index], processed: !updated[index].processed };
+		notes.current = updated;
+		await save();
+	}
+
+	async function toggle(): Promise<void> {
+		if (!windowCtx.isWorkspace) {
+			return;
+		}
+		if (open.current) {
+			close();
+		} else {
+			open.current = true;
+			editingIndex.current = null;
+			await load();
+		}
+	}
+
+	function close(): void {
+		open.current = false;
+		editingIndex.current = null;
+	}
+
+	return {
+		get notes() {
+			return notes.current;
+		},
+		get open() {
+			return open.current;
+		},
+		set open(value: boolean) {
+			open.current = value;
+			if (!value) {
+				editingIndex.current = null;
+			}
+		},
+		get loading() {
+			return loading.current;
+		},
+		get editingIndex() {
+			return editingIndex.current;
+		},
+		set editingIndex(value: number | null) {
+			editingIndex.current = value;
+		},
+		get hasNotes() {
+			return notes.current.length > 0;
+		},
+
+		toggle,
+		close,
+		load,
+		addNote,
+		updateNote,
+		toggleProcessed,
+	};
+}

--- a/src/lib/modules/raw-requirements/types.ts
+++ b/src/lib/modules/raw-requirements/types.ts
@@ -1,0 +1,5 @@
+export interface RawRequirementNote {
+	timestamp: string;
+	content: string;
+	processed: boolean;
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -23,7 +23,9 @@
 	import { setWindowContext, openWorkspaceWindow } from '$lib/modules/window';
 	import { setKeyboardShortcutsContext } from '$lib/modules/keyboard-shortcuts';
 	import { setCommandPaletteContext } from '$lib/modules/command-palette';
+	import { setRawRequirementsContext } from '$lib/modules/raw-requirements';
 	import CommandPalette from '$lib/components/CommandPalette.svelte';
+	import RawRequirementsModal from '$lib/components/RawRequirementsModal.svelte';
 	import type { Dashboard } from '$lib/types/generated';
 
 	let { children } = $props();
@@ -38,6 +40,7 @@
 	setActionsContext();
 	const shortcutsCtx = setKeyboardShortcutsContext();
 	const commandPaletteCtx = setCommandPaletteContext();
+	const rawRequirementsCtx = setRawRequirementsContext();
 
 	let editingDashboard = $state<Dashboard | null>(null);
 
@@ -67,6 +70,13 @@
 			label: 'Open Settings',
 			defaultBinding: 'Ctrl+,',
 			callback: () => void goto(resolve('/settings')),
+		});
+		shortcutsCtx.registerShortcut({
+			id: 'quick-ideas',
+			label: 'Quick Ideas',
+			defaultBinding: 'Ctrl+Shift+I',
+			allowFromEditable: true,
+			callback: () => void rawRequirementsCtx.toggle(),
 		});
 	});
 
@@ -164,3 +174,4 @@
 />
 
 <CommandPalette />
+<RawRequirementsModal />


### PR DESCRIPTION
## Description

- Adds `RawRequirementsContext` to manage quick ideas state with CRUD operations
- Implements Rust backend with two Tauri commands (`read_raw_requirements`, `write_raw_requirements`) for per-workspace `.mpx/RAW_REQUIREMENTS.md`
- Adds TypeScript markdown parser supporting `## YYYY-MM-DD HH:mm` headers, `---` delimiters, and `[processed]` markers
- Creates `RawRequirementsModal` component with shadcn Dialog, previous notes display (gray), per-note edit buttons, and auto-focused textarea
- Binds `Ctrl+Shift+I` keyboard shortcut with `allowFromEditable` flag to bypass editable element guard
- Includes i18n translations (English/Czech) for all UI strings
- Adds 4 Rust unit tests for file I/O and 13 TypeScript tests for parser/serializer round-trip
- Fixes pre-existing dead_code lint in `dependency_commands.rs` by gating test-only function with `#[cfg(test)]`

## Resolves
Closes #136

## Testing
- [ ] Manual test: `Ctrl+Shift+I` toggles modal in dev environment
- [ ] Parser round-trip tests pass: `pnpm test`
- [ ] Rust tests pass: `pnpm tauri build`