### PR TITLE
fix: wizard UX polish — step dots, highlight color, card hover states

### DIFF
--- a/src/lib/components/creation-wizard/CreationWizard.svelte
+++ b/src/lib/components/creation-wizard/CreationWizard.svelte
@@ -228,6 +228,16 @@
 		}
 	});
 
+	const navigableSteps = $derived.by(() => {
+		const steps: string[] = [WIZARD_STEPS.GITHUB_SEARCH, WIZARD_STEPS.ISSUE_NAME];
+		if (wizard.worktreeAvailable) {
+			steps.push(WIZARD_STEPS.WORKTREE_CHOICE);
+		}
+		steps.push(WIZARD_STEPS.COLOR_SELECTION);
+		return steps;
+	});
+	const currentStepIndex = $derived(navigableSteps.indexOf(wizard.currentStep));
+
 	const isFirstStep = $derived(wizard.currentStep === WIZARD_STEPS.GITHUB_SEARCH);
 	const isIssueNameStep = $derived(wizard.currentStep === WIZARD_STEPS.ISSUE_NAME);
 	const isFinalStep = $derived(wizard.currentStep === WIZARD_STEPS.COLOR_SELECTION);
@@ -248,10 +258,24 @@
 
 <Dialog.Root open={wizard.open} onOpenChange={handleOpenChange}>
 	<Dialog.Content class="top-[15%] -translate-y-0 max-w-lg">
-		<Dialog.Header>
+		<Dialog.Header class="flex items-center">
 			<Dialog.Title class="text-base font-semibold text-foreground">
 				{stepLabel}
 			</Dialog.Title>
+			{#if !showWorktreeProgress}
+				<div class="ml-auto flex items-center gap-[5px]">
+					{#each navigableSteps as step, index (step)}
+						<div
+							class="h-1.5 transition-all duration-200
+								{index === currentStepIndex
+								? 'w-4 rounded-sm bg-primary'
+								: index < currentStepIndex
+									? 'w-1.5 rounded-full bg-primary/50'
+									: 'w-1.5 rounded-full bg-border-strong'}"
+						></div>
+					{/each}
+				</div>
+			{/if}
 		</Dialog.Header>
 
 		<Dialog.Body class="flex flex-col gap-3 py-2">

--- a/src/lib/components/creation-wizard/StepGithubSearch.svelte
+++ b/src/lib/components/creation-wizard/StepGithubSearch.svelte
@@ -123,8 +123,8 @@
 					onclick={() => wizard.selectGithubIssue(toSearchedIssue(item))}
 					class="flex items-center gap-2 rounded px-2 py-1.5 text-left text-sm transition-colors
 						{index === selectedIndex
-						? 'bg-accent text-accent-foreground'
-						: 'text-foreground hover:bg-accent/50'}"
+						? 'bg-primary-soft text-foreground'
+						: 'text-foreground hover:bg-surface-hover'}"
 				>
 					{#if item.state === 'OPEN'}
 						<CircleDot size={14} class="shrink-0 text-green-400" />

--- a/src/lib/components/creation-wizard/StepWorktreeChoice.svelte
+++ b/src/lib/components/creation-wizard/StepWorktreeChoice.svelte
@@ -35,7 +35,7 @@
 			class="flex flex-col items-center gap-2 rounded-lg border-2 px-6 py-4 transition-colors
 				{selectedChoice === true
 				? 'border-green-500 bg-green-500/10 text-green-400'
-				: 'border-border text-muted-foreground hover:border-green-500/50 hover:text-green-400'}"
+				: 'border-border bg-transparent text-muted-foreground hover:bg-surface-hover'}"
 		>
 			<TreePine size={24} />
 			<span class="text-xs font-medium">{m.wizard_worktree_yes()}</span>
@@ -46,7 +46,7 @@
 			class="flex flex-col items-center gap-2 rounded-lg border-2 px-6 py-4 transition-colors
 				{selectedChoice === false
 				? 'border-red-500 bg-red-500/10 text-red-400'
-				: 'border-border text-muted-foreground hover:border-red-500/50 hover:text-red-400'}"
+				: 'border-border bg-transparent text-muted-foreground hover:bg-surface-hover'}"
 		>
 			<X size={24} />
 			<span class="text-xs font-medium">{m.wizard_worktree_no()}</span>


### PR DESCRIPTION
## Summary

- Add step progress dots to wizard header — active step shown as wider pill, completed steps as primary/50 circles, inactive as border-strong circles. Adapts to 3 or 4 steps based on worktree availability. Hidden during worktree progress.
- Replace issue list highlight from `bg-accent` (orange) to `bg-primary-soft` (sage green in Forest Moss palette). Hover on non-selected items uses `bg-surface-hover` instead of `bg-accent/50`.
- Fix worktree choice card unselected hover to neutral `bg-surface-hover` instead of colored borders per grilled design decisions.

Fixes #172

## Design Conflicts Flagged

1. **Step dots** — Design has them enabled; brief lists as optional "UI Freedom"; issue doesn't mention. User confirmed they want them.
2. **Next button on GitHub Search** — Design shows Next on Step 1, but brief+issue say hidden. Current implementation (no Next on Step 1) is correct.
3. **Modal width** — Design uses 480px, brief says max-w-lg (512px). Kept max-w-lg per brief.
4. **Fewer than 24 colors** — Mock data provides 8 colors; component renders all it receives. Data issue, not component.

## Test plan

- [x] Walk through all 4 wizard steps verifying step dots update correctly
- [x] Verify selected issue row uses sage green highlight (not orange)
- [x] Verify worktree card hover is neutral (not colored) when unselected
- [x] Verify Yes card pre-selected with green border+fill
- [x] Verify footer buttons are default (md) size across all steps
- [x] `pnpm check:all` passes
- [x] `pnpm test` passes (698 tests)