### PR TITLE
feat: issue card redesign with batch selection and context menu

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -18,7 +18,8 @@
 		"@fallow-cli/win32-x64-msvc",
 		"low-poly-2d-trees",
 		"lucide-svelte",
-		"@inlang/paraglide-js"
+		"@inlang/paraglide-js",
+		"@internationalized/date"
 	],
 	"health": {
 		"maxCrap": 60

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
 	},
 	"devDependencies": {
 		"@chromatic-com/storybook": "^5.1.1",
+		"@internationalized/date": "^3.12.0",
 		"@lucide/svelte": "^1.14.0",
 		"@playwright/test": "^1.58.2",
 		"@storybook/addon-a11y": "^10.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
             '@chromatic-com/storybook':
                 specifier: ^5.1.1
                 version: 5.1.1(storybook@10.3.3(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+            '@internationalized/date':
+                specifier: ^3.12.0
+                version: 3.12.0
             '@lucide/svelte':
                 specifier: ^1.14.0
                 version: 1.14.0(svelte@5.55.0)

--- a/src/lib/actions/long_press.test.ts
+++ b/src/lib/actions/long_press.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { longPress } from './long_press.js';
+
+/**
+ * Creates a minimal HTMLElement stub backed by an EventTarget for dispatching events.
+ * This avoids needing jsdom while still testing real event wiring.
+ */
+function createElementStub(): HTMLElement {
+	const eventTarget = new EventTarget();
+	const element = {
+		addEventListener: vi.fn(
+			(
+				type: string,
+				listener: EventListenerOrEventListenerObject,
+				options?: AddEventListenerOptions | boolean,
+			) => {
+				eventTarget.addEventListener(type, listener as EventListener, options);
+			},
+		),
+		removeEventListener: vi.fn(
+			(
+				type: string,
+				listener: EventListenerOrEventListenerObject,
+				options?: EventListenerOptions | boolean,
+			) => {
+				eventTarget.removeEventListener(type, listener as EventListener, options);
+			},
+		),
+		dispatchEvent: (event: Event) => eventTarget.dispatchEvent(event),
+	} as unknown as HTMLElement;
+	return element;
+}
+
+/**
+ * Node.js lacks PointerEvent, so we create a plain Event and attach
+ * clientX/clientY properties that the action reads.
+ */
+function createPointerEvent(
+	type: string,
+	options: { clientX?: number; clientY?: number } = {},
+): Event {
+	const event = new Event(type, { bubbles: true, cancelable: true });
+	Object.defineProperty(event, 'clientX', { value: options.clientX ?? 0 });
+	Object.defineProperty(event, 'clientY', { value: options.clientY ?? 0 });
+	return event;
+}
+
+describe('longPress', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('fires callback after default 500ms pointerdown', () => {
+		const element = createElementStub();
+		const onLongPress = vi.fn();
+		longPress(element, { onLongPress });
+
+		element.dispatchEvent(createPointerEvent('pointerdown'));
+		vi.advanceTimersByTime(500);
+
+		expect(onLongPress).toHaveBeenCalledOnce();
+	});
+
+	it('does NOT fire callback if pointerup before 500ms', () => {
+		const element = createElementStub();
+		const onLongPress = vi.fn();
+		longPress(element, { onLongPress });
+
+		element.dispatchEvent(createPointerEvent('pointerdown'));
+		vi.advanceTimersByTime(300);
+		element.dispatchEvent(createPointerEvent('pointerup'));
+		vi.advanceTimersByTime(500);
+
+		expect(onLongPress).not.toHaveBeenCalled();
+	});
+
+	// fallow-ignore-next-line code-duplication
+	it('does NOT fire callback if pointermove exceeds threshold', () => {
+		const element = createElementStub();
+		const onLongPress = vi.fn();
+		longPress(element, { onLongPress, moveThreshold: 10 });
+
+		element.dispatchEvent(createPointerEvent('pointerdown', { clientX: 0, clientY: 0 }));
+		element.dispatchEvent(createPointerEvent('pointermove', { clientX: 11, clientY: 0 }));
+		vi.advanceTimersByTime(500);
+
+		expect(onLongPress).not.toHaveBeenCalled();
+	});
+
+	it('fires callback if pointermove stays within threshold', () => {
+		const element = createElementStub();
+		const onLongPress = vi.fn();
+		longPress(element, { onLongPress, moveThreshold: 10 });
+
+		element.dispatchEvent(createPointerEvent('pointerdown', { clientX: 0, clientY: 0 }));
+		element.dispatchEvent(createPointerEvent('pointermove', { clientX: 5, clientY: 7 }));
+		vi.advanceTimersByTime(500);
+
+		expect(onLongPress).toHaveBeenCalledOnce();
+	});
+
+	it('cancels on pointercancel event', () => {
+		const element = createElementStub();
+		const onLongPress = vi.fn();
+		longPress(element, { onLongPress });
+
+		element.dispatchEvent(createPointerEvent('pointerdown'));
+		vi.advanceTimersByTime(200);
+		element.dispatchEvent(createPointerEvent('pointercancel'));
+		vi.advanceTimersByTime(500);
+
+		expect(onLongPress).not.toHaveBeenCalled();
+	});
+
+	it('respects custom duration', () => {
+		const element = createElementStub();
+		const onLongPress = vi.fn();
+		longPress(element, { onLongPress, duration: 300 });
+
+		element.dispatchEvent(createPointerEvent('pointerdown'));
+		vi.advanceTimersByTime(299);
+		expect(onLongPress).not.toHaveBeenCalled();
+
+		vi.advanceTimersByTime(1);
+		expect(onLongPress).toHaveBeenCalledOnce();
+	});
+
+	it('cleans up event listeners on destroy', () => {
+		const element = createElementStub();
+		const onLongPress = vi.fn();
+		const action = longPress(element, { onLongPress });
+
+		action.destroy();
+
+		element.dispatchEvent(createPointerEvent('pointerdown'));
+		vi.advanceTimersByTime(500);
+
+		expect(onLongPress).not.toHaveBeenCalled();
+	});
+
+	it('update() changes options for subsequent interactions', () => {
+		const element = createElementStub();
+		const originalCallback = vi.fn();
+		const updatedCallback = vi.fn();
+		const action = longPress(element, { onLongPress: originalCallback, duration: 500 });
+
+		action.update({ onLongPress: updatedCallback, duration: 200 });
+
+		element.dispatchEvent(createPointerEvent('pointerdown'));
+		vi.advanceTimersByTime(200);
+
+		expect(originalCallback).not.toHaveBeenCalled();
+		expect(updatedCallback).toHaveBeenCalledOnce();
+	});
+});

--- a/src/lib/actions/long_press.ts
+++ b/src/lib/actions/long_press.ts
@@ -1,0 +1,91 @@
+const DEFAULT_DURATION_MS = 500;
+const DEFAULT_MOVE_THRESHOLD_PX = 10;
+
+/** @public */
+export interface LongPressOptions {
+	onLongPress: () => void;
+	duration?: number;
+	moveThreshold?: number;
+}
+
+export function longPress(
+	node: HTMLElement,
+	options: LongPressOptions,
+): { update(options: LongPressOptions): void; destroy(): void } {
+	let currentOptions = options;
+	let timeoutId: ReturnType<typeof setTimeout> | null = null;
+	let startX = 0;
+	let startY = 0;
+	let isPressed = false;
+
+	function getDuration(): number {
+		return currentOptions.duration ?? DEFAULT_DURATION_MS;
+	}
+
+	function getMoveThreshold(): number {
+		return currentOptions.moveThreshold ?? DEFAULT_MOVE_THRESHOLD_PX;
+	}
+
+	function cancelPress(): void {
+		if (timeoutId !== null) {
+			clearTimeout(timeoutId);
+			timeoutId = null;
+		}
+		isPressed = false;
+	}
+
+	function handlePointerDown(event: Event): void {
+		const pointerEvent = event as PointerEvent;
+		startX = pointerEvent.clientX;
+		startY = pointerEvent.clientY;
+		isPressed = true;
+
+		timeoutId = setTimeout(() => {
+			if (isPressed) {
+				currentOptions.onLongPress();
+			}
+			isPressed = false;
+			timeoutId = null;
+		}, getDuration());
+	}
+
+	function handlePointerMove(event: Event): void {
+		if (!isPressed) {
+			return;
+		}
+		const pointerEvent = event as PointerEvent;
+		const deltaX = Math.abs(pointerEvent.clientX - startX);
+		const deltaY = Math.abs(pointerEvent.clientY - startY);
+		const distance = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
+
+		if (distance > getMoveThreshold()) {
+			cancelPress();
+		}
+	}
+
+	function handleContextMenu(event: Event): void {
+		if (isPressed) {
+			event.preventDefault();
+		}
+	}
+
+	node.addEventListener('pointerdown', handlePointerDown);
+	node.addEventListener('pointermove', handlePointerMove);
+	node.addEventListener('pointerup', cancelPress);
+	node.addEventListener('pointercancel', cancelPress);
+	node.addEventListener('contextmenu', handleContextMenu);
+
+	return {
+		update(newOptions: LongPressOptions): void {
+			currentOptions = newOptions;
+		},
+		destroy(): void {
+			cancelPress();
+			node.removeEventListener('pointerdown', handlePointerDown);
+			node.removeEventListener('pointermove', handlePointerMove);
+			node.removeEventListener('pointerup', cancelPress);
+			node.removeEventListener('pointercancel', cancelPress);
+			node.removeEventListener('contextmenu', handleContextMenu);
+		},
+	};
+}

--- a/src/lib/components/BatchActionToolbar.svelte
+++ b/src/lib/components/BatchActionToolbar.svelte
@@ -1,0 +1,210 @@
+<script lang="ts">
+	import type { Issue, IssuePriority } from '$lib/modules/issues';
+	import { PRIORITY_OPTIONS } from '$lib/components/issue_card_utils.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import Checkbox from '$lib/components/ui/checkbox/Checkbox.svelte';
+	import * as Popover from '$lib/components/ui/popover/index.js';
+	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
+	import ArchiveIcon from '@lucide/svelte/icons/archive';
+	import ArchiveRestoreIcon from '@lucide/svelte/icons/archive-restore';
+	import Trash2Icon from '@lucide/svelte/icons/trash-2';
+	import ScissorsIcon from '@lucide/svelte/icons/scissors';
+	import ChevronDownIcon from '@lucide/svelte/icons/chevron-down';
+	import XIcon from '@lucide/svelte/icons/x';
+
+	interface Props {
+		selectedCount: number;
+		selectedIssues: Issue[];
+		selectAllCheckboxState: 'all' | 'some' | 'none';
+		onSelectAll: () => void;
+		onDeselectAll: () => void;
+		onBatchArchive: () => void;
+		onBatchUnarchive: () => void;
+		onBatchDelete: () => void;
+		onBatchChangePriority: (priority: IssuePriority | null) => void;
+		onBatchPrune: () => void;
+	}
+
+	let {
+		selectedCount,
+		selectedIssues,
+		selectAllCheckboxState,
+		onSelectAll,
+		onDeselectAll,
+		onBatchArchive,
+		onBatchUnarchive,
+		onBatchDelete,
+		onBatchChangePriority,
+		onBatchPrune,
+	}: Props = $props();
+
+	const hasActiveIssues = $derived(selectedIssues.some((i) => i.status === 'active'));
+	const hasArchivedIssues = $derived(selectedIssues.some((i) => i.status === 'archived'));
+	const hasActiveWorktrees = $derived(selectedIssues.some((i) => i.worktree_state === 'active'));
+
+	const checkboxChecked = $derived(selectAllCheckboxState === 'all');
+	const checkboxIndeterminate = $derived(selectAllCheckboxState === 'some');
+
+	let priorityPopoverOpen = $state(false);
+
+	function handleCheckboxClick() {
+		if (selectAllCheckboxState === 'all') {
+			onDeselectAll();
+		} else {
+			onSelectAll();
+		}
+	}
+
+	function handlePrioritySelect(priority: IssuePriority | null) {
+		priorityPopoverOpen = false;
+		onBatchChangePriority(priority);
+	}
+</script>
+
+<Tooltip.Provider>
+	<div
+		class="flex items-center gap-3 rounded-[var(--radius-md)] border px-[14px] py-2 text-[13px] font-medium"
+		style="background: color-mix(in oklch, var(--primary) 10%, var(--surface)); border-color: color-mix(in oklch, var(--primary) 30%, var(--border));"
+	>
+		<!-- Select-all checkbox -->
+		<Checkbox
+			checked={checkboxChecked}
+			indeterminate={checkboxIndeterminate}
+			onclick={handleCheckboxClick}
+			aria-label="Select all issues"
+		/>
+
+		<!-- Count badge + label -->
+		<div class="flex items-center gap-2">
+			<span class="rounded bg-primary px-2 py-0.5 font-mono text-xs text-primary-foreground">
+				{selectedCount}
+			</span>
+			<span class="text-foreground-muted">
+				{selectedCount === 1 ? 'issue selected' : 'issues selected'}
+			</span>
+		</div>
+
+		<!-- Spacer -->
+		<div class="flex-1"></div>
+
+		<!-- Action buttons -->
+		<div class="flex items-center gap-1.5">
+			<!-- Archive -->
+			{#if hasActiveIssues}
+				<Tooltip.Root>
+					<Tooltip.Trigger>
+						{#snippet child({ props })}
+							<Button
+								{...props}
+								variant="ghost"
+								size="sm"
+								onclick={onBatchArchive}
+								disabled={!hasActiveIssues}
+								aria-label="Archive selected"
+							>
+								<ArchiveIcon />
+								Archive
+							</Button>
+						{/snippet}
+					</Tooltip.Trigger>
+					<Tooltip.Content>Archive selected issues</Tooltip.Content>
+				</Tooltip.Root>
+			{/if}
+
+			<!-- Unarchive -->
+			{#if hasArchivedIssues}
+				<Tooltip.Root>
+					<Tooltip.Trigger>
+						{#snippet child({ props })}
+							<Button
+								{...props}
+								variant="ghost"
+								size="sm"
+								onclick={onBatchUnarchive}
+								disabled={!hasArchivedIssues}
+								aria-label="Unarchive selected"
+							>
+								<ArchiveRestoreIcon />
+								Unarchive
+							</Button>
+						{/snippet}
+					</Tooltip.Trigger>
+					<Tooltip.Content>Unarchive selected issues</Tooltip.Content>
+				</Tooltip.Root>
+			{/if}
+
+			<!-- Delete -->
+			<Tooltip.Root>
+				<Tooltip.Trigger>
+					{#snippet child({ props })}
+						<Button
+							{...props}
+							variant="danger"
+							size="sm"
+							onclick={onBatchDelete}
+							aria-label="Delete selected"
+						>
+							<Trash2Icon />
+							Delete
+						</Button>
+					{/snippet}
+				</Tooltip.Trigger>
+				<Tooltip.Content>Delete selected issues</Tooltip.Content>
+			</Tooltip.Root>
+
+			<!-- Change Priority -->
+			<Popover.Root bind:open={priorityPopoverOpen}>
+				<Popover.Trigger>
+					{#snippet child({ props })}
+						<Button {...props} variant="ghost" size="sm" aria-label="Change priority">
+							Change Priority
+							<ChevronDownIcon />
+						</Button>
+					{/snippet}
+				</Popover.Trigger>
+				<Popover.Content class="w-40 p-1" align="end">
+					{#each PRIORITY_OPTIONS as option (option.value)}
+						<Popover.Item
+							onclick={() => handlePrioritySelect(option.value)}
+							role="menuitem"
+						>
+							{option.label()}
+						</Popover.Item>
+					{/each}
+				</Popover.Content>
+			</Popover.Root>
+
+			<!-- Prune worktrees -->
+			{#if hasActiveWorktrees}
+				<Tooltip.Root>
+					<Tooltip.Trigger>
+						{#snippet child({ props })}
+							<Button
+								{...props}
+								variant="ghost"
+								size="sm"
+								onclick={onBatchPrune}
+								disabled={!hasActiveWorktrees}
+								aria-label="Prune worktrees"
+							>
+								<ScissorsIcon />
+								Prune worktrees
+							</Button>
+						{/snippet}
+					</Tooltip.Trigger>
+					<Tooltip.Content>Remove active worktrees for selected issues</Tooltip.Content>
+				</Tooltip.Root>
+			{/if}
+
+			<!-- Deselect all -->
+			<Button
+				variant="ghost"
+				size="icon-sm"
+				onclick={onDeselectAll}
+				aria-label="Deselect all"
+			>
+				<XIcon />
+			</Button>
+		</div>
+	</div>
+</Tooltip.Provider>

--- a/src/lib/components/ForestView.svelte
+++ b/src/lib/components/ForestView.svelte
@@ -28,6 +28,7 @@
 	import { TREE_CONTEXT_MENU_ACTIONS } from '$lib/modules/visualization';
 	import type { TreeContextMenuAction } from '$lib/modules/visualization';
 	import { useSelection } from '$lib/modules/board';
+	import { GLOW_COLORS } from '$lib/modules/visualization/constants.js';
 
 	interface Props {
 		issues: readonly Issue[];
@@ -208,8 +209,10 @@
 			issueId: entry.issue.id,
 			hoveredIssueId: interaction.hoveredIssueId,
 			selectedIssueId: interaction.selectedIssueId,
+			batchSelectedIssueIds: interaction.batchSelectedIssueIds,
 			hoverGlowColor: interaction.hoverGlowColor,
 			selectedGlowColor: interaction.selectedGlowColor,
+			batchSelectedGlowColor: GLOW_COLORS.pink,
 		});
 	}
 

--- a/src/lib/components/IssueCard.svelte
+++ b/src/lib/components/IssueCard.svelte
@@ -2,39 +2,40 @@
 	import * as m from '$lib/paraglide/messages.js';
 	import type { Issue } from '$lib/modules/issues';
 	import type { Action, GitStatusCache } from '$lib/types/generated';
-	import type { IssueCardCallbacks } from '$lib/modules/issues';
+	import { getContrastTextColor } from '$lib/components/color-picker/color_utils.js';
 	import PullRequestBadge from './PullRequestBadge.svelte';
 	import GitHubIssueBadge from './GitHubIssueBadge.svelte';
 	import SyncStatusIndicator from './SyncStatusIndicator.svelte';
 	import GitBadgeGroup from './GitBadgeGroup.svelte';
 	import WorktreeProgressIndicator from './WorktreeProgressIndicator.svelte';
 	import ActionButtonGroup from './ActionButtonGroup.svelte';
-	import IssueCardTooltip from './IssueCardTooltip.svelte';
 	import WorktreeStateIcon from './WorktreeStateIcon.svelte';
-	import ColorPicker from './color-picker/ColorPicker.svelte';
-	import { clickOutside } from '$lib/actions/click_outside';
-	import {
-		getPriorityBorderClass,
-		PRIORITY_OPTIONS,
-		PRIORITY_BADGE_CLASSES,
-		issueExpandedStates,
-	} from './issue_card_utils.js';
+	import IssueCardTooltip from './IssueCardTooltip.svelte';
+	import FolderOpenIcon from '@lucide/svelte/icons/folder-open';
+	import TerminalIcon from '@lucide/svelte/icons/terminal';
+	import CodeIcon from '@lucide/svelte/icons/code';
+	import MoreHorizontalIcon from '@lucide/svelte/icons/more-horizontal';
+	import LayersIcon from '@lucide/svelte/icons/layers';
+	import GitBranchIcon from '@lucide/svelte/icons/git-branch';
+	import { CARD_STATE_CLASSES } from './batch_selection_utils.js';
+	import { PRIORITY_BADGE_CLASSES, issueExpandedStates } from './issue_card_utils.js';
 
-	interface Props extends IssueCardCallbacks {
+	interface Props {
 		issue: Issue;
 		actions?: Action[];
 		cache?: GitStatusCache | null;
 		ghAvailable?: boolean;
 		notificationDotColor?: string | null;
-		indented?: boolean;
-		isLastChild?: boolean;
 		childCount?: number;
 		forceExpanded?: boolean;
 		progressLines?: readonly string[];
 		prioritiesEnabled?: boolean;
-		paletteColors?: string[];
-		usedColors?: string[];
-		isDarkMode?: boolean;
+		isActive?: boolean;
+		isBatchSelected?: boolean;
+		isSelectionReady?: boolean;
+		onOverflowClick?: () => void;
+		onCardClick?: (event: MouseEvent) => void;
+		onExecuteAction?: (actionId: string, issueId: string) => void;
 	}
 
 	let {
@@ -43,49 +44,33 @@
 		cache = null,
 		ghAvailable = false,
 		notificationDotColor = null,
-		indented = false,
-		isLastChild = false,
 		childCount = 0,
 		forceExpanded,
 		progressLines = [],
 		prioritiesEnabled = true,
-		paletteColors = [],
-		usedColors = [],
-		isDarkMode = false,
-		onArchive,
-		onUnarchive,
-		onEdit,
-		onDelete,
-		onChangePriority,
-		onRename,
-		onSetupWorktree,
-		onRemoveWorktree,
+		isActive = false,
+		isBatchSelected = false,
+		isSelectionReady = false,
+		onOverflowClick,
+		onCardClick,
 		onExecuteAction,
-		onChangeColor,
 	}: Props = $props();
+
+	const color = $derived(issue.color ?? '#525252');
+	const headerTextColor = $derived(getContrastTextColor(color));
+	const isLightHeader = $derived(headerTextColor === '#000000');
+	const isArchived = $derived(issue.status === 'archived');
+	const hasWorktree = $derived(
+		issue.worktree_state === 'active' || issue.worktree_state === 'pending',
+	);
 
 	const persistedExpanded = $derived(issueExpandedStates.current[issue.id] ?? false);
 	const expanded = $derived(
 		forceExpanded ?? (issue.worktree_state === 'pending' || persistedExpanded),
 	);
 
-	function toggleExpanded() {
-		const current = issueExpandedStates.current;
-		issueExpandedStates.current = {
-			...current,
-			[issue.id]: !persistedExpanded,
-		};
-	}
-
-	let showOverflow = $state(false);
-	let showPrioritySubmenu = $state(false);
-
-	const color = $derived(issue.color ?? '#525252');
-	const isArchived = $derived(issue.status === 'archived');
-	const isStandalone = $derived(issue.github_issue_url === null);
-
 	let badgeContainerWidth = $state(0);
-	const compactBadges = $derived(badgeContainerWidth < 300);
+	const compactBadges = $derived(badgeContainerWidth < 240);
 
 	const worktreeBadge = $derived.by(() => {
 		switch (issue.worktree_state) {
@@ -103,353 +88,297 @@
 		}
 	});
 
-	const priorityBorderClass = $derived(getPriorityBorderClass(issue.priority, prioritiesEnabled));
-
 	const priorityBadgeClass = $derived(
 		issue.priority !== null ? (PRIORITY_BADGE_CLASSES[issue.priority] ?? null) : null,
 	);
 
-	function closeOverflow() {
-		showOverflow = false;
-		showPrioritySubmenu = false;
+	const cardStateClass = $derived.by(() => {
+		if (isArchived) {
+			return CARD_STATE_CLASSES.archived;
+		}
+		if (isBatchSelected) {
+			return CARD_STATE_CLASSES.selected;
+		}
+		if (isActive) {
+			return CARD_STATE_CLASSES.active;
+		}
+		if (isSelectionReady) {
+			return CARD_STATE_CLASSES.selectionReady;
+		}
+		return '';
+	});
+
+	const quickActionButtonClass = $derived(
+		isLightHeader
+			? 'hover:bg-black/10 text-black/60 hover:text-black/90'
+			: 'hover:bg-white/12 text-white/60 hover:text-white/90',
+	);
+
+	const priorityChipClass = $derived(
+		isLightHeader ? 'bg-white/22 text-black/80' : 'bg-black/18 text-inherit',
+	);
+
+	function handleCardClick(event: MouseEvent) {
+		if (onCardClick) {
+			onCardClick(event);
+		}
 	}
 
-	function handleColorSelect(newColor: string) {
-		if (onChangeColor && newColor) {
-			onChangeColor(issue.id, newColor);
+	function handleQuickAction(event: MouseEvent, action: string) {
+		event.stopPropagation();
+		if (!hasWorktree) {
+			return;
+		}
+		if (onExecuteAction) {
+			onExecuteAction(action, issue.id);
 		}
 	}
 </script>
 
 <IssueCardTooltip {issue}>
+	<!-- svelte-ignore a11y_click_events_have_key_events -->
+	<!-- svelte-ignore a11y_no_static_element_interactions -->
 	<div
-		class="group grid rounded border border-l-[3px] border-border transition-colors {priorityBorderClass} {isArchived
+		class="group relative overflow-hidden rounded-lg border border-border shadow-sm transition-all duration-150 {cardStateClass} {isArchived
 			? ''
-			: 'hover:border-input'}"
-		style="grid-template-columns: 92px 1fr; {isArchived
-			? 'filter: grayscale(0.8) opacity(0.7)'
-			: ''}"
-		class:ml-6={indented}
+			: 'hover:border-[color-mix(in_oklch,var(--ic)_35%,var(--border-strong))] hover:shadow-md hover:bg-[color-mix(in_oklch,var(--ic)_6%,var(--surface))]'}"
+		style="
+
+--ic: {color};
+
+ background: var(--surface);"
+		onclick={handleCardClick}
 	>
-		{#if indented}
-			<div class="relative -ml-6 w-6 shrink-0" style="grid-column: 1 / -1; grid-row: 1;">
+		<!-- Header band -->
+		<div
+			class="flex min-h-8 items-center justify-between gap-2.5 px-3 py-1.5"
+			style="background-color: {color}; color: {headerTextColor};"
+		>
+			<div class="flex min-w-0 flex-1 items-baseline gap-1.5">
+				<span class="shrink-0 font-mono text-[11px] font-semibold opacity-72">
+					#{issue.github_issue_number ?? '—'}
+				</span>
+				{#if issue.github_issue_url}
+					<!-- eslint-disable svelte/no-navigation-without-resolve -- external GitHub link -->
+					<a
+						href={issue.github_issue_url}
+						target="_blank"
+						rel="noopener noreferrer"
+						class="min-w-0 truncate text-[13.5px] font-semibold leading-snug hover:underline hover:underline-offset-2"
+						style="color: inherit;"
+						onclick={(event) => event.stopPropagation()}
+					>
+						{issue.name}
+					</a>
+					<!-- eslint-enable svelte/no-navigation-without-resolve -->
+				{:else}
+					<span class="min-w-0 truncate text-[13.5px] font-semibold leading-snug">
+						{issue.name}
+					</span>
+				{/if}
+			</div>
+
+			<div class="flex shrink-0 items-center gap-1.5">
+				{#if childCount > 0}
+					<span class="flex items-center gap-1 font-mono text-[10px] opacity-72">
+						<LayersIcon size={10} />
+						{childCount}
+					</span>
+				{/if}
+
+				{#if priorityBadgeClass && prioritiesEnabled && issue.priority !== 'medium'}
+					<span
+						class="inline-flex items-center gap-1 rounded px-1.5 py-0.5 font-mono text-[9px] font-bold uppercase leading-none tracking-wide {priorityChipClass}"
+					>
+						{issue.priority}
+					</span>
+				{/if}
+
+				<!-- Quick-action buttons -->
+				<div class="ml-0.5 flex items-center gap-0.5">
+					<button
+						class="inline-flex size-5 items-center justify-center rounded border-none bg-transparent p-0 transition-all {quickActionButtonClass}"
+						style:opacity={hasWorktree ? 0.6 : 0.35}
+						style:pointer-events={hasWorktree ? 'auto' : 'none'}
+						title="Open Folder"
+						onclick={(event) => handleQuickAction(event, 'open-folder')}
+					>
+						<FolderOpenIcon size={12} />
+					</button>
+					<button
+						class="inline-flex size-5 items-center justify-center rounded border-none bg-transparent p-0 transition-all {quickActionButtonClass}"
+						style:opacity={hasWorktree ? 0.6 : 0.35}
+						style:pointer-events={hasWorktree ? 'auto' : 'none'}
+						title="Open Terminal"
+						onclick={(event) => handleQuickAction(event, 'open-terminal')}
+					>
+						<TerminalIcon size={12} />
+					</button>
+					<button
+						class="inline-flex size-5 items-center justify-center rounded border-none bg-transparent p-0 transition-all {quickActionButtonClass}"
+						style:opacity={hasWorktree ? 0.6 : 0.35}
+						style:pointer-events={hasWorktree ? 'auto' : 'none'}
+						title="Open Editor"
+						onclick={(event) => handleQuickAction(event, 'open-editor')}
+					>
+						<CodeIcon size={12} />
+					</button>
+				</div>
+			</div>
+		</div>
+
+		<!-- Body: tree thumbnail | info -->
+		<div class="grid items-start gap-2.5 p-2.5 pr-3" style="grid-template-columns: 72px 1fr;">
+			<!-- Tree thumbnail placeholder -->
+			<div
+				class="relative flex size-[72px] shrink-0 items-end justify-center overflow-hidden rounded-[7px] border"
+				style="background: linear-gradient(180deg, color-mix(in oklch, {color} 18%, var(--surface-2, hsl(0 0% 12%))) 0%, color-mix(in oklch, {color} 5%, var(--surface-3, hsl(0 0% 10%))) 100%); border-color: color-mix(in oklch, {color} 20%, var(--border));"
+			>
+				{#if notificationDotColor}
+					<span
+						class="absolute top-1.5 right-1.5 size-[7px] animate-pulse rounded-full {notificationDotColor}"
+						title={m.issue_card_session_needs_attention()}
+					></span>
+				{/if}
+				<div class="mb-4 size-6 rounded-full bg-foreground/20"></div>
+			</div>
+
+			<!-- Info rows -->
+			<div class="flex min-w-0 flex-col gap-1">
+				<!-- Branch row -->
 				<div
-					class="absolute top-0 left-3 h-1/2 w-px bg-border"
-					class:h-full={!isLastChild}
-				></div>
-				<div class="absolute top-1/2 left-3 h-px w-3 bg-border"></div>
+					class="flex min-w-0 items-center gap-1.5 font-mono text-[11px] text-muted-foreground"
+				>
+					<GitBranchIcon size={10} class="shrink-0" />
+					{#if issue.branch_name}
+						<span class="min-w-0 flex-1 truncate text-foreground/60">
+							{issue.branch_name}
+						</span>
+					{:else}
+						<span class="text-foreground/35">no worktree</span>
+					{/if}
+					<WorktreeStateIcon worktreeState={issue.worktree_state} />
+				</div>
+
+				<!-- Status badges row -->
+				<div
+					class="flex flex-wrap items-center gap-1"
+					bind:clientWidth={badgeContainerWidth}
+				>
+					{#if cache?.github_issue_state}
+						<GitHubIssueBadge
+							state={cache.github_issue_state}
+							url={issue.github_issue_url}
+							issueNumber={issue.github_issue_number}
+							disabled={!ghAvailable}
+						/>
+					{/if}
+					{#if cache?.pr_state}
+						<PullRequestBadge
+							state={cache.pr_state}
+							url={cache.pr_url}
+							prNumber={cache.pr_number}
+							disabled={!ghAvailable}
+						/>
+					{/if}
+					{#if issue.branch_name !== null && !compactBadges}
+						<GitBadgeGroup
+							branchName={issue.branch_name}
+							gitStatus={cache ?? undefined}
+						/>
+					{/if}
+					{#if worktreeBadge}
+						<span
+							class="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs {worktreeBadge.class}"
+						>
+							{#if issue.worktree_state === 'pending'}
+								<span
+									class="inline-block size-3 animate-spin rounded-full border-2 border-current border-t-transparent"
+								></span>
+							{/if}
+							{worktreeBadge.label}
+						</span>
+					{/if}
+				</div>
+
+				<!-- Labels row -->
+				{#if issue.labels.length > 0}
+					<div class="flex flex-wrap items-center gap-1">
+						{#each issue.labels as label (label.name)}
+							<span
+								class="inline-block rounded-full px-1.5 py-px text-[10px] font-medium leading-3"
+								style="background-color: {label.color}33; color: {label.color}; border: 1px solid {label.color}44;"
+								title={label.name}
+							>
+								{label.name}
+							</span>
+						{/each}
+					</div>
+				{/if}
+			</div>
+		</div>
+
+		<!-- Expanded detail section -->
+		{#if expanded}
+			<div class="border-t border-border px-3 py-3 text-xs text-muted-foreground">
+				<div class="grid grid-cols-2 gap-2">
+					<div>
+						<span class="text-muted-foreground/60">{m.issue_card_status()}</span>
+						{issue.status}
+					</div>
+					<div>
+						<span class="text-muted-foreground/60">{m.issue_card_worktree_label()}</span
+						>
+						{issue.worktree_state}
+					</div>
+					{#if issue.priority}
+						<div>
+							<span class="text-muted-foreground/60"
+								>{m.issue_card_priority_label()}</span
+							>
+							{issue.priority}
+						</div>
+					{/if}
+					{#if issue.created_at}
+						<div>
+							<span class="text-muted-foreground/60">{m.issue_card_created()}</span>
+							{new Date(issue.created_at).toLocaleDateString()}
+						</div>
+					{/if}
+					{#if cache}
+						<div>
+							<span class="text-muted-foreground/60">{m.issue_card_synced()}</span>
+							<SyncStatusIndicator fetchedAt={cache.fetched_at} />
+						</div>
+					{/if}
+				</div>
+				{#if issue.worktree_state === 'pending' && progressLines.length > 0}
+					<WorktreeProgressIndicator lines={progressLines} />
+				{/if}
 			</div>
 		{/if}
 
-		<!-- Left: Colored thumbnail -->
-		<div
-			class="relative flex items-center justify-center rounded-l"
-			style="background-color: {color}"
-		>
-			{#if notificationDotColor}
-				<span
-					class="h-3 w-3 animate-pulse rounded-full {notificationDotColor}"
-					title={m.issue_card_session_needs_attention()}
-				></span>
-			{:else}
-				<div
-					class="h-2.5 w-2.5 rounded-full bg-foreground/30"
-					title={m.issue_card_session_idle()}
-				></div>
-			{/if}
-		</div>
-
-		<!-- Right: Content area -->
-		<div class="flex min-w-0 flex-col">
-			<!-- Title row -->
-			<div class="flex items-center gap-2 px-3 py-2">
-				<button
-					onclick={toggleExpanded}
-					class="text-xs text-muted-foreground transition-transform {expanded
-						? 'rotate-90'
-						: ''} hover:text-foreground"
-					title={expanded ? m.issue_card_collapse() : m.issue_card_expand()}
-				>
-					▸
-				</button>
-
-				<div class="min-w-0 flex-1">
-					<div class="flex items-center gap-1.5">
-						<span class="truncate text-sm font-medium">{issue.name}</span>
-						{#if priorityBadgeClass}
-							<span
-								class="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium leading-3 {priorityBadgeClass}"
-							>
-								{issue.priority}
-							</span>
-						{/if}
-					</div>
-				</div>
-
-				{#if childCount > 0}
-					<span class="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
-						{childCount > 1
-							? m.issue_card_children_count({ count: childCount })
-							: m.issue_card_child_count({ count: childCount })}
-					</span>
-				{/if}
-
-				{#if actions.length > 0 && onExecuteAction && !isArchived}
-					<div class="opacity-0 transition-opacity group-hover:opacity-100">
-						<ActionButtonGroup
-							{actions}
-							onExecute={(actionId) => onExecuteAction(actionId, issue.id)}
-						/>
-					</div>
-				{/if}
-
-				<!-- Overflow menu -->
-				<div class="relative">
-					<button
-						onclick={() => (showOverflow = !showOverflow)}
-						class="rounded p-1 text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground group-hover:opacity-100"
-					>
-						⋯
-					</button>
-
-					{#if showOverflow}
-						<div
-							class="absolute right-0 z-[var(--z-dropdown)] mt-1 min-w-35 rounded border border-border bg-popover py-1 shadow-lg"
-							use:clickOutside={closeOverflow}
-						>
-							<button
-								onclick={() => {
-									onEdit(issue);
-									closeOverflow();
-								}}
-								class="w-full px-3 py-1.5 text-left text-sm text-popover-foreground hover:bg-accent"
-							>
-								{m.issue_card_edit()}
-							</button>
-							{#if isStandalone && onRename}
-								<button
-									onclick={() => {
-										onRename(issue);
-										closeOverflow();
-									}}
-									class="w-full px-3 py-1.5 text-left text-sm text-popover-foreground hover:bg-accent"
-								>
-									{m.issue_card_rename()}
-								</button>
-							{/if}
-
-							<!-- Priority submenu -->
-							{#if !isArchived}
-								<div class="relative">
-									<button
-										onclick={() => (showPrioritySubmenu = !showPrioritySubmenu)}
-										class="flex w-full items-center justify-between px-3 py-1.5 text-left text-sm text-popover-foreground hover:bg-accent"
-									>
-										{m.issue_card_priority()}
-										<span class="text-xs text-muted-foreground">▸</span>
-									</button>
-									{#if showPrioritySubmenu}
-										<div
-											class="absolute top-0 left-full z-[var(--z-dropdown)] ml-1 min-w-28 rounded border border-border bg-popover py-1 shadow-lg"
-										>
-											{#each PRIORITY_OPTIONS as option (option.value)}
-												<button
-													onclick={() => {
-														onChangePriority(issue.id, option.value);
-														closeOverflow();
-													}}
-													class="w-full px-3 py-1.5 text-left text-sm hover:bg-accent {issue.priority ===
-													option.value
-														? 'font-medium text-foreground'
-														: 'text-popover-foreground'}"
-												>
-													{option.label()}
-												</button>
-											{/each}
-										</div>
-									{/if}
-								</div>
-							{/if}
-
-							<!-- Change Color -->
-							{#if !isArchived && onChangeColor}
-								<div class="flex items-center gap-2 px-3 py-1.5">
-									<span class="text-sm text-popover-foreground"
-										>{m.issue_card_change_color()}</span
-									>
-									<ColorPicker
-										selectedColor={issue.color ?? ''}
-										colors={paletteColors}
-										{usedColors}
-										{isDarkMode}
-										displayText="A"
-										side="left"
-										onSelect={handleColorSelect}
-									/>
-								</div>
-							{/if}
-
-							{#if onSetupWorktree && issue.branch_name !== null && (issue.worktree_state === 'none' || issue.worktree_state === 'failed')}
-								<button
-									onclick={() => {
-										onSetupWorktree(issue);
-										closeOverflow();
-									}}
-									class="w-full px-3 py-1.5 text-left text-sm text-green-400 hover:bg-accent"
-								>
-									{issue.worktree_state === 'failed'
-										? m.issue_card_retry_worktree()
-										: m.issue_card_add_worktree()}
-								</button>
-							{/if}
-							{#if onRemoveWorktree && issue.worktree_state === 'active'}
-								<button
-									onclick={() => {
-										onRemoveWorktree(issue);
-										closeOverflow();
-									}}
-									class="w-full px-3 py-1.5 text-left text-sm text-orange-400 hover:bg-accent"
-								>
-									{m.issue_card_remove_worktree()}
-								</button>
-							{/if}
-							{#if isArchived}
-								<button
-									onclick={() => {
-										onUnarchive(issue.id);
-										closeOverflow();
-									}}
-									class="w-full px-3 py-1.5 text-left text-sm text-popover-foreground hover:bg-accent"
-								>
-									{m.issue_card_unarchive()}
-								</button>
-							{:else}
-								<button
-									onclick={() => {
-										onArchive(issue);
-										closeOverflow();
-									}}
-									class="w-full px-3 py-1.5 text-left text-sm text-popover-foreground hover:bg-accent"
-								>
-									{m.issue_card_archive()}
-								</button>
-							{/if}
-							<button
-								onclick={() => {
-									onDelete(issue);
-									closeOverflow();
-								}}
-								class="w-full px-3 py-1.5 text-left text-sm text-destructive hover:bg-accent"
-							>
-								{m.issue_card_delete()}
-							</button>
-						</div>
-					{/if}
-				</div>
-			</div>
-
-			<!-- Info row: issue# + branch + worktree indicator -->
-			<div class="flex items-center gap-2 px-3 pb-1 text-xs text-muted-foreground">
-				{#if issue.github_issue_number}
-					<span>#{issue.github_issue_number}</span>
-				{/if}
-				{#if issue.branch_name}
-					<span class="truncate font-mono text-[10px]">{issue.branch_name}</span>
-				{/if}
-				<WorktreeStateIcon worktreeState={issue.worktree_state} />
-			</div>
-
-			<!-- Badge row -->
+		<!-- Hover actions (bottom-right corner) -->
+		{#if actions.length > 0 && onExecuteAction && !isArchived}
 			<div
-				class="flex flex-wrap items-center gap-1 px-3 pb-2"
-				bind:clientWidth={badgeContainerWidth}
+				class="pointer-events-none absolute bottom-2 right-2.5 flex items-center gap-1 opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100"
 			>
-				{#if cache?.github_issue_state}
-					<GitHubIssueBadge
-						state={cache.github_issue_state}
-						url={issue.github_issue_url}
-						issueNumber={issue.github_issue_number}
-						disabled={!ghAvailable}
-					/>
-				{/if}
-				{#if cache?.pr_state}
-					<PullRequestBadge
-						state={cache.pr_state}
-						url={cache.pr_url}
-						prNumber={cache.pr_number}
-						disabled={!ghAvailable}
-					/>
-				{/if}
-				{#if issue.branch_name !== null && !compactBadges}
-					<GitBadgeGroup branchName={issue.branch_name} gitStatus={cache ?? undefined} />
-				{/if}
-				{#if worktreeBadge}
-					<span
-						class="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs {worktreeBadge.class}"
+				<ActionButtonGroup
+					{actions}
+					onExecute={(actionId) => onExecuteAction(actionId, issue.id)}
+				/>
+				{#if onOverflowClick}
+					<button
+						onclick={(event) => {
+							event.stopPropagation();
+							onOverflowClick();
+						}}
+						class="inline-flex size-[22px] items-center justify-center rounded-[5px] border border-border bg-[var(--surface-2,hsl(0_0%_12%))] text-muted-foreground transition-colors hover:bg-[var(--surface-3,hsl(0_0%_14%))] hover:border-[var(--border-strong)]"
 					>
-						{#if issue.worktree_state === 'pending'}
-							<span
-								class="inline-block h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent"
-							></span>
-						{/if}
-						{worktreeBadge.label}
-					</span>
-				{/if}
-				{#if issue.labels.length > 0}
-					{#each issue.labels as label (label.name)}
-						<span
-							class="inline-block rounded-full px-1.5 py-px text-[10px] font-medium leading-3"
-							style="background-color: {label.color}33; color: {label.color}; border: 1px solid {label.color}44;"
-							title={label.name}
-						>
-							{label.name}
-						</span>
-					{/each}
+						<MoreHorizontalIcon size={10} />
+					</button>
 				{/if}
 			</div>
-
-			{#if expanded}
-				<div class="border-t border-border px-3 py-3 text-xs text-muted-foreground">
-					<div class="grid grid-cols-2 gap-2">
-						<div>
-							<span class="text-muted-foreground/60">{m.issue_card_status()}</span>
-							{issue.status}
-						</div>
-						<div>
-							<span class="text-muted-foreground/60"
-								>{m.issue_card_worktree_label()}</span
-							>
-							{issue.worktree_state}
-						</div>
-						{#if issue.priority}
-							<div>
-								<span class="text-muted-foreground/60"
-									>{m.issue_card_priority_label()}</span
-								>
-								{issue.priority}
-							</div>
-						{/if}
-						{#if issue.created_at}
-							<div>
-								<span class="text-muted-foreground/60"
-									>{m.issue_card_created()}</span
-								>
-								{new Date(issue.created_at).toLocaleDateString()}
-							</div>
-						{/if}
-						{#if cache}
-							<div>
-								<span class="text-muted-foreground/60">{m.issue_card_synced()}</span
-								>
-								<SyncStatusIndicator fetchedAt={cache.fetched_at} />
-							</div>
-						{/if}
-					</div>
-					{#if issue.worktree_state === 'pending' && progressLines.length > 0}
-						<WorktreeProgressIndicator lines={progressLines} />
-					{/if}
-				</div>
-			{/if}
-		</div>
+		{/if}
 	</div>
 </IssueCardTooltip>

--- a/src/lib/components/IssueCardContextMenu.svelte
+++ b/src/lib/components/IssueCardContextMenu.svelte
@@ -1,0 +1,166 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import * as ContextMenu from '$lib/components/ui/context-menu/index.js';
+	import ColorPicker from '$lib/components/color-picker/ColorPicker.svelte';
+	import type { Issue, IssueCardCallbacks } from '$lib/modules/issues';
+	import { PRIORITY_OPTIONS } from '$lib/components/issue_card_utils.js';
+	import CheckIcon from '@lucide/svelte/icons/check';
+	import EditIcon from '@lucide/svelte/icons/pencil';
+	import TagIcon from '@lucide/svelte/icons/tag';
+	import PriorityIcon from '@lucide/svelte/icons/bar-chart-2';
+	import PaletteIcon from '@lucide/svelte/icons/palette';
+	import ArchiveIcon from '@lucide/svelte/icons/archive';
+	import ArchiveRestoreIcon from '@lucide/svelte/icons/archive-restore';
+	import GitBranchIcon from '@lucide/svelte/icons/git-branch';
+	import GitBranchMinusIcon from '@lucide/svelte/icons/git-branch-minus';
+	import TrashIcon from '@lucide/svelte/icons/trash-2';
+	import SquareCheckIcon from '@lucide/svelte/icons/square-check';
+	import SquareIcon from '@lucide/svelte/icons/square';
+
+	// fallow-ignore-next-line code-duplication
+	interface Props extends IssueCardCallbacks {
+		issue: Issue;
+		isBatchSelected: boolean;
+		paletteColors?: string[];
+		usedColors?: string[];
+		isDarkMode?: boolean;
+		onToggleSelect: () => void;
+		children: Snippet;
+	}
+
+	let {
+		issue,
+		isBatchSelected,
+		paletteColors = [],
+		usedColors = [],
+		isDarkMode = false,
+		onToggleSelect,
+		onArchive,
+		onUnarchive,
+		onEdit,
+		onDelete,
+		onChangePriority,
+		onRename,
+		onSetupWorktree,
+		onRemoveWorktree,
+		onChangeColor,
+		children,
+	}: Props = $props();
+
+	const isArchived = $derived(issue.status === 'archived');
+	const isStandalone = $derived(issue.github_issue_url === null);
+	const hasWorktree = $derived(
+		issue.worktree_state !== 'none' && issue.worktree_state !== 'removed',
+	);
+
+	const selectLabel = $derived(isBatchSelected ? 'Deselect' : 'Select');
+</script>
+
+<ContextMenu.Root>
+	<ContextMenu.Trigger>
+		{@render children()}
+	</ContextMenu.Trigger>
+
+	<ContextMenu.Content>
+		<!-- Select / Deselect -->
+		<ContextMenu.Item onclick={onToggleSelect}>
+			{#if isBatchSelected}
+				<SquareCheckIcon class="size-4" />
+			{:else}
+				<SquareIcon class="size-4" />
+			{/if}
+			{selectLabel}
+		</ContextMenu.Item>
+
+		<ContextMenu.Separator />
+
+		<!-- Edit -->
+		<ContextMenu.Item onclick={() => onEdit(issue)}>
+			<EditIcon class="size-4" />
+			Edit
+		</ContextMenu.Item>
+
+		<!-- Rename — only for standalone issues (no GitHub URL) -->
+		{#if isStandalone && onRename}
+			<ContextMenu.Item onclick={() => onRename!(issue)}>
+				<TagIcon class="size-4" />
+				Rename
+			</ContextMenu.Item>
+		{/if}
+
+		<!-- Priority submenu -->
+		<ContextMenu.Sub>
+			<ContextMenu.SubTrigger>
+				<PriorityIcon class="size-4" />
+				Priority
+			</ContextMenu.SubTrigger>
+			<ContextMenu.SubContent>
+				{#each PRIORITY_OPTIONS as option (option.value)}
+					<ContextMenu.Item onclick={() => onChangePriority(issue.id, option.value)}>
+						{#if issue.priority === option.value}
+							<CheckIcon class="size-4" />
+						{:else}
+							<span class="size-4"></span>
+						{/if}
+						{option.label()}
+					</ContextMenu.Item>
+				{/each}
+			</ContextMenu.SubContent>
+		</ContextMenu.Sub>
+
+		<!-- Change Color — inline ColorPicker -->
+		{#if onChangeColor}
+			<ContextMenu.Item class="gap-2" onSelect={(event) => event.preventDefault()}>
+				<PaletteIcon class="size-4" />
+				<span>Change Color</span>
+				<span class="ml-auto">
+					<ColorPicker
+						selectedColor={issue.color ?? '#000000'}
+						colors={paletteColors}
+						{usedColors}
+						{isDarkMode}
+						side="right"
+						portalDisabled={false}
+						onSelect={(color) => onChangeColor!(issue.id, color)}
+					/>
+				</span>
+			</ContextMenu.Item>
+		{/if}
+
+		<ContextMenu.Separator />
+
+		<!-- Setup / Remove Worktree -->
+		{#if hasWorktree}
+			{#if onRemoveWorktree}
+				<ContextMenu.Item onclick={() => onRemoveWorktree!(issue)}>
+					<GitBranchMinusIcon class="size-4" />
+					Remove Worktree
+				</ContextMenu.Item>
+			{/if}
+		{:else if onSetupWorktree}
+			<ContextMenu.Item onclick={() => onSetupWorktree!(issue)}>
+				<GitBranchIcon class="size-4" />
+				Setup Worktree
+			</ContextMenu.Item>
+		{/if}
+
+		<!-- Archive / Unarchive -->
+		{#if isArchived}
+			<ContextMenu.Item onclick={() => onUnarchive(issue.id)}>
+				<ArchiveRestoreIcon class="size-4" />
+				Unarchive
+			</ContextMenu.Item>
+		{:else}
+			<ContextMenu.Item onclick={() => onArchive(issue)}>
+				<ArchiveIcon class="size-4" />
+				Archive
+			</ContextMenu.Item>
+		{/if}
+
+		<!-- Delete — destructive -->
+		<ContextMenu.Item variant="destructive" onclick={() => onDelete(issue)}>
+			<TrashIcon class="size-4" />
+			Delete
+		</ContextMenu.Item>
+	</ContextMenu.Content>
+</ContextMenu.Root>

--- a/src/lib/components/IssueCardList.svelte
+++ b/src/lib/components/IssueCardList.svelte
@@ -1,9 +1,14 @@
 <script lang="ts">
 	import type { Issue } from '$lib/modules/issues';
 	import type { Action, GitStatusCache } from '$lib/types/generated';
-	import type { IssueCardCallbacks } from '$lib/modules/issues';
+	import type { IssueCardCallbacks, IssuePriority } from '$lib/modules/issues';
+	import { useSelection } from '$lib/modules/board';
 	import IssueCard from './IssueCard.svelte';
+	import IssueCardContextMenu from './IssueCardContextMenu.svelte';
+	import BatchActionToolbar from './BatchActionToolbar.svelte';
+	import { computeSelectAllCheckboxState } from './batch_selection_utils.js';
 
+	// fallow-ignore-next-line code-duplication
 	interface Props extends IssueCardCallbacks {
 		parentIssues: Issue[];
 		archivedIssues: Issue[];
@@ -20,6 +25,11 @@
 		getChildren: (parentId: string) => Issue[];
 		getNotificationDotColor?: (issueId: string) => string | null;
 		getProgressLines?: (issueId: string) => readonly string[];
+		onBatchArchive?: (issueIds: string[]) => void;
+		onBatchUnarchive?: (issueIds: string[]) => void;
+		onBatchDelete?: (issueIds: string[]) => void;
+		onBatchChangePriority?: (issueIds: string[], priority: IssuePriority | null) => void;
+		onBatchPrune?: (issueIds: string[]) => void;
 	}
 
 	let {
@@ -48,69 +58,219 @@
 		onRemoveWorktree,
 		onExecuteAction,
 		onChangeColor,
+		onBatchArchive,
+		onBatchUnarchive,
+		onBatchDelete,
+		onBatchChangePriority,
+		onBatchPrune,
 	}: Props = $props();
+
+	const selection = useSelection();
+
+	const flatVisualOrder = $derived.by(() => {
+		const order: Issue[] = [];
+		for (const parent of parentIssues) {
+			order.push(parent);
+			if (isPortfolio) {
+				const children = getChildren(parent.id);
+				for (const child of children) {
+					order.push(child);
+				}
+			}
+		}
+		return order;
+	});
+
+	const flatIssueIds = $derived(flatVisualOrder.map((issue) => issue.id));
+
+	const selectedIssues = $derived(
+		flatVisualOrder.filter((issue) => selection.batchSelectedIssueIds.has(issue.id)),
+	);
+
+	const selectAllState = $derived(
+		computeSelectAllCheckboxState(selection.batchCount, flatVisualOrder.length),
+	);
+
+	let isModifierHeld = $state(false);
+
+	function handleCardClick(issue: Issue, event: MouseEvent) {
+		if (event.ctrlKey || event.metaKey) {
+			event.preventDefault();
+			selection.toggleBatchSelect(issue.id);
+			return;
+		}
+		if (event.shiftKey) {
+			event.preventDefault();
+			selection.batchRangeSelect(issue.id, flatIssueIds);
+			return;
+		}
+		selection.selectIssue(issue.id);
+	}
+
+	// fallow-ignore-next-line complexity
+	function handleKeydown(event: KeyboardEvent) {
+		if ((event.ctrlKey || event.metaKey) && event.key === 'a') {
+			event.preventDefault();
+			selection.batchSelectAll(flatIssueIds);
+			return;
+		}
+		if (event.key === 'Escape') {
+			event.preventDefault();
+			selection.batchDeselectAll();
+			return;
+		}
+		if (event.key === 'Control' || event.key === 'Meta' || event.key === 'Shift') {
+			isModifierHeld = true;
+		}
+	}
+
+	function handleKeyup(event: KeyboardEvent) {
+		if (event.key === 'Control' || event.key === 'Meta' || event.key === 'Shift') {
+			isModifierHeld = false;
+		}
+	}
+
+	function handleToggleSelect(issueId: string) {
+		selection.toggleBatchSelect(issueId);
+	}
+
+	function handleSelectAll() {
+		selection.batchSelectAll(flatIssueIds);
+	}
+
+	function handleDeselectAll() {
+		selection.batchDeselectAll();
+	}
+
+	function handleBatchArchive() {
+		const ids = selectedIssues
+			.filter((issue) => issue.status === 'active')
+			.map((issue) => issue.id);
+		if (onBatchArchive) {
+			onBatchArchive(ids);
+		} else {
+			for (const issue of selectedIssues.filter((i) => i.status === 'active')) {
+				onArchive(issue);
+			}
+		}
+		selection.removeBatchItems(ids);
+	}
+
+	function handleBatchUnarchive() {
+		const ids = selectedIssues
+			.filter((issue) => issue.status === 'archived')
+			.map((issue) => issue.id);
+		if (onBatchUnarchive) {
+			onBatchUnarchive(ids);
+		} else {
+			for (const id of ids) {
+				onUnarchive(id);
+			}
+		}
+	}
+
+	function handleBatchDelete() {
+		const ids = selectedIssues.map((issue) => issue.id);
+		if (onBatchDelete) {
+			onBatchDelete(ids);
+		} else {
+			for (const issue of selectedIssues) {
+				onDelete(issue);
+			}
+		}
+		selection.removeBatchItems(ids);
+	}
+
+	function handleBatchChangePriority(priority: IssuePriority | null) {
+		const ids = selectedIssues.map((issue) => issue.id);
+		if (onBatchChangePriority) {
+			onBatchChangePriority(ids, priority);
+		} else {
+			for (const id of ids) {
+				onChangePriority(id, priority);
+			}
+		}
+	}
+
+	function handleBatchPrune() {
+		const ids = selectedIssues
+			.filter((issue) => issue.worktree_state === 'active')
+			.map((issue) => issue.id);
+		if (onBatchPrune) {
+			onBatchPrune(ids);
+		}
+	}
+
+	function getChildCount(issueId: string): number {
+		if (!isPortfolio) {
+			return 0;
+		}
+		return getChildren(issueId).length;
+	}
 </script>
 
-<div class="flex flex-col gap-2">
-	{#each parentIssues as issue (issue.id)}
-		{@const children = isPortfolio ? getChildren(issue.id) : []}
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div onkeydown={handleKeydown} onkeyup={handleKeyup} tabindex="-1" class="outline-none">
+	<!-- Batch action toolbar -->
+	{#if selection.batchCount > 0}
+		<div class="mb-3">
+			<BatchActionToolbar
+				selectedCount={selection.batchCount}
+				{selectedIssues}
+				selectAllCheckboxState={selectAllState}
+				onSelectAll={handleSelectAll}
+				onDeselectAll={handleDeselectAll}
+				onBatchArchive={handleBatchArchive}
+				onBatchUnarchive={handleBatchUnarchive}
+				onBatchDelete={handleBatchDelete}
+				onBatchChangePriority={handleBatchChangePriority}
+				onBatchPrune={handleBatchPrune}
+			/>
+		</div>
+	{/if}
 
-		<IssueCard
-			{issue}
-			{actions}
-			cache={cacheMap.get(issue.id)}
-			{ghAvailable}
-			notificationDotColor={getNotificationDotColor?.(issue.id) ?? null}
-			childCount={children.length}
-			{forceExpanded}
-			progressLines={getProgressLines?.(issue.id) ?? []}
-			{prioritiesEnabled}
-			{paletteColors}
-			{usedColors}
-			{isDarkMode}
-			{onArchive}
-			{onUnarchive}
-			{onEdit}
-			{onDelete}
-			{onChangePriority}
-			{onRename}
-			{onSetupWorktree}
-			{onRemoveWorktree}
-			{onExecuteAction}
-			{onChangeColor}
-		/>
-
-		{#if isPortfolio && children.length > 0}
-			{#each children as child, index (child.id)}
+	<!-- Two-column grid -->
+	<div class="grid grid-cols-2 gap-2">
+		{#each flatVisualOrder as issue (issue.id)}
+			<IssueCardContextMenu
+				{issue}
+				isBatchSelected={selection.batchSelectedIssueIds.has(issue.id)}
+				{paletteColors}
+				{usedColors}
+				{isDarkMode}
+				onToggleSelect={() => handleToggleSelect(issue.id)}
+				{onArchive}
+				{onUnarchive}
+				{onEdit}
+				{onDelete}
+				{onChangePriority}
+				{onRename}
+				{onSetupWorktree}
+				{onRemoveWorktree}
+				{onChangeColor}
+			>
 				<IssueCard
-					issue={child}
+					{issue}
 					{actions}
-					cache={cacheMap.get(child.id)}
+					cache={cacheMap.get(issue.id)}
 					{ghAvailable}
-					notificationDotColor={getNotificationDotColor?.(child.id) ?? null}
-					indented={true}
-					isLastChild={index === children.length - 1}
+					notificationDotColor={getNotificationDotColor?.(issue.id) ?? null}
+					childCount={getChildCount(issue.id)}
 					{forceExpanded}
-					progressLines={getProgressLines?.(child.id) ?? []}
+					progressLines={getProgressLines?.(issue.id) ?? []}
 					{prioritiesEnabled}
-					{paletteColors}
-					{usedColors}
-					{isDarkMode}
-					{onArchive}
-					{onUnarchive}
-					{onEdit}
-					{onDelete}
-					{onChangePriority}
-					{onRename}
-					{onSetupWorktree}
-					{onRemoveWorktree}
+					isActive={selection.selectedIssueId === issue.id}
+					isBatchSelected={selection.batchSelectedIssueIds.has(issue.id)}
+					isSelectionReady={isModifierHeld &&
+						!selection.batchSelectedIssueIds.has(issue.id)}
+					onCardClick={(event) => handleCardClick(issue, event)}
 					{onExecuteAction}
-					{onChangeColor}
 				/>
-			{/each}
-		{/if}
-	{/each}
+			</IssueCardContextMenu>
+		{/each}
+	</div>
 
+	<!-- Archived issues section -->
 	{#if showArchived && archivedIssues.length > 0}
 		<div class="mt-4 border-t border-border pt-4">
 			<h3
@@ -118,18 +278,30 @@
 			>
 				Archived ({archivedIssues.length})
 			</h3>
-			<div class="flex flex-col gap-2">
+			<div class="grid grid-cols-2 gap-2">
 				{#each archivedIssues as issue (issue.id)}
-					<IssueCard
+					<IssueCardContextMenu
 						{issue}
-						cache={cacheMap.get(issue.id)}
-						{ghAvailable}
+						isBatchSelected={selection.batchSelectedIssueIds.has(issue.id)}
+						{paletteColors}
+						{usedColors}
+						{isDarkMode}
+						onToggleSelect={() => handleToggleSelect(issue.id)}
 						{onArchive}
 						{onUnarchive}
 						{onEdit}
 						{onDelete}
 						{onChangePriority}
-					/>
+					>
+						<IssueCard
+							{issue}
+							cache={cacheMap.get(issue.id)}
+							{ghAvailable}
+							isActive={selection.selectedIssueId === issue.id}
+							isBatchSelected={selection.batchSelectedIssueIds.has(issue.id)}
+							onCardClick={(event) => handleCardClick(issue, event)}
+						/>
+					</IssueCardContextMenu>
 				{/each}
 			</div>
 		</div>

--- a/src/lib/components/batch_selection_utils.test.ts
+++ b/src/lib/components/batch_selection_utils.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import {
+	computeRangeSelection,
+	computeSelectAllCheckboxState,
+	CARD_STATE_CLASSES,
+	BATCH_SELECTED_GLOW_COLOR,
+} from './batch_selection_utils.js';
+
+describe('computeRangeSelection', () => {
+	it('returns IDs between anchor and target inclusive when anchor comes first', () => {
+		const flatOrder = ['a', 'b', 'c', 'd', 'e'];
+		expect(computeRangeSelection('b', 'd', flatOrder)).toEqual(['b', 'c', 'd']);
+	});
+
+	it('returns IDs between target and anchor inclusive when anchor comes after target', () => {
+		const flatOrder = ['a', 'b', 'c', 'd', 'e'];
+		expect(computeRangeSelection('d', 'b', flatOrder)).toEqual(['b', 'c', 'd']);
+	});
+
+	it('returns single-element array when anchor equals target', () => {
+		const flatOrder = ['a', 'b', 'c'];
+		expect(computeRangeSelection('b', 'b', flatOrder)).toEqual(['b']);
+	});
+
+	it('returns [targetId] when anchor is not in flatOrder', () => {
+		const flatOrder = ['a', 'b', 'c'];
+		expect(computeRangeSelection('z', 'b', flatOrder)).toEqual(['b']);
+	});
+
+	it('returns [targetId] when target is not in flatOrder', () => {
+		const flatOrder = ['a', 'b', 'c'];
+		expect(computeRangeSelection('a', 'z', flatOrder)).toEqual(['z']);
+	});
+
+	it('returns [targetId] when neither ID is in flatOrder', () => {
+		const flatOrder = ['a', 'b', 'c'];
+		expect(computeRangeSelection('x', 'z', flatOrder)).toEqual(['z']);
+	});
+
+	it('returns [targetId] when flatOrder is empty', () => {
+		expect(computeRangeSelection('a', 'b', [])).toEqual(['b']);
+	});
+
+	it('returns full range when anchor is first and target is last', () => {
+		const flatOrder = ['a', 'b', 'c'];
+		expect(computeRangeSelection('a', 'c', flatOrder)).toEqual(['a', 'b', 'c']);
+	});
+
+	it('returns full range when anchor is last and target is first', () => {
+		const flatOrder = ['a', 'b', 'c'];
+		expect(computeRangeSelection('c', 'a', flatOrder)).toEqual(['a', 'b', 'c']);
+	});
+});
+
+describe('computeSelectAllCheckboxState', () => {
+	it("returns 'all' when selectedCount equals totalCount and totalCount > 0", () => {
+		expect(computeSelectAllCheckboxState(5, 5)).toBe('all');
+	});
+
+	it("returns 'some' when selectedCount is between 0 and totalCount", () => {
+		expect(computeSelectAllCheckboxState(3, 5)).toBe('some');
+	});
+
+	it("returns 'some' when selectedCount is 1 out of many", () => {
+		expect(computeSelectAllCheckboxState(1, 10)).toBe('some');
+	});
+
+	it("returns 'none' when selectedCount is 0", () => {
+		expect(computeSelectAllCheckboxState(0, 5)).toBe('none');
+	});
+
+	it("returns 'none' when totalCount is 0", () => {
+		expect(computeSelectAllCheckboxState(0, 0)).toBe('none');
+	});
+
+	it("returns 'all' when both counts are 1", () => {
+		expect(computeSelectAllCheckboxState(1, 1)).toBe('all');
+	});
+});
+
+describe('CARD_STATE_CLASSES', () => {
+	it('has all expected state keys', () => {
+		const expectedKeys = [
+			'active',
+			'selected',
+			'selectionReady',
+			'dragging',
+			'loading',
+			'archived',
+			'error',
+			'disabled',
+		];
+		expect(Object.keys(CARD_STATE_CLASSES).sort()).toEqual(expectedKeys.sort());
+	});
+
+	it('has non-empty string values for every key', () => {
+		for (const value of Object.values(CARD_STATE_CLASSES)) {
+			expect(typeof value).toBe('string');
+			expect(value.length).toBeGreaterThan(0);
+		}
+	});
+});
+
+describe('BATCH_SELECTED_GLOW_COLOR', () => {
+	it('is a hex color string', () => {
+		expect(BATCH_SELECTED_GLOW_COLOR).toMatch(/^#[0-9a-fA-F]{6}$/);
+	});
+
+	it('equals #ec4899', () => {
+		expect(BATCH_SELECTED_GLOW_COLOR).toBe('#ec4899');
+	});
+});

--- a/src/lib/components/batch_selection_utils.ts
+++ b/src/lib/components/batch_selection_utils.ts
@@ -1,0 +1,58 @@
+/** @public */
+export type SelectAllCheckboxState = 'all' | 'some' | 'none';
+
+/**
+ * Compute the range of issue IDs between anchor and target in a flat visual order.
+ * Always returns IDs in forward (array) order regardless of anchor/target positions.
+ * Falls back to [targetId] if either ID is missing from the order array.
+ */
+export function computeRangeSelection(
+	anchorId: string,
+	targetId: string,
+	flatOrder: readonly string[],
+): string[] {
+	const anchorIndex = flatOrder.indexOf(anchorId);
+	const targetIndex = flatOrder.indexOf(targetId);
+
+	if (anchorIndex === -1 || targetIndex === -1) {
+		return [targetId];
+	}
+
+	const startIndex = Math.min(anchorIndex, targetIndex);
+	const endIndex = Math.max(anchorIndex, targetIndex);
+
+	return flatOrder.slice(startIndex, endIndex + 1);
+}
+
+/**
+ * Compute the select-all checkbox state based on selected vs total count.
+ */
+export function computeSelectAllCheckboxState(
+	selectedCount: number,
+	totalCount: number,
+): SelectAllCheckboxState {
+	if (totalCount === 0) {
+		return 'none';
+	}
+	if (selectedCount === totalCount) {
+		return 'all';
+	}
+	if (selectedCount > 0) {
+		return 'some';
+	}
+	return 'none';
+}
+
+export const CARD_STATE_CLASSES = {
+	active: 'ring-2 ring-ring shadow-[0_0_12px_color-mix(in_oklch,var(--ring)_25%,transparent)]',
+	selected: 'ring-2 ring-primary bg-[color-mix(in_oklch,var(--primary)_4%,var(--surface))]',
+	selectionReady:
+		'ring-1 ring-[#c084fc] shadow-md bg-[color-mix(in_oklch,oklch(0.700_0.200_300)_4%,var(--surface))]',
+	dragging: 'rotate-[-1.5deg] scale-[1.02] shadow-lg opacity-92',
+	loading: 'pointer-events-none',
+	archived: 'opacity-70 grayscale-[0.8]',
+	error: 'border-l-[3px] border-l-destructive',
+	disabled: 'opacity-42 pointer-events-none',
+} as const;
+
+export const BATCH_SELECTED_GLOW_COLOR = '#ec4899';

--- a/src/lib/components/ui/context-menu/context-menu-checkbox-item.svelte
+++ b/src/lib/components/ui/context-menu/context-menu-checkbox-item.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+	import { ContextMenu as ContextMenuPrimitive } from 'bits-ui';
+	import { cn, type WithoutChildrenOrChild } from '$lib/utils.js';
+	import type { Snippet } from 'svelte';
+	import CheckIcon from '@lucide/svelte/icons/check';
+
+	let {
+		ref = $bindable(null),
+		checked = $bindable(false),
+		indeterminate = $bindable(false),
+		class: className,
+		inset,
+		children: childrenProp,
+		...restProps
+	}: WithoutChildrenOrChild<ContextMenuPrimitive.CheckboxItemProps> & {
+		inset?: boolean;
+		children?: Snippet;
+	} = $props();
+</script>
+
+<ContextMenuPrimitive.CheckboxItem
+	bind:ref
+	bind:checked
+	bind:indeterminate
+	data-slot="context-menu-checkbox-item"
+	data-inset={inset}
+	class={cn(
+		"focus:bg-accent focus:text-accent-foreground gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm data-inset:pl-8 [&_svg:not([class*='size-'])]:size-4 relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		className,
+	)}
+	{...restProps}
+>
+	{#snippet children({ checked })}
+		<span class="absolute right-2 pointer-events-none">
+			{#if checked}
+				<CheckIcon />
+			{/if}
+		</span>
+		{@render childrenProp?.()}
+	{/snippet}
+</ContextMenuPrimitive.CheckboxItem>

--- a/src/lib/components/ui/context-menu/context-menu-content.svelte
+++ b/src/lib/components/ui/context-menu/context-menu-content.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+	import { ContextMenu as ContextMenuPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+	import ContextMenuPortal from './context-menu-portal.svelte';
+	import type { ComponentProps } from 'svelte';
+	import type { WithoutChildrenOrChild } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		portalProps,
+		class: className,
+		...restProps
+	}: ContextMenuPrimitive.ContentProps & {
+		portalProps?: WithoutChildrenOrChild<ComponentProps<typeof ContextMenuPortal>>;
+	} = $props();
+</script>
+
+<ContextMenuPortal {...portalProps}>
+	<ContextMenuPrimitive.Content
+		bind:ref
+		data-slot="context-menu-content"
+		class={cn(
+			'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground min-w-36 rounded-md p-1 shadow-md ring-1 duration-100 z-50 overflow-x-hidden overflow-y-auto outline-none',
+			className,
+		)}
+		{...restProps}
+	/>
+</ContextMenuPortal>

--- a/src/lib/components/ui/context-menu/context-menu-group-heading.svelte
+++ b/src/lib/components/ui/context-menu/context-menu-group-heading.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import { ContextMenu as ContextMenuPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		inset,
+		...restProps
+	}: ContextMenuPrimitive.GroupHeadingProps & {
+		inset?: boolean;
+	} = $props();
+</script>
+
+<ContextMenuPrimitive.GroupHeading
+	bind:ref
+	data-slot="context-menu-group-heading"
+	data-inset={inset}
+	class={cn('text-foreground px-2 py-1.5 text-sm font-medium data-inset:ps-8', className)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/context-menu/context-menu-group.svelte
+++ b/src/lib/components/ui/context-menu/context-menu-group.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { ContextMenu as ContextMenuPrimitive } from 'bits-ui';
+
+	let { ref = $bindable(null), ...restProps }: ContextMenuPrimitive.GroupProps = $props();
+</script>
+
+<ContextMenuPrimitive.Group bind:ref data-slot="context-menu-group" {...restProps} />

--- a/src/lib/components/ui/context-menu/context-menu-item.svelte
+++ b/src/lib/components/ui/context-menu/context-menu-item.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import { ContextMenu as ContextMenuPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		inset,
+		variant = 'default',
+		...restProps
+	}: ContextMenuPrimitive.ItemProps & {
+		inset?: boolean;
+		variant?: 'default' | 'destructive';
+	} = $props();
+</script>
+
+<ContextMenuPrimitive.Item
+	bind:ref
+	data-slot="context-menu-item"
+	data-inset={inset}
+	data-variant={variant}
+	class={cn(
+		"focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:text-destructive focus:*:[svg]:text-accent-foreground gap-2 rounded-sm px-2 py-1.5 text-sm data-inset:pl-8 [&_svg:not([class*='size-'])]:size-4 group/context-menu-item relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		className,
+	)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/context-menu/context-menu-label.svelte
+++ b/src/lib/components/ui/context-menu/context-menu-label.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from '$lib/utils.js';
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		inset,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> & {
+		inset?: boolean;
+	} = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="context-menu-label"
+	data-inset={inset}
+	class={cn(
+		'text-muted-foreground px-2 py-1.5 text-xs font-medium data-inset:pl-8 data-inset:pl-8',
+		className,
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/context-menu/context-menu-portal.svelte
+++ b/src/lib/components/ui/context-menu/context-menu-portal.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { ContextMenu as ContextMenuPrimitive } from 'bits-ui';
+
+	let { ...restProps }: ContextMenuPrimitive.PortalProps = $props();
+</script>
+
+<ContextMenuPrimitive.Portal {...restProps} />

--- a/src/lib/components/ui/context-menu/context-menu-radio-group.svelte
+++ b/src/lib/components/ui/context-menu/context-menu-radio-group.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import { ContextMenu as ContextMenuPrimitive } from 'bits-ui';
+
+	let {
+		ref = $bindable(null),
+		value = $bindable(''),
+		...restProps
+	}: ContextMenuPrimitive.RadioGroupProps = $props();
+</script>
+
+<ContextMenuPrimitive.RadioGroup
+	bind:ref
+	bind:value
+	data-slot="context-menu-radio-group"
+	{...restProps}
+/>

--- a/src/lib/components/ui/context-menu/context-menu-radio-item.svelte
+++ b/src/lib/components/ui/context-menu/context-menu-radio-item.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import { ContextMenu as ContextMenuPrimitive } from 'bits-ui';
+	import { cn, type WithoutChild } from '$lib/utils.js';
+	import CheckIcon from '@lucide/svelte/icons/check';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		inset,
+		children: childrenProp,
+		...restProps
+	}: WithoutChild<ContextMenuPrimitive.RadioItemProps> & {
+		inset?: boolean;
+		children?: Snippet<[{ checked: boolean }]>;
+	} = $props();
+</script>
+
+<ContextMenuPrimitive.RadioItem
+	bind:ref
+	data-slot="context-menu-radio-item"
+	data-inset={inset}
+	class={cn(
+		"focus:bg-accent focus:text-accent-foreground gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm data-inset:pl-8 [&_svg:not([class*='size-'])]:size-4 relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		className,
+	)}
+	{...restProps}
+>
+	{#snippet children({ checked })}
+		<span class="absolute right-2 pointer-events-none">
+			{#if checked}
+				<CheckIcon />
+			{/if}
+		</span>
+		{@render childrenProp?.({ checked })}
+	{/snippet}
+</ContextMenuPrimitive.RadioItem>

--- a/src/lib/components/ui/context-menu/context-menu-separator.svelte
+++ b/src/lib/components/ui/context-menu/context-menu-separator.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { ContextMenu as ContextMenuPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: ContextMenuPrimitive.SeparatorProps = $props();
+</script>
+
+<ContextMenuPrimitive.Separator
+	bind:ref
+	data-slot="context-menu-separator"
+	class={cn('bg-border -mx-1 my-1 h-px', className)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/context-menu/context-menu-shortcut.svelte
+++ b/src/lib/components/ui/context-menu/context-menu-shortcut.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from '$lib/utils.js';
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLSpanElement>> = $props();
+</script>
+
+<span
+	bind:this={ref}
+	data-slot="context-menu-shortcut"
+	class={cn(
+		'text-muted-foreground group-focus/context-menu-item:text-accent-foreground ml-auto text-xs tracking-widest',
+		className,
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</span>

--- a/src/lib/components/ui/context-menu/context-menu-sub-content.svelte
+++ b/src/lib/components/ui/context-menu/context-menu-sub-content.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { ContextMenu as ContextMenuPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: ContextMenuPrimitive.SubContentProps = $props();
+</script>
+
+<ContextMenuPrimitive.SubContent
+	bind:ref
+	data-slot="context-menu-sub-content"
+	class={cn(
+		'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 bg-popover text-popover-foreground min-w-32 rounded-md border p-1 shadow-lg duration-100',
+		className,
+	)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/context-menu/context-menu-sub-trigger.svelte
+++ b/src/lib/components/ui/context-menu/context-menu-sub-trigger.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import { ContextMenu as ContextMenuPrimitive } from 'bits-ui';
+	import { cn, type WithoutChild } from '$lib/utils.js';
+	import ChevronRightIcon from '@lucide/svelte/icons/chevron-right';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		inset,
+		children,
+		...restProps
+	}: WithoutChild<ContextMenuPrimitive.SubTriggerProps> & {
+		inset?: boolean;
+		children?: Snippet;
+	} = $props();
+</script>
+
+<ContextMenuPrimitive.SubTrigger
+	bind:ref
+	data-slot="context-menu-sub-trigger"
+	data-inset={inset}
+	class={cn(
+		"focus:bg-accent focus:text-accent-foreground data-open:bg-accent data-open:text-accent-foreground rounded-sm px-2 py-1.5 text-sm data-inset:pl-8 [&_svg:not([class*='size-'])]:size-4 flex cursor-default items-center outline-hidden select-none data-inset:ps-8 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		className,
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+	<ChevronRightIcon class="ml-auto" />
+</ContextMenuPrimitive.SubTrigger>

--- a/src/lib/components/ui/context-menu/context-menu-sub.svelte
+++ b/src/lib/components/ui/context-menu/context-menu-sub.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { ContextMenu as ContextMenuPrimitive } from 'bits-ui';
+
+	let { open = $bindable(false), ...restProps }: ContextMenuPrimitive.SubProps = $props();
+</script>
+
+<ContextMenuPrimitive.Sub bind:open {...restProps} />

--- a/src/lib/components/ui/context-menu/context-menu-trigger.svelte
+++ b/src/lib/components/ui/context-menu/context-menu-trigger.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { ContextMenu as ContextMenuPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: ContextMenuPrimitive.TriggerProps = $props();
+</script>
+
+<ContextMenuPrimitive.Trigger
+	bind:ref
+	data-slot="context-menu-trigger"
+	class={cn('cn-context-menu-trigger select-none', className)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/context-menu/context-menu.svelte
+++ b/src/lib/components/ui/context-menu/context-menu.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { ContextMenu as ContextMenuPrimitive } from 'bits-ui';
+
+	let { open = $bindable(false), ...restProps }: ContextMenuPrimitive.RootProps = $props();
+</script>
+
+<ContextMenuPrimitive.Root bind:open {...restProps} />

--- a/src/lib/components/ui/context-menu/index.ts
+++ b/src/lib/components/ui/context-menu/index.ts
@@ -1,0 +1,52 @@
+import Root from './context-menu.svelte';
+import Sub from './context-menu-sub.svelte';
+import Portal from './context-menu-portal.svelte';
+import Trigger from './context-menu-trigger.svelte';
+import Group from './context-menu-group.svelte';
+import RadioGroup from './context-menu-radio-group.svelte';
+import Item from './context-menu-item.svelte';
+import GroupHeading from './context-menu-group-heading.svelte';
+import Content from './context-menu-content.svelte';
+import Shortcut from './context-menu-shortcut.svelte';
+import RadioItem from './context-menu-radio-item.svelte';
+import Separator from './context-menu-separator.svelte';
+import SubContent from './context-menu-sub-content.svelte';
+import SubTrigger from './context-menu-sub-trigger.svelte';
+import CheckboxItem from './context-menu-checkbox-item.svelte';
+import Label from './context-menu-label.svelte';
+
+export {
+	Root,
+	Sub,
+	Portal,
+	Item,
+	GroupHeading,
+	Label,
+	Group,
+	Trigger,
+	Content,
+	Shortcut,
+	Separator,
+	RadioItem,
+	SubContent,
+	SubTrigger,
+	RadioGroup,
+	CheckboxItem,
+	//
+	Root as ContextMenu,
+	Sub as ContextMenuSub,
+	Portal as ContextMenuPortal,
+	Item as ContextMenuItem,
+	GroupHeading as ContextMenuGroupHeading,
+	Group as ContextMenuGroup,
+	Content as ContextMenuContent,
+	Trigger as ContextMenuTrigger,
+	Shortcut as ContextMenuShortcut,
+	RadioItem as ContextMenuRadioItem,
+	Separator as ContextMenuSeparator,
+	RadioGroup as ContextMenuRadioGroup,
+	SubContent as ContextMenuSubContent,
+	SubTrigger as ContextMenuSubTrigger,
+	CheckboxItem as ContextMenuCheckboxItem,
+	Label as ContextMenuLabel,
+};

--- a/src/lib/modules/board/selection.context.svelte.ts
+++ b/src/lib/modules/board/selection.context.svelte.ts
@@ -1,4 +1,5 @@
 import { createContext } from 'svelte';
+import { SvelteSet } from 'svelte/reactivity';
 import { StateRaw } from '$lib/reactivity/state.svelte.js';
 import { Persisted, stringSerde } from '$lib/reactivity/persisted.svelte.js';
 import { GLOW_COLORS } from '$lib/modules/visualization/constants.js';
@@ -26,6 +27,8 @@ function createSelectionContext() {
 	const activeTab = new StateRaw<BottomPanelTab | null>(null);
 	const prdIssueId = new StateRaw<string | null>(null);
 	const forestCollapsed = new StateRaw(false);
+	const batchSelectedIssueIds = new SvelteSet<string>();
+	const batchAnchorId = new StateRaw<string | null>(null);
 
 	const hoverGlowColor = new Persisted<string>({
 		key: 'grovekeeper_hover_glow_color',
@@ -57,6 +60,8 @@ function createSelectionContext() {
 				activeTab.current = BOTTOM_PANEL_TABS.issueDetail;
 			}
 		}
+		batchSelectedIssueIds.clear();
+		batchAnchorId.current = null;
 	}
 
 	function deselect() {
@@ -66,6 +71,54 @@ function createSelectionContext() {
 
 	function setActiveTab(tab: BottomPanelTab | null) {
 		activeTab.current = tab;
+		batchSelectedIssueIds.clear();
+		batchAnchorId.current = null;
+	}
+
+	function toggleBatchSelect(issueId: string) {
+		if (batchSelectedIssueIds.has(issueId)) {
+			batchSelectedIssueIds.delete(issueId);
+		} else {
+			batchSelectedIssueIds.add(issueId);
+		}
+		batchAnchorId.current = issueId;
+	}
+
+	function batchRangeSelect(targetId: string, flatOrder: readonly string[]) {
+		const anchorId = batchAnchorId.current;
+		if (anchorId === null) {
+			batchSelectedIssueIds.add(targetId);
+			batchAnchorId.current = targetId;
+			return;
+		}
+		const anchorIndex = flatOrder.indexOf(anchorId);
+		const targetIndex = flatOrder.indexOf(targetId);
+		if (anchorIndex === -1 || targetIndex === -1) {
+			batchSelectedIssueIds.add(targetId);
+			return;
+		}
+		const startIndex = Math.min(anchorIndex, targetIndex);
+		const endIndex = Math.max(anchorIndex, targetIndex);
+		for (let i = startIndex; i <= endIndex; i++) {
+			batchSelectedIssueIds.add(flatOrder[i]);
+		}
+	}
+
+	function batchSelectAll(issueIds: readonly string[]) {
+		for (const id of issueIds) {
+			batchSelectedIssueIds.add(id);
+		}
+	}
+
+	function batchDeselectAll() {
+		batchSelectedIssueIds.clear();
+		batchAnchorId.current = null;
+	}
+
+	function removeBatchItems(ids: readonly string[]) {
+		for (const id of ids) {
+			batchSelectedIssueIds.delete(id);
+		}
 	}
 
 	function setPrdIssueId(id: string | null) {
@@ -107,6 +160,13 @@ function createSelectionContext() {
 		get forestCollapsed() {
 			return forestCollapsed.current;
 		},
+		batchSelectedIssueIds: batchSelectedIssueIds as ReadonlySet<string>,
+		get batchCount() {
+			return batchSelectedIssueIds.size;
+		},
+		get batchAnchorId() {
+			return batchAnchorId.current;
+		},
 		hoverIssue,
 		unhover,
 		selectIssue,
@@ -114,5 +174,10 @@ function createSelectionContext() {
 		setActiveTab,
 		setPrdIssueId,
 		toggleForestCollapsed,
+		toggleBatchSelect,
+		batchRangeSelect,
+		batchSelectAll,
+		batchDeselectAll,
+		removeBatchItems,
 	};
 }

--- a/src/lib/modules/visualization/forest_interaction.test.ts
+++ b/src/lib/modules/visualization/forest_interaction.test.ts
@@ -9,6 +9,7 @@ import type { TreeContextMenuAction, ResolveGlowOverlayParams } from './index';
 
 const HOVER_COLOR = '#ffd700';
 const SELECT_COLOR = '#4a9eff';
+const BATCH_SELECTED_COLOR = '#ec4899';
 
 const STATE_ERRORED: OverlayConfig = {
 	glow: { enabled: true, color: '#ff4444', intensity: 4, pulse: true },
@@ -29,6 +30,8 @@ function createParams(overrides: Partial<ResolveGlowOverlayParams> = {}): Resolv
 		selectedIssueId: null,
 		hoverGlowColor: HOVER_COLOR,
 		selectedGlowColor: SELECT_COLOR,
+		batchSelectedIssueIds: new Set<string>(),
+		batchSelectedGlowColor: BATCH_SELECTED_COLOR,
 		...overrides,
 	};
 }
@@ -145,5 +148,73 @@ describe('resolveGlowOverlay', () => {
 		);
 		expect(result.glow.enabled).toBe(false);
 		expect(result).toEqual(STATE_DISABLED);
+	});
+
+	it('returns batch-selected glow when issueId is in batchSelectedIssueIds', () => {
+		const result = resolveGlowOverlay(
+			createParams({
+				issueId: 'issue-1',
+				hoveredIssueId: null,
+				selectedIssueId: null,
+				batchSelectedIssueIds: new Set(['issue-1', 'issue-2']),
+			}),
+		);
+		expect(result.glow).toEqual({
+			enabled: true,
+			color: BATCH_SELECTED_COLOR,
+			intensity: 3,
+			pulse: false,
+		});
+	});
+
+	it('hover takes priority over batch-selected', () => {
+		const result = resolveGlowOverlay(
+			createParams({
+				issueId: 'issue-1',
+				hoveredIssueId: 'issue-1',
+				selectedIssueId: null,
+				batchSelectedIssueIds: new Set(['issue-1']),
+			}),
+		);
+		expect(result.glow.color).toBe(HOVER_COLOR);
+	});
+
+	it('selected takes priority over batch-selected', () => {
+		const result = resolveGlowOverlay(
+			createParams({
+				issueId: 'issue-1',
+				hoveredIssueId: null,
+				selectedIssueId: 'issue-1',
+				batchSelectedIssueIds: new Set(['issue-1']),
+			}),
+		);
+		expect(result.glow.color).toBe(SELECT_COLOR);
+	});
+
+	it('batch-selected takes priority over state-driven overlay', () => {
+		const result = resolveGlowOverlay(
+			createParams({
+				stateOverlay: STATE_ERRORED,
+				issueId: 'issue-1',
+				hoveredIssueId: null,
+				selectedIssueId: null,
+				batchSelectedIssueIds: new Set(['issue-1']),
+			}),
+		);
+		expect(result.glow.color).toBe(BATCH_SELECTED_COLOR);
+		expect(result.glow.pulse).toBe(false);
+	});
+
+	it('returns state-driven when not hovered, not selected, not batch-selected', () => {
+		const result = resolveGlowOverlay(
+			createParams({
+				stateOverlay: STATE_ERRORED,
+				issueId: 'issue-1',
+				hoveredIssueId: null,
+				selectedIssueId: null,
+				batchSelectedIssueIds: new Set(['issue-99']),
+			}),
+		);
+		expect(result).toEqual(STATE_ERRORED);
 	});
 });

--- a/src/lib/modules/visualization/forest_interaction.ts
+++ b/src/lib/modules/visualization/forest_interaction.ts
@@ -7,12 +7,14 @@ export interface ResolveGlowOverlayParams {
 	readonly issueId: string;
 	readonly hoveredIssueId: string | null;
 	readonly selectedIssueId: string | null;
+	readonly batchSelectedIssueIds: ReadonlySet<string>;
 	readonly hoverGlowColor: string;
 	readonly selectedGlowColor: string;
+	readonly batchSelectedGlowColor: string;
 }
 
 export function resolveGlowOverlay(params: ResolveGlowOverlayParams): OverlayConfig {
-	// Priority: hover(1) > selected(2) > state-driven(3-6)
+	// Priority: hover(1) > selected(2) > batch-selected(3) > state-driven(4-6)
 	if (params.issueId === params.hoveredIssueId) {
 		return {
 			glow: {
@@ -28,6 +30,16 @@ export function resolveGlowOverlay(params: ResolveGlowOverlayParams): OverlayCon
 			glow: {
 				enabled: true,
 				color: params.selectedGlowColor,
+				intensity: INTERACTION_GLOW_INTENSITY,
+				pulse: false,
+			},
+		};
+	}
+	if (params.batchSelectedIssueIds.has(params.issueId)) {
+		return {
+			glow: {
+				enabled: true,
+				color: params.batchSelectedGlowColor,
 				intensity: INTERACTION_GLOW_INTENSITY,
 				pulse: false,
 			},

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -9,6 +9,8 @@ export type WithElementRef<T, E extends HTMLElement = HTMLElement> = T & {
 	ref?: E | null;
 };
 
+export type WithoutChild<T> = T extends { child?: unknown } ? Omit<T, 'child'> : T;
+
 export type WithoutChildren<T> = T extends { children?: unknown } ? Omit<T, 'children'> : T;
 
 export type WithoutChildrenOrChild<T> = T extends { children?: unknown; child?: unknown }


### PR DESCRIPTION
## Summary

- Redesigns IssueCard with Banner variant (vivid color header band, WCAG-contrast text, quick-action buttons, visual states)
- Adds two-column CSS grid layout with row-major order for issue card list
- Implements batch selection system (Ctrl+click, Shift+click, Ctrl+A, Escape) backed by SvelteSet context state
- Adds bits-ui ContextMenu with full action set (Select, Edit, Rename, Priority, Color, Worktree, Archive, Delete)
- Adds BatchActionToolbar with select-all checkbox, count badge, and batch actions
- Extends forest interaction to show hot-pink glow on batch-selected trees
- Adds `longPress` action (500ms) for future mobile/touch support
- Adds `batch_selection_utils` with range computation and tri-state checkbox helpers

Refs #173

## Test plan

- [ ] Verify two-column grid renders correctly at various panel widths
- [ ] Test Ctrl+click toggles batch selection (green ring, no checkbox)
- [ ] Test Shift+click range selects between anchor and target
- [ ] Test Ctrl+A selects all issues, Escape deselects
- [ ] Test right-click shows context menu with all actions
- [ ] Test batch toolbar appears with count and action buttons
- [ ] Test quick-action buttons disabled when no worktree assigned
- [ ] Test color header auto-switches text color (dark/light) based on WCAG luminance
- [ ] Verify forest trees glow hot-pink when batch-selected
- [ ] Test tab change clears batch selection