### PR TITLE
fix: wizard UX — keyboard routing, dynamic footer, name formatting, click-to-advance

### DIFF
--- a/.mpx/REQUIREMENTS.md
+++ b/.mpx/REQUIREMENTS.md
@@ -48,12 +48,15 @@ Developer who uses Claude Code (and other AI CLIs) for parallel task execution a
 ### Issue Creation
 
 - **Manual create:** Multi-step keyboard-driven wizard (modal at top of screen):
-    1. GitHub issue search (live, number-aware, arrow-key navigation)
-    2. Issue name entry (pre-filled from GitHub if selected)
-    3. Worktree yes/no (conditional)
-    4. Color selection (24-color palette, auto-rotation, custom input)
+    1. GitHub issue search (live, number-aware, arrow-key navigation). No preselection on open — Enter with no selection = Skip. Arrow nav fills search bar with selected issue title (display only, no search trigger). Clicking an issue = select + advance
+    2. Issue name entry (pre-filled from GitHub if selected). Name excludes issue number (displayed separately on card). Trailing special characters stripped
+    3. Worktree yes/no (conditional). Clicking Yes/No = select + advance
+    4. Color selection (24-color palette, auto-rotation, custom input). Clicking a swatch = select + advance (creates issue on last step)
     5. Worktree creation progress (if yes)
-    - Enter confirms, Escape cancels, Back navigates
+    - **Click-to-advance:** Clicking any selectable item confirms + advances to next step across all steps
+    - **Dynamic footer:** Back/Cancel buttons swap keyboard hints based on text input focus. Back shows Esc when input focused, Backspace when not. Cancel shows Esc only when no Back button or input not focused. Navigation hint (arrow Kbd labels + "Navigate" text) shown per step: ↑↓ on step 1, hidden on step 2, ←→ on step 3, ↑↓←→ on step 4
+    - **Arrow nav from any focus:** Arrow keys navigate items when any element in the modal is focused (not just text input). Exception: text input focused = arrows control cursor
+    - **Keyboard routing:** Enter confirms current step. Escape goes back when text input focused on non-first step, closes wizard otherwise. Backspace goes back when no text input focused
 - **Quick add (no worktree):** One-click from assigned GitHub issue. Auto-fills name, GitHub link, assigns next color.
 - **Quick add (with worktree):** One-click from assigned issue or GitHub trigger. Auto-fills everything, auto-detects base branch, runs setup-worktree.sh.
 - **From raw requirements:** Quick ideas widget appends to `.mpx/RAW_REQUIREMENTS.md`. Processing trigger runs `/mp-grill-requirements` to refine → create GitHub issue.

--- a/claude_design/design_briefs/ISSUE_CREATION_WIZARD.md
+++ b/claude_design/design_briefs/ISSUE_CREATION_WIZARD.md
@@ -31,13 +31,16 @@ The wizard is opened via `Ctrl+N` or the "+" button on the dashboard.
 - Arrow key navigation scrolls the selected issue into view
 - Each issue row shows: state icon (green circle-dot for OPEN, purple circle-check for CLOSED), `#number title`
 - "Skip — create without GitHub issue" link at the bottom
+- **No preselection on open** — search bar empty, no issue highlighted. Enter with no selection = Skip
+- **Arrow nav fills search bar** — when navigating with ArrowUp/Down, the selected issue's title and number appear in the search bar (display only, does NOT trigger a GitHub search). Typing after arrow selection clears the arrow-selected state and resumes normal search
+- **Clicking an issue** = select that issue + advance to step 2 (acts like confirming)
 
 **Keyboard**:
-- Arrow Up/Down: navigate the issue list
-- Enter: select highlighted issue and advance
+- Arrow Up/Down: navigate the issue list. First ArrowDown selects item 0, first ArrowUp selects last item. Works from **any focus within the modal** (not just the search input)
+- Enter: select highlighted issue and advance (or Skip if no selection)
 - Typing: filters the list
 
-**Footer buttons**: Cancel [Esc], Next [Enter]. No Back button (this is the first step). Next confirms the highlighted issue selection (or skips if no results).
+**Footer buttons**: Cancel [Esc], Next [Enter]. No Back button (this is the first step). Cancel always shows Esc hint (since no Back button competes for Escape). Navigation hint ↑↓ visible when navigation is active.
 
 **Decision (grilled 2026-05-04)**: The selected/highlighted issue row uses `bg-primary-soft` — a subtle green-tinted highlight from the Forest Moss palette (light: `oklch(0.92 0.03 135)` sage green, dark: `oklch(0.305 0.045 145)` deep forest green). Replaces the previous orange `bg-accent` highlight. Designer should verify text contrast on this background in both light and dark modes.
 
@@ -47,6 +50,7 @@ The wizard is opened via `Ctrl+N` or the "+" button on the dashboard.
 
 **Content**:
 - Text input with the issue name, auto-focused with cursor at end
+- **Issue name excludes issue number** — the number is displayed separately on the issue card and in the branch name. `generateIssueName` produces the first 4 words of the title only (e.g., "Issue card redesign states"). Trailing special characters (commas, colons, dashes, dots, semicolons) are stripped. Inline special chars kept but not counted toward word limit
 - No duplicate label — the dialog header already displays the step name
 - Below: branch name preview in muted monospace (e.g., `Branch: 163-build-session-history-browsing`)
 
@@ -55,9 +59,11 @@ The wizard is opened via `Ctrl+N` or the "+" button on the dashboard.
 - All typing goes to the input (Backspace deletes text, not navigate back)
 - Escape: goes back one step (does NOT close the wizard) — because text input captures Backspace
 
-**Footer buttons**: Back [Esc], Next [Enter]. No Backspace Back button — Backspace must edit text, not navigate.
+**Footer buttons (dynamic based on focus)**:
+- Input focused: Back [Esc], Cancel (no hint), Next [Enter]. No navigation hint
+- Input not focused: Back [⌫], Cancel [Esc], Next [Enter]. No navigation hint (step 2 has no navigable items)
 
-**Decision**: Wherever a text input is focused, Escape means "go back" instead of "close wizard". This applies to Step 2 and any other step with focused text input (except Step 1, where Escape closes since there's nowhere to go back).
+**Decision**: Wherever a text input is focused, Escape means "go back" instead of "close wizard". This applies to Step 2 and any other step with focused text input (except Step 1, where Escape closes since there's nowhere to go back). Cancel button shows no keyboard hint when Escape is claimed by Back.
 
 ### Step 3: Create Worktree?
 
@@ -67,7 +73,7 @@ The wizard is opened via `Ctrl+N` or the "+" button on the dashboard.
 - Two equal-sized square choice cards (`size-24`) side by side: Yes (tree-pine icon) and No (X icon)
 - No duplicate title in the body — the dialog header already displays "Create Worktree?"
 - Button labels: "Yes" and "No" (short, no extra text)
-- Clicking a card selects it but does NOT advance — user must press Next/Enter to proceed
+- **Clicking a card selects AND advances** to the next step (click-to-advance rule)
 - **Decision (grilled 2026-05-04)**: Three visual states per card:
   - **Unselected**: `border-border`, `bg-transparent`
   - **Hover**: `border-border`, `bg-surface-hover`
@@ -75,11 +81,11 @@ The wizard is opened via `Ctrl+N` or the "+" button on the dashboard.
   - **Selected No**: `border-red-500` + `bg-red-500/10` (red-tinted fill)
 
 **Keyboard**:
-- Left/Right arrows: toggle between Yes and No
+- Left/Right arrows: toggle between Yes and No. Works from **any focus within the modal** (not just the cards)
 - Enter: confirms the selected choice and advances
 - Yes is pre-selected by default
 
-**Footer buttons**: Back [⌫], Cancel [Esc], Next [Enter].
+**Footer buttons**: Back [⌫], Cancel [Esc], Next [Enter]. Navigation hint ←→ visible.
 
 ### Step 4: Pick a Color
 
@@ -87,11 +93,12 @@ The wizard is opened via `Ctrl+N` or the "+" button on the dashboard.
 
 **Content**:
 - **Color grid**: 4 rows x 6 columns = 24 preset colors, displayed inline (not in a popover/dropdown)
-- Each swatch shows the letter "A" with contrast-appropriate text color
+- Each swatch shows the letter "A" with contrast-appropriate text color. **Text is not selectable** (`user-select: none`, `pointer-events: none` on the display text span)
 - Used colors (assigned to other issues) are dimmed (`opacity-30`, disabled, skipped by arrow navigation)
-- The selected swatch has `scale-110` + `ring-2 ring-ring ring-inset`
-- Below the grid: a divider, then the hex input row (native color picker swatch + text input)
+- The selected swatch has `scale-110` + `ring-2 ring-ring ring-inset`. **No additional focus-visible outline** — remove `focus-visible:outline` to avoid double ring when keyboard navigating
+- Below the grid: a divider, then the hex input row (native color picker swatch + text input). **Vertically centered** between the divider and the footer separator
 - The hex input and native picker **must stay visible** (not hidden under an "Advanced" section)
+- **Clicking a swatch** = select that color + advance (creates the issue since this is the last step). This follows the click-to-advance rule — if a future step is added, swatch click would advance to that step instead
 
 **Color grid layout** (set in stone):
 - Grid must be exactly 6 columns x 4 rows
@@ -100,12 +107,16 @@ The wizard is opened via `Ctrl+N` or the "+" button on the dashboard.
 - The gap between swatches should be visually uniform (same in both axes)
 
 **Keyboard**:
-- Arrow keys: navigate the grid (wrapping, skipping disabled colors). Navigation **selects** the color — the hex input and native picker update immediately to reflect the focused color
-- Enter: confirms the selection and creates the issue
+- Arrow keys: navigate the grid (wrapping, skipping disabled colors). Navigation **selects** the color — the hex input and native picker update immediately to reflect the focused color. Works from **any focus within the modal** (not just the swatch grid). Exception: arrows control cursor when hex text input is focused
+- Enter: confirms the selection and creates the issue. Enter in the hex input also creates the issue
 
 **Preselection**: The `nextAvailableColor` (first unused color in the palette) is pre-selected and focused when this step loads.
 
-**Footer buttons**: Back [kbd], Cancel [Esc], Create [Enter kbd]. The Create button is the primary action button for the entire wizard. **Decision (grilled 2026-05-04)**: All footer buttons use `default` (md) size — not just Create. Consistent sizing across Back, Cancel, and Create/Next buttons in all steps.
+**Footer buttons (dynamic based on focus)**:
+- Hex input focused: Back [Esc], Cancel (no hint), Create [Enter]. Navigation hint hidden
+- Hex input not focused: Back [⌫], Cancel [Esc], Create [Enter]. Navigation hint ↑↓←→ visible
+
+**Decision (grilled 2026-05-04)**: All footer buttons use `default` (md) size — not just Create. Consistent sizing across Back, Cancel, and Create/Next buttons in all steps.
 
 ### Step 5: Worktree Progress (terminal state)
 
@@ -121,18 +132,31 @@ The wizard is opened via `Ctrl+N` or the "+" button on the dashboard.
 
 All footer buttons follow the same visual pattern: `Label [Kbd badge]` with the Kbd badge always on the **right** side of the text. This is consistent across Raycast, Linear, VS Code, and cmdk conventions.
 
-- **Back** button: ghost variant, left-aligned in footer. `Back [⌫]` where ⌫ is the Lucide `delete` icon (backspace key with X inside, not the thin-line variant) inside a Kbd pill
-- **Cancel** button: ghost variant, right-aligned. `Cancel [Esc]` with text "Esc" inside a Kbd pill
+- **Back** button: ghost variant, left-aligned in footer. Not shown on step 1 (no previous step). **Dynamic hint based on text input focus:**
+  - Text input focused: `Back [Esc]` — Escape goes back
+  - Text input not focused: `Back [⌫]` — Backspace goes back (⌫ is Lucide `delete` icon)
+- **Cancel** button: ghost variant, right-aligned. **Dynamic hint based on context:**
+  - Step 1 (no Back button): always `Cancel [Esc]`
+  - Other steps, text input focused: `Cancel` with **no Kbd hint** (Escape is claimed by Back)
+  - Other steps, text input not focused: `Cancel [Esc]`
 - **Create/Confirm** button: primary variant, right-aligned. `Create [↵]` where ↵ is the Lucide `corner-down-left` icon inside a Kbd pill with `variant="inverted"` (semi-transparent white on primary background)
+- **Navigation hint**: ghost-style non-clickable label, centered in footer. Shows Kbd arrow icons + "Navigate" text. Visibility and arrows per step:
+  - Step 1: `↑↓` — visible when navigation is active
+  - Step 2: **never visible** (no navigable items)
+  - Step 3: `←→` — always visible
+  - Step 4: `↑↓←→` — hidden when hex text input is focused
 
-Layout: `[Back ⌫]  ———spacer———  [Cancel Esc] [Create ↵]`
+Layout: `[Back ⌫]  ———[Navigate ↑↓]———  [Cancel Esc] [Create ↵]`
+
+**Critical rule:** Every button must always perform the action its label and Kbd hint describe. The keyboard shortcut shown must match the actual key behavior at all times.
 
 ### Keyboard Shortcut Routing
 
-- **Escape**: Closes the wizard UNLESS a text input is focused on a non-first step, in which case it goes back one step (because Backspace edits the input text). This applies to Step 2 (name input) and any future step with text input. Step 1 always closes on Escape (nowhere to go back)
-- **Backspace**: Goes back one step on all steps EXCEPT when a text input is focused and non-empty (the keypress edits the text instead). This applies to Step 1 (search input), Step 2 (name input), and Step 4 (hex input)
-- **Enter**: Handled per-step (selects issue, confirms name, confirms worktree choice, creates issue)
-- **Arrow keys**: Handled per-step (navigate issue list, toggle worktree choice, navigate color grid)
+- **Escape**: Closes the wizard UNLESS a text input is focused on a non-first step, in which case it goes back one step (because Backspace edits the input text). This applies to Step 2 (name input) and Step 4 (hex input). Step 1 always closes on Escape (nowhere to go back)
+- **Backspace**: Goes back one step on all steps EXCEPT when a text input is focused (the keypress edits the text instead). This applies to Step 1 (search input), Step 2 (name input), and Step 4 (hex input)
+- **Enter**: Handled per-step (selects issue, confirms name, confirms worktree choice, creates issue). **Must not double-fire** — gate step transitions so only one advance per keypress (fixes Enter-on-step-2-skips-step-3 bug)
+- **Arrow keys**: Handled per-step (navigate issue list, toggle worktree choice, navigate color grid). **Work from any focus within the modal**, not just inside the step component. Exception: when a text input is focused, arrows control the cursor instead
+- **Click on selectable item**: Confirms the current step and advances to next step across all steps (click-to-advance rule)
 - Mouse back button (button 4): Goes back one step (already implemented)
 
 ### Step Header
@@ -177,12 +201,20 @@ Layout: `[Back ⌫]  ———spacer———  [Cancel Esc] [Create ↵]`
 - Color grid is 6 columns x 4 rows
 - Issue list highlight: `bg-primary-soft` (sage green / deep forest green)
 - Worktree card states: unselected (transparent), hover (`bg-surface-hover`), selected Yes (green fill), selected No (red fill)
-- Worktree cards: equal-sized squares (`size-24`), labels "Yes"/"No" only, clicking selects but does not advance
+- Worktree cards: equal-sized squares (`size-24`), labels "Yes"/"No" only, clicking selects AND advances (click-to-advance)
+- Click-to-advance rule: clicking any selectable item confirms + advances across all steps
 - Step body must NOT duplicate the dialog header title text
 - Step 1 loads 20 issues by default, 10 visible without scrolling
 - Arrow navigation in issue list scrolls selected item into view
+- Arrow keys work from any focus within the modal (not just inside step components). Exception: text input focused = arrows control cursor
 - Next button visible on Steps 1, 2, and 3
 - Escape goes back (not close) when text input is focused on any non-first step
+- Dynamic footer buttons: Back/Cancel swap Kbd hints based on text input focus state
+- Navigation hint (arrow Kbd icons + "Navigate" text) shown per step: ↑↓ step 1, hidden step 2, ←→ step 3, ↑↓←→ step 4
+- Step 1: no preselection on open, arrow nav fills search bar (display only, no search trigger)
+- Issue name excludes issue number, trailing special chars stripped
+- Color swatch text ("A") not selectable (`user-select: none`, `pointer-events: none`)
+- No double ring on color swatches — selected ring only, no focus-visible outline
 - Color grid gaps must be equal in both axes (fix gap uniformity before adjusting modal width)
 
 ## Grilled Decisions (2026-05-04)
@@ -194,6 +226,22 @@ The following items were resolved during grilling and are now **set in stone**:
 - **Worktree choice cards**: Three states — unselected (`border-border`, transparent), hover (`bg-surface-hover`), selected Yes (`border-green-500` + `bg-green-500/10`), selected No (`border-red-500` + `bg-red-500/10`)
 - **Color grid priority**: Fix gap uniformity first (equal horizontal and vertical spacing). The grid was too spread out — tighten swatch gaps rather than widening the modal. Only adjust modal width if uniform gaps still don't fit within `max-w-lg`
 
+### Grilled Decisions (2026-05-05)
+
+- **Click-to-advance**: Clicking any selectable item (issue row, worktree card, color swatch) confirms the current step and advances to the next step. This is a general rule — mouse click = confirm + next. On the last step (color), this means creating the issue
+- **No preselection on step 1**: Wizard opens with empty search bar and no highlighted issue. Enter with no selection = Skip (create without GitHub issue)
+- **Arrow nav fills search bar**: ArrowUp/Down in step 1 fills the search bar with the selected issue's title and number. Display only — does NOT trigger a search. Typing after arrow selection clears the arrow-selected state
+- **Arrow nav from any focus**: Arrow keys navigate items when any element in the modal has focus (not just the step component). Exception: text input focused = arrows control cursor. Applies to steps 1, 3, 4
+- **Dynamic footer buttons**: Back shows Esc hint when text input focused, Backspace hint when not. Cancel shows Esc hint only when no Back button exists (step 1) or when text input is not focused. Cancel shows no hint when Escape is claimed by Back
+- **Navigation hint in footer**: Ghost-style non-clickable label centered in footer with Kbd arrow icons + "Navigate" text. Step 1: ↑↓, Step 2: hidden, Step 3: ←→, Step 4: ↑↓←→ (hidden when hex input focused)
+- **Issue name excludes number**: `generateIssueName` returns title words only, no number prefix. Trailing special characters (commas, colons, dashes, dots, semicolons) stripped. Inline special chars kept but not counted toward word limit
+- **Swatch text not selectable**: `user-select: none` and `pointer-events: none` on the display text span
+- **No double ring**: Remove `focus-visible:outline` from color swatches — selected `ring-2` is sufficient
+- **Color picker vertical centering**: Hex input row vertically centered between divider and footer separator
+- **Modal content padding**: Larger top and bottom padding on modal body
+- **Enter in hex input**: Creates the issue (same as clicking Create button)
+- **Step 1 Cancel always shows Esc**: Since there's no Back button to compete for Escape on step 1
+
 ## UI Freedom (designer should explore)
 
 - **Step header styling**: Font size, weight, color. Should clearly indicate the current step without dominating. Current `text-sm font-medium text-muted-foreground` is too subtle
@@ -201,6 +249,7 @@ The following items were resolved during grilling and are now **set in stone**:
 - **Overall modal width**: Currently `max-w-lg`. May increase to `max-w-xl` (576px) only if uniform grid gaps require it — not as a first resort
 - **Step transition**: Currently instant swap. Could add a subtle crossfade or slide if it improves perceived flow (not required)
 - ~~**Progress indicators**: Step dots implemented in header top-right. Active step = wider pill, completed = primary/50 circles, inactive = border-strong~~ ✅ Done
+- **Modal body padding**: Increase top and bottom padding — currently too tight, especially visible on the Create Worktree step. Designer should set appropriate `py-*` values
 
 ## Not Included in This Design
 
@@ -221,3 +270,7 @@ The following items were resolved during grilling and are now **set in stone**:
 7. ~~Backspace in text inputs (search, name, hex) must not propagate to wizard navigation~~ ✅ Fixed on dev
 8. ~~Escape in Issue Name step should go back (not close wizard) since Backspace edits text~~ ✅ Fixed on dev
 9. ~~Step header text is not vertically centered and is too small~~ ✅ Fixed on dev
+10. Enter on step 2 (Issue Name) skips step 3 (Worktree), jumping directly to step 4 (Color). Suspected cause: keydown event double-fires across step transition. See #181
+11. Escape with focused input on step 2 may cancel the wizard instead of going back. Button label and actual behavior must match. See #181
+12. Issue name includes the issue number prefix — should be excluded. See #181
+13. Color swatches show double ring (selected + focus-visible outline). See #181

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -334,6 +334,7 @@
 	"wizard_hint_enter": "Enter pro potvrzení",
 	"wizard_hint_escape": "Esc pro zrušení",
 	"wizard_hint_back": "Backspace pro návrat",
+	"wizard_navigate": "Navigovat",
 	"wizard_quick_add": "Rychle přidat",
 	"wizard_quick_add_worktree": "Rychle přidat + worktree",
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -350,6 +350,7 @@
 	"wizard_hint_enter": "Enter to confirm",
 	"wizard_hint_escape": "Esc to cancel",
 	"wizard_hint_back": "Backspace to go back",
+	"wizard_navigate": "Navigate",
 	"wizard_quick_add": "Quick add",
 	"wizard_quick_add_worktree": "Quick add + worktree",
 

--- a/src/lib/components/color-picker/ColorPickerContent.svelte
+++ b/src/lib/components/color-picker/ColorPickerContent.svelte
@@ -9,6 +9,7 @@
 	let {
 		selectedColor,
 		onSelect,
+		onPresetClick,
 		colors = DEFAULT_COLOR_PALETTE,
 		usedColors = [],
 		displayText,
@@ -40,6 +41,31 @@
 		tick().then(() => {
 			swatchElements[focusedIndex]?.focus();
 		});
+	}
+
+	export function handleArrowKey(key: string) {
+		let step: number;
+		switch (key) {
+			case 'ArrowRight':
+				step = 1;
+				break;
+			case 'ArrowLeft':
+				step = -1;
+				break;
+			case 'ArrowDown':
+				step = GRID_COLUMNS;
+				break;
+			case 'ArrowUp':
+				step = -GRID_COLUMNS;
+				break;
+			default:
+				return;
+		}
+
+		const newIndex = findNextIndex(focusedIndex, step);
+		focusedIndex = newIndex;
+		swatchElements[newIndex]?.focus();
+		onSelect(colors[newIndex]);
 	}
 
 	function isSwatchDisabled(color: string): boolean {
@@ -84,8 +110,12 @@
 		onSelect(colors[newIndex]);
 	}
 
-	function handlePresetClick(color: string) {
-		onSelect(color);
+	function handlePresetClickInternal(color: string) {
+		if (onPresetClick) {
+			onPresetClick(color);
+		} else {
+			onSelect(color);
+		}
 		if (closeOnPresetClick) {
 			onClose?.();
 		}
@@ -113,17 +143,19 @@
 			type="button"
 			tabindex={index === focusedIndex ? 0 : -1}
 			class="flex h-7 w-7 items-center justify-center rounded-sm border border-border outline-none transition-transform
-				focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-ring focus-visible:outline-offset-2
 				{color === effectiveColor ? 'scale-110 ring-2 ring-ring ring-inset' : ''}
 				{isUsed ? 'opacity-30 cursor-not-allowed' : 'hover:scale-110'}"
 			style="background-color: {color}"
 			disabled={isUsed}
 			onkeydown={handleGridKeydown}
-			onclick={() => handlePresetClick(color)}
+			onclick={() => handlePresetClickInternal(color)}
 			aria-label={color}
 		>
 			{#if displayText}
-				<span style="color: {getContrastTextColor(color)}" class="text-xs font-medium">
+				<span
+					style="color: {getContrastTextColor(color)}"
+					class="pointer-events-none select-none text-xs font-medium"
+				>
 					{displayText}
 				</span>
 			{/if}
@@ -133,7 +165,7 @@
 
 <div class="my-2 border-t border-border"></div>
 
-<div class="flex items-center gap-2">
+<div class="flex flex-1 items-center justify-center gap-2">
 	<label
 		class="relative flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center overflow-hidden rounded-md border border-border shadow-sm transition-transform hover:scale-105"
 		style="background-color: {effectiveColor}"
@@ -141,7 +173,7 @@
 		{#if displayText}
 			<span
 				style="color: {getContrastTextColor(effectiveColor)}"
-				class="pointer-events-none text-xs font-medium"
+				class="pointer-events-none select-none text-xs font-medium"
 			>
 				{displayText}
 			</span>

--- a/src/lib/components/color-picker/color_picker_types.ts
+++ b/src/lib/components/color-picker/color_picker_types.ts
@@ -1,6 +1,7 @@
 export interface ColorPickerContentProps {
 	selectedColor: string;
 	onSelect: (color: string) => void;
+	onPresetClick?: (color: string) => void;
 	colors?: string[];
 	usedColors?: string[];
 	displayText?: string;

--- a/src/lib/components/creation-wizard/CreationWizard.svelte
+++ b/src/lib/components/creation-wizard/CreationWizard.svelte
@@ -5,6 +5,10 @@
 	import { Kbd } from '$lib/components/ui/kbd/index.js';
 	import CornerDownLeftIcon from '@lucide/svelte/icons/corner-down-left';
 	import DeleteIcon from '@lucide/svelte/icons/delete';
+	import ArrowUpIcon from '@lucide/svelte/icons/arrow-up';
+	import ArrowDownIcon from '@lucide/svelte/icons/arrow-down';
+	import ArrowLeftIcon from '@lucide/svelte/icons/arrow-left';
+	import ArrowRightIcon from '@lucide/svelte/icons/arrow-right';
 	import { useCreationWizard, WIZARD_STEPS } from '$lib/modules/creation-wizard';
 	import type {
 		CreateIssueRequest,
@@ -37,6 +41,8 @@
 	let githubSearchRef: ReturnType<typeof StepGithubSearch> | undefined = $state();
 	let issueNameRef: ReturnType<typeof StepIssueName> | undefined = $state();
 	let worktreeChoiceRef: ReturnType<typeof StepWorktreeChoice> | undefined = $state();
+	let colorSelectionRef: ReturnType<typeof StepColorSelection> | undefined = $state();
+	let textInputFocused = $state(false);
 
 	function handleOpenChange(isOpen: boolean) {
 		if (!isOpen) {
@@ -51,10 +57,8 @@
 		return el?.tagName === 'INPUT' || el?.tagName === 'TEXTAREA';
 	}
 
-	function isTextInputNonEmpty(): boolean {
-		const el = document.activeElement;
-		const isInput = el?.tagName === 'INPUT' || el?.tagName === 'TEXTAREA';
-		return isInput && (el as HTMLInputElement).value !== '';
+	function trackFocus() {
+		textInputFocused = isTextInputFocused();
 	}
 
 	function handleBackspace(event: KeyboardEvent) {
@@ -72,20 +76,55 @@
 		event.preventDefault();
 		event.stopPropagation();
 
-		if (wizard.currentStep !== WIZARD_STEPS.GITHUB_SEARCH && isTextInputFocused()) {
+		if (wizard.currentStep === WIZARD_STEPS.GITHUB_SEARCH) {
+			wizard.closeWizard();
+		} else if (isTextInputFocused()) {
 			wizard.goBack();
 		} else {
 			wizard.closeWizard();
 		}
 	}
 
+	// fallow-ignore-next-line complexity
+	function handleArrowKeys(event: KeyboardEvent) {
+		if (isTextInputFocused()) {
+			return;
+		}
+
+		switch (wizard.currentStep) {
+			case WIZARD_STEPS.GITHUB_SEARCH:
+				if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+					event.preventDefault();
+					githubSearchRef?.handleArrow(event.key === 'ArrowDown' ? 1 : -1);
+				}
+				break;
+			case WIZARD_STEPS.WORKTREE_CHOICE:
+				if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
+					event.preventDefault();
+					worktreeChoiceRef?.toggleChoice();
+				}
+				break;
+			case WIZARD_STEPS.COLOR_SELECTION:
+				if (
+					event.key === 'ArrowUp' ||
+					event.key === 'ArrowDown' ||
+					event.key === 'ArrowLeft' ||
+					event.key === 'ArrowRight'
+				) {
+					event.preventDefault();
+					colorSelectionRef?.handleArrow(event.key);
+				}
+				break;
+			case WIZARD_STEPS.ISSUE_NAME:
+			case WIZARD_STEPS.WORKTREE_PROGRESS:
+				break;
+		}
+	}
+
 	function handleEnter(event: KeyboardEvent) {
 		switch (wizard.currentStep) {
 			case WIZARD_STEPS.GITHUB_SEARCH:
-				break;
 			case WIZARD_STEPS.ISSUE_NAME:
-				event.preventDefault();
-				issueNameRef?.confirm();
 				break;
 			case WIZARD_STEPS.WORKTREE_CHOICE:
 				event.preventDefault();
@@ -100,6 +139,7 @@
 		}
 	}
 
+	// fallow-ignore-next-line complexity
 	function handleGlobalKeydown(event: KeyboardEvent) {
 		if (!wizard.open) {
 			return;
@@ -109,8 +149,15 @@
 			handleEscape(event);
 		} else if (event.key === 'Backspace') {
 			handleBackspace(event);
-		} else if (event.key === 'Enter' && !isTextInputNonEmpty()) {
+		} else if (event.key === 'Enter') {
 			handleEnter(event);
+		} else if (
+			event.key === 'ArrowUp' ||
+			event.key === 'ArrowDown' ||
+			event.key === 'ArrowLeft' ||
+			event.key === 'ArrowRight'
+		) {
+			handleArrowKeys(event);
 		}
 	}
 
@@ -243,9 +290,7 @@
 	const currentStepIndex = $derived(navigableSteps.indexOf(wizard.currentStep));
 
 	const isFirstStep = $derived(wizard.currentStep === WIZARD_STEPS.GITHUB_SEARCH);
-	const isIssueNameStep = $derived(wizard.currentStep === WIZARD_STEPS.ISSUE_NAME);
 	const isFinalStep = $derived(wizard.currentStep === WIZARD_STEPS.COLOR_SELECTION);
-	const showBackButton = $derived(!isFirstStep && !isIssueNameStep);
 	const showNextButton = $derived(
 		wizard.currentStep === WIZARD_STEPS.GITHUB_SEARCH ||
 			wizard.currentStep === WIZARD_STEPS.ISSUE_NAME ||
@@ -257,9 +302,47 @@
 	const showFooter = $derived(
 		!showWorktreeProgress && wizard.currentStep !== WIZARD_STEPS.WORKTREE_PROGRESS,
 	);
+
+	const showBackButton = $derived(!isFirstStep);
+	const backKbdHint = $derived.by(() => {
+		if (textInputFocused) {
+			return 'escape' as const;
+		}
+		return 'backspace' as const;
+	});
+
+	const showCancelKbdHint = $derived.by(() => {
+		if (isFirstStep) {
+			return true;
+		}
+		return !textInputFocused;
+	});
+
+	const navigationHint = $derived.by((): 'vertical' | 'horizontal' | 'grid' | null => {
+		if (textInputFocused) {
+			return null;
+		}
+		switch (wizard.currentStep) {
+			case WIZARD_STEPS.GITHUB_SEARCH:
+				return 'vertical';
+			case WIZARD_STEPS.ISSUE_NAME:
+				return null;
+			case WIZARD_STEPS.WORKTREE_CHOICE:
+				return 'horizontal';
+			case WIZARD_STEPS.COLOR_SELECTION:
+				return 'grid';
+			default:
+				return null;
+		}
+	});
 </script>
 
-<svelte:window onkeydown={handleGlobalKeydown} onmouseup={handleMouseBack} />
+<svelte:window
+	onkeydown={handleGlobalKeydown}
+	onmouseup={handleMouseBack}
+	onfocusin={trackFocus}
+	onfocusout={trackFocus}
+/>
 
 <Dialog.Root open={wizard.open} onOpenChange={handleOpenChange}>
 	<Dialog.Content class="top-[15%] -translate-y-0 max-w-lg">
@@ -283,7 +366,7 @@
 			{/if}
 		</Dialog.Header>
 
-		<Dialog.Body class="flex flex-col gap-3 py-2">
+		<Dialog.Body class="flex flex-col gap-3 py-4">
 			{#if showWorktreeProgress}
 				<StepWorktreeProgress
 					worktreeState={worktreeProgressState}
@@ -297,7 +380,7 @@
 			{:else if wizard.currentStep === WIZARD_STEPS.WORKTREE_CHOICE}
 				<StepWorktreeChoice bind:this={worktreeChoiceRef} />
 			{:else if wizard.currentStep === WIZARD_STEPS.COLOR_SELECTION}
-				<StepColorSelection />
+				<StepColorSelection bind:this={colorSelectionRef} onConfirm={handleConfirmColor} />
 			{/if}
 		</Dialog.Body>
 
@@ -306,23 +389,41 @@
 				{#if showBackButton}
 					<Button variant="ghost" type="button" onclick={() => wizard.goBack()}>
 						{m.wizard_back()}
-						<Kbd><DeleteIcon /></Kbd>
+						{#if backKbdHint === 'escape'}
+							<Kbd>Esc</Kbd>
+						{:else}
+							<Kbd><DeleteIcon /></Kbd>
+						{/if}
 					</Button>
 				{/if}
-				<div class="flex-1"></div>
-				<Button
-					variant="ghost"
-					type="button"
-					onclick={() => {
-						if (isIssueNameStep) {
-							wizard.goBack();
-						} else {
-							wizard.closeWizard();
-						}
-					}}
-				>
-					{isIssueNameStep ? m.wizard_back() : m.btn_cancel()}
-					<Kbd>Esc</Kbd>
+				<div class="flex flex-1 items-center justify-center">
+					{#if navigationHint === 'vertical'}
+						<span class="flex items-center gap-1.5 text-xs text-muted-foreground/60">
+							<Kbd><ArrowUpIcon /></Kbd>
+							<Kbd><ArrowDownIcon /></Kbd>
+							{m.wizard_navigate()}
+						</span>
+					{:else if navigationHint === 'horizontal'}
+						<span class="flex items-center gap-1.5 text-xs text-muted-foreground/60">
+							<Kbd><ArrowLeftIcon /></Kbd>
+							<Kbd><ArrowRightIcon /></Kbd>
+							{m.wizard_navigate()}
+						</span>
+					{:else if navigationHint === 'grid'}
+						<span class="flex items-center gap-1.5 text-xs text-muted-foreground/60">
+							<Kbd><ArrowUpIcon /></Kbd>
+							<Kbd><ArrowDownIcon /></Kbd>
+							<Kbd><ArrowLeftIcon /></Kbd>
+							<Kbd><ArrowRightIcon /></Kbd>
+							{m.wizard_navigate()}
+						</span>
+					{/if}
+				</div>
+				<Button variant="ghost" type="button" onclick={() => wizard.closeWizard()}>
+					{m.btn_cancel()}
+					{#if showCancelKbdHint}
+						<Kbd>Esc</Kbd>
+					{/if}
 				</Button>
 				{#if showNextButton}
 					<Button type="button" onclick={handleNextClick}>

--- a/src/lib/components/creation-wizard/StepColorSelection.svelte
+++ b/src/lib/components/creation-wizard/StepColorSelection.svelte
@@ -2,20 +2,40 @@
 	import { useCreationWizard } from '$lib/modules/creation-wizard';
 	import { ColorPickerContent } from '$lib/components/color-picker/index.js';
 
-	const wizard = useCreationWizard();
+	interface Props {
+		onConfirm: () => void;
+	}
 
+	let { onConfirm }: Props = $props();
+
+	const wizard = useCreationWizard();
 	const deps = wizard.dependencies;
+
+	let pickerRef: ReturnType<typeof ColorPickerContent> | undefined = $state();
+
+	export function handleArrow(key: string) {
+		pickerRef?.handleArrowKey(key);
+	}
+
+	function handleSelect(color: string) {
+		wizard.selectColor(color);
+	}
+
+	function handlePresetClick(color: string) {
+		wizard.selectColor(color);
+		onConfirm();
+	}
 </script>
 
 <div class="flex flex-col gap-3">
 	<ColorPickerContent
+		bind:this={pickerRef}
 		colors={deps.paletteColors}
 		selectedColor={wizard.formData.selectedColor}
 		usedColors={deps.usedColors}
 		displayText="A"
 		autofocus
-		onSelect={(color) => {
-			wizard.selectColor(color);
-		}}
+		onSelect={handleSelect}
+		onPresetClick={handlePresetClick}
 	/>
 </div>

--- a/src/lib/components/creation-wizard/StepGithubSearch.svelte
+++ b/src/lib/components/creation-wizard/StepGithubSearch.svelte
@@ -17,7 +17,9 @@
 
 	const wizard = useCreationWizard();
 
-	let selectedIndex = $state(0);
+	let selectedIndex = $state(-1);
+	let arrowDisplayValue = $state('');
+	let isArrowSelecting = $state(false);
 	let inputElement = $state<HTMLInputElement | null>(null);
 	let listElement = $state<HTMLDivElement | null>(null);
 
@@ -28,16 +30,20 @@
 		return assignedIssues;
 	});
 
+	const inputDisplayValue = $derived(isArrowSelecting ? arrowDisplayValue : wizard.searchQuery);
+
 	$effect(() => {
 		void displayItems.length;
 		untrack(() => {
-			selectedIndex = 0;
+			selectedIndex = -1;
+			isArrowSelecting = false;
+			arrowDisplayValue = '';
 		});
 	});
 
 	$effect(() => {
 		const index = selectedIndex;
-		if (listElement) {
+		if (listElement && index >= 0) {
 			const child = listElement.querySelector(
 				`[data-index="${index}"]`,
 			) as HTMLElement | null;
@@ -59,13 +65,23 @@
 	}
 
 	function moveSelection(delta: number) {
-		if (displayItems.length > 0) {
+		if (displayItems.length === 0) {
+			return;
+		}
+
+		if (selectedIndex === -1) {
+			selectedIndex = delta > 0 ? 0 : displayItems.length - 1;
+		} else {
 			selectedIndex = (selectedIndex + delta + displayItems.length) % displayItems.length;
 		}
+
+		const item = displayItems[selectedIndex];
+		arrowDisplayValue = `#${item.number} ${item.title}`;
+		isArrowSelecting = true;
 	}
 
 	function confirmSelection() {
-		if (displayItems.length > 0 && selectedIndex < displayItems.length) {
+		if (selectedIndex >= 0 && selectedIndex < displayItems.length) {
 			wizard.selectGithubIssue(toSearchedIssue(displayItems[selectedIndex]));
 		} else {
 			wizard.skipGithubSearch();
@@ -74,6 +90,10 @@
 
 	export function confirm() {
 		confirmSelection();
+	}
+
+	export function handleArrow(delta: number) {
+		moveSelection(delta);
 	}
 
 	function handleKeydown(event: KeyboardEvent) {
@@ -85,12 +105,15 @@
 			moveSelection(-1);
 		} else if (event.key === 'Enter') {
 			event.preventDefault();
+			event.stopPropagation();
 			confirmSelection();
 		}
 	}
 
 	function handleInput(event: Event) {
 		const target = event.currentTarget as HTMLInputElement;
+		isArrowSelecting = false;
+		arrowDisplayValue = '';
 		wizard.updateSearchQuery(target.value);
 	}
 </script>
@@ -104,7 +127,7 @@
 		/>
 		<Input
 			bind:ref={inputElement}
-			value={wizard.searchQuery}
+			value={inputDisplayValue}
 			oninput={handleInput}
 			placeholder={m.wizard_search_placeholder()}
 			class="pl-9"

--- a/src/lib/components/creation-wizard/StepIssueName.svelte
+++ b/src/lib/components/creation-wizard/StepIssueName.svelte
@@ -35,6 +35,7 @@
 	function handleKeydown(event: KeyboardEvent) {
 		if (event.key === 'Enter') {
 			event.preventDefault();
+			event.stopPropagation();
 			confirm();
 		}
 	}

--- a/src/lib/components/creation-wizard/StepWorktreeChoice.svelte
+++ b/src/lib/components/creation-wizard/StepWorktreeChoice.svelte
@@ -12,12 +12,22 @@
 		wizard.selectWorktreeChoice(selectedChoice);
 	}
 
+	export function toggleChoice() {
+		selectedChoice = !selectedChoice;
+	}
+
+	function handleClick(choice: boolean) {
+		selectedChoice = choice;
+		wizard.selectWorktreeChoice(choice);
+	}
+
 	function handleKeydown(event: KeyboardEvent) {
 		if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
 			event.preventDefault();
 			selectedChoice = !selectedChoice;
 		} else if (event.key === 'Enter') {
 			event.preventDefault();
+			event.stopPropagation();
 			confirm();
 		}
 	}
@@ -28,7 +38,7 @@
 	<div class="flex items-center justify-center gap-4">
 		<button
 			type="button"
-			onclick={() => (selectedChoice = true)}
+			onclick={() => handleClick(true)}
 			class="flex size-24 flex-col items-center justify-center gap-2 rounded-lg border-2 transition-colors
 				{selectedChoice === true
 				? 'border-green-500 bg-green-500/10 text-green-400'
@@ -39,7 +49,7 @@
 		</button>
 		<button
 			type="button"
-			onclick={() => (selectedChoice = false)}
+			onclick={() => handleClick(false)}
 			class="flex size-24 flex-col items-center justify-center gap-2 rounded-lg border-2 transition-colors
 				{selectedChoice === false
 				? 'border-red-500 bg-red-500/10 text-red-400'

--- a/src/lib/modules/creation-wizard/smart_naming.test.ts
+++ b/src/lib/modules/creation-wizard/smart_naming.test.ts
@@ -298,109 +298,142 @@ describe('generateBranchName', () => {
 });
 
 describe('generateIssueName', () => {
+	describe('no number prefix', () => {
+		it('does not include issue number in output', () => {
+			const result = generateIssueName(133, 'multi-step creation wizard with smart naming');
+			expect(result).toBe('multi-step creation wizard with');
+		});
+
+		it('ignores issue number completely', () => {
+			const result = generateIssueName(42, 'Fix login bug in auth module');
+			expect(result).toBe('Fix login bug in');
+		});
+	});
+
 	describe('basic formatting', () => {
-		it('formats number followed by first four words', () => {
+		it('takes first four words from title', () => {
 			const result = generateIssueName(
 				133,
 				'feat: multi-step creation wizard with smart naming',
 			);
-			expect(result).toBe('133 multi-step creation wizard with');
-		});
-
-		it('formats simple title with issue number', () => {
-			const result = generateIssueName(42, 'Fix login bug in auth module');
-			expect(result).toBe('42 Fix login bug in');
+			expect(result).toBe('multi-step creation wizard with');
 		});
 
 		it('strips conventional commit prefix before taking words', () => {
-			const result = generateIssueName(
-				133,
-				'feat: multi-step creation wizard with smart naming',
-			);
-			expect(result).toBe('133 multi-step creation wizard with');
+			const result = generateIssueName(133, 'feat(ui): add dashboard layout for users');
+			expect(result).toBe('add dashboard layout for');
+		});
+	});
+
+	describe('trailing special character stripping', () => {
+		it('strips trailing comma', () => {
+			const result = generateIssueName(173, 'Issue card redesign: states,');
+			expect(result).toBe('Issue card redesign: states');
 		});
 
-		it('strips scoped prefix before taking words', () => {
-			const result = generateIssueName(133, 'feat(ui): add dashboard layout for users');
-			expect(result).toBe('133 add dashboard layout for');
+		it('strips trailing colon', () => {
+			const result = generateIssueName(1, 'fix: thing one:');
+			expect(result).toBe('thing one');
+		});
+
+		it('strips trailing dash', () => {
+			const result = generateIssueName(1, 'some feature name -');
+			expect(result).toBe('some feature name');
+		});
+
+		it('strips trailing semicolon', () => {
+			const result = generateIssueName(1, 'word one two three;');
+			expect(result).toBe('word one two three');
+		});
+
+		it('strips trailing em dash', () => {
+			const result = generateIssueName(1, 'feature name here —');
+			expect(result).toBe('feature name here');
+		});
+
+		it('strips trailing dot', () => {
+			const result = generateIssueName(1, 'fix the login bug.');
+			expect(result).toBe('fix the login bug');
+		});
+
+		it('preserves inline special characters', () => {
+			const result = generateIssueName(173, 'Issue card redesign: states and more');
+			expect(result).toBe('Issue card redesign: states');
 		});
 	});
 
 	describe('preserves original casing', () => {
 		it('preserves mixed case', () => {
 			const result = generateIssueName(42, 'Fix Login Bug In Auth');
-			expect(result).toBe('42 Fix Login Bug In');
+			expect(result).toBe('Fix Login Bug In');
 		});
 
 		it('preserves uppercase words', () => {
 			const result = generateIssueName(1, 'Add OAUTH2 Support For Users');
-			expect(result).toBe('1 Add OAUTH2 Support For');
+			expect(result).toBe('Add OAUTH2 Support For');
 		});
 
 		it('preserves lowercase title', () => {
 			const result = generateIssueName(1, 'add new feature for app');
-			expect(result).toBe('1 add new feature for');
+			expect(result).toBe('add new feature for');
 		});
 	});
 
 	describe('fewer than four words', () => {
 		it('uses all words when title has fewer than 4 words after prefix stripping', () => {
 			const result = generateIssueName(1, 'fix bug');
-			expect(result).toBe('1 fix bug');
+			expect(result).toBe('fix bug');
 		});
 
 		it('uses single word when only one word remains after prefix stripping', () => {
 			const result = generateIssueName(1, 'feat: refactoring');
-			expect(result).toBe('1 refactoring');
+			expect(result).toBe('refactoring');
 		});
 
-		it('returns just number when title is empty after prefix stripping', () => {
+		it('returns empty string when title is empty after prefix stripping', () => {
 			const result = generateIssueName(1, 'feat:');
-			expect(result).toBe('1');
+			expect(result).toBe('');
 		});
 
 		it('uses all words when exactly 4 words', () => {
 			const result = generateIssueName(1, 'add new login page');
-			expect(result).toBe('1 add new login page');
+			expect(result).toBe('add new login page');
 		});
 	});
 
 	describe('no filler word stripping', () => {
 		it('preserves filler words in issue name', () => {
 			const result = generateIssueName(42, 'Fix the login bug');
-			expect(result).toBe('42 Fix the login bug');
+			expect(result).toBe('Fix the login bug');
 		});
 
 		it('preserves "a", "an" articles', () => {
 			const result = generateIssueName(1, 'Add a new button for users');
-			expect(result).toBe('1 Add a new button');
+			expect(result).toBe('Add a new button');
 		});
 	});
 
 	describe('edge cases', () => {
-		it('returns just the number string for empty title', () => {
+		it('returns empty string for empty title', () => {
 			const result = generateIssueName(133, '');
-			expect(result).toBe('133');
+			expect(result).toBe('');
 		});
 
 		it('handles title that is only a conventional prefix with no content', () => {
 			const result = generateIssueName(1, 'feat: ');
-			expect(result).toBe('1');
+			expect(result).toBe('');
 		});
 	});
 
 	describe('full integration examples', () => {
-		it('example from spec: feat: multi-step creation wizard', () => {
-			const result = generateIssueName(
-				133,
-				'feat: multi-step creation wizard with smart naming',
-			);
-			expect(result).toBe('133 multi-step creation wizard with');
+		it('example from spec: Issue card redesign produces no number prefix', () => {
+			const result = generateIssueName(173, 'Issue card redesign: states, hover, borders');
+			expect(result).toBe('Issue card redesign: states');
 		});
 
-		it('example from spec: Fix login bug in auth module', () => {
+		it('example from spec: Fix login bug produces clean name', () => {
 			const result = generateIssueName(42, 'Fix login bug in auth module');
-			expect(result).toBe('42 Fix login bug in');
+			expect(result).toBe('Fix login bug in');
 		});
 	});
 });

--- a/src/lib/modules/creation-wizard/smart_naming.ts
+++ b/src/lib/modules/creation-wizard/smart_naming.ts
@@ -110,16 +110,21 @@ export function generateBranchName(issueNumber: number, title: string): string {
 	return `${prefix}${truncatedSlug}`;
 }
 
-export function generateIssueName(issueNumber: number, title: string): string {
+function stripTrailingSpecialCharacters(text: string): string {
+	return text.replace(/[\s,:\-.;—]+$/, '');
+}
+
+export function generateIssueName(_issueNumber: number, title: string): string {
 	const withoutPrefix = stripConventionalCommitPrefix(title);
 
 	const words = withoutPrefix.split(/\s+/).filter((word) => word.length > 0);
 
 	if (words.length === 0) {
-		return String(issueNumber);
+		return '';
 	}
 
 	const firstFourWords = words.slice(0, 4);
+	const joined = firstFourWords.join(' ');
 
-	return `${issueNumber} ${firstFourWords.join(' ')}`;
+	return stripTrailingSpecialCharacters(joined);
 }


### PR DESCRIPTION
## Summary

- Fix Enter on step 2 double-advancing to step 4 (stopPropagation on local handlers)
- Fix Escape behavior: focused input = go back, no focus = close wizard
- Remove issue number prefix from `generateIssueName`, strip trailing special characters
- Step 1 opens with no preselection; arrow keys fill search bar (display only)
- Global arrow key routing from any focus within modal (steps 1, 3, 4)
- Click-to-advance on worktree choice and color swatch steps
- Dynamic footer with context-aware Back/Cancel/Navigation hints
- Visual: increased modal padding, select-none on swatch text, centered custom picker

Fixes #181

## Test plan

- [x] Unit tests updated for `generateIssueName` (no number prefix, trailing char stripping)
- [x] All 705 unit tests pass
- [x] Full check suite passes (format + lint + fallow + typecheck + eslint)
- [ ] Manual: Enter on step 2 advances to step 3 only
- [ ] Manual: Escape with focused input goes back; without focus closes
- [ ] Manual: Arrow keys navigate from any focus
- [ ] Manual: Click on worktree Yes/No advances immediately
- [ ] Manual: Click on color swatch creates issue
- [ ] Manual: Footer buttons update dynamically with correct kbd hints