### PR TITLE
#172 fix(wizard): UX improvements and form validation

### DIFF
--- a/.mpx/REQUIREMENTS.md
+++ b/.mpx/REQUIREMENTS.md
@@ -54,9 +54,9 @@ Developer who uses Claude Code (and other AI CLIs) for parallel task execution a
     4. Color selection (24-color palette, auto-rotation, custom input). Clicking a swatch = select + advance (creates issue on last step)
     5. Worktree creation progress (if yes)
     - **Click-to-advance:** Clicking any selectable item confirms + advances to next step across all steps
-    - **Dynamic footer:** Back/Cancel buttons swap keyboard hints based on text input focus. Back shows Esc when input focused, Backspace when not. Cancel shows Esc only when no Back button or input not focused. Navigation hint (arrow Kbd labels + "Navigate" text) shown per step: ↑↓ on step 1, hidden on step 2, ←→ on step 3, ↑↓←→ on step 4
+    - **Dynamic footer:** Back/Cancel buttons swap keyboard hints based on text input focus. Back shows Esc when input focused, Backspace when not. Cancel shows Esc only when no Back button or input not focused. Navigation hint ("Navigate" text + separate arrow Kbd icons) shown per step: ↑↓ on step 1 (always visible), hidden on step 2, ←→ on step 3, ↑↓←→ on step 4 (hidden when hex input focused). Step 3: no element focused on entry (blur on mount)
     - **Arrow nav from any focus:** Arrow keys navigate items when any element in the modal is focused (not just text input). Exception: text input focused = arrows control cursor
-    - **Keyboard routing:** Enter confirms current step. Escape goes back when text input focused on non-first step, closes wizard otherwise. Backspace goes back when no text input focused
+    - **Keyboard routing:** Enter confirms current step from **any focus within the modal** (global handler routes to step's confirm function). Empty name on step 2 shows inline validation error. Escape goes back when text input focused on non-first step, closes wizard otherwise (Dialog's own Escape suppressed via `onEscapeKeydown`). Backspace goes back when no text input focused
 - **Quick add (no worktree):** One-click from assigned GitHub issue. Auto-fills name, GitHub link, assigns next color.
 - **Quick add (with worktree):** One-click from assigned issue or GitHub trigger. Auto-fills everything, auto-detects base branch, runs setup-worktree.sh.
 - **From raw requirements:** Quick ideas widget appends to `.mpx/RAW_REQUIREMENTS.md`. Processing trigger runs `/mp-grill-requirements` to refine → create GitHub issue.

--- a/claude_design/design_briefs/ISSUE_CREATION_WIZARD.md
+++ b/claude_design/design_briefs/ISSUE_CREATION_WIZARD.md
@@ -40,7 +40,7 @@ The wizard is opened via `Ctrl+N` or the "+" button on the dashboard.
 - Enter: select highlighted issue and advance (or Skip if no selection)
 - Typing: filters the list
 
-**Footer buttons**: Cancel [Esc], Next [Enter]. No Back button (this is the first step). Cancel always shows Esc hint (since no Back button competes for Escape). Navigation hint ↑↓ visible when navigation is active.
+**Footer buttons**: Cancel [Esc], Next [Enter]. No Back button (this is the first step). Cancel always shows Esc hint (since no Back button competes for Escape). Navigation hint ↑↓ always visible (even when search input is focused, since arrow nav works from the input).
 
 **Decision (grilled 2026-05-04)**: The selected/highlighted issue row uses `bg-primary-soft` — a subtle green-tinted highlight from the Forest Moss palette (light: `oklch(0.92 0.03 135)` sage green, dark: `oklch(0.305 0.045 145)` deep forest green). Replaces the previous orange `bg-accent` highlight. Designer should verify text contrast on this background in both light and dark modes.
 
@@ -55,9 +55,11 @@ The wizard is opened via `Ctrl+N` or the "+" button on the dashboard.
 - Below: branch name preview in muted monospace (e.g., `Branch: 163-build-session-history-browsing`)
 
 **Keyboard**:
-- Enter: confirms the name and advances
+- Enter: confirms the name and advances. Works from **any focus within the modal** (global handler routes to confirm). If name is empty, shows inline error instead of advancing
 - All typing goes to the input (Backspace deletes text, not navigate back)
 - Escape: goes back one step (does NOT close the wizard) — because text input captures Backspace
+
+**Validation**: Empty name is rejected with inline error text "Issue name is required" (`text-destructive`) below the input. Error clears when user types any character.
 
 **Footer buttons (dynamic based on focus)**:
 - Input focused: Back [Esc], Cancel (no hint), Next [Enter]. No navigation hint
@@ -81,9 +83,11 @@ The wizard is opened via `Ctrl+N` or the "+" button on the dashboard.
   - **Selected No**: `border-red-500` + `bg-red-500/10` (red-tinted fill)
 
 **Keyboard**:
-- Left/Right arrows: toggle between Yes and No. Works from **any focus within the modal** (not just the cards)
-- Enter: confirms the selected choice and advances
+- Left/Right arrows: toggle between Yes and No. Works from **any focus within the modal** (not just the cards). Handled by the global keyboard router only (step component does not duplicate arrow handling)
+- Enter: confirms the selected choice and advances. Works from **any focus within the modal** (global handler routes to confirm)
 - Yes is pre-selected by default
+
+**Focus on step entry**: No element is focused when entering this step — `activeElement` is blurred on mount (via `requestAnimationFrame` to run after Dialog's focus trap). This prevents the Back button or Yes card from showing a focus outline. Tab cycles through Yes → No → footer buttons normally.
 
 **Footer buttons**: Back [⌫], Cancel [Esc], Next [Enter]. Navigation hint ←→ visible.
 
@@ -140,11 +144,11 @@ All footer buttons follow the same visual pattern: `Label [Kbd badge]` with the 
   - Other steps, text input focused: `Cancel` with **no Kbd hint** (Escape is claimed by Back)
   - Other steps, text input not focused: `Cancel [Esc]`
 - **Create/Confirm** button: primary variant, right-aligned. `Create [↵]` where ↵ is the Lucide `corner-down-left` icon inside a Kbd pill with `variant="inverted"` (semi-transparent white on primary background)
-- **Navigation hint**: ghost-style non-clickable label, centered in footer. Shows Kbd arrow icons + "Navigate" text. Visibility and arrows per step:
-  - Step 1: `↑↓` — visible when navigation is active
+- **Navigation hint**: ghost-style non-clickable label, centered in footer. Shows "Navigate" text followed by separate Kbd badges with individual arrow icons on the **right**. Uses `ArrowUpIcon`, `ArrowDownIcon`, `ArrowLeftIcon`, `ArrowRightIcon` (separate per direction). Visibility and arrows per step:
+  - Step 1: `Navigate [↑] [↓]` — **always visible** (even when search input is focused, since arrow nav works from the input)
   - Step 2: **never visible** (no navigable items)
-  - Step 3: `←→` — always visible
-  - Step 4: `↑↓←→` — hidden when hex text input is focused
+  - Step 3: `Navigate [←] [→]` — always visible
+  - Step 4: `Navigate [↑] [↓] [←] [→]` — hidden when hex text input is focused
 
 Layout: `[Back ⌫]  ———[Navigate ↑↓]———  [Cancel Esc] [Create ↵]`
 
@@ -185,7 +189,7 @@ Layout: `[Back ⌫]  ———[Navigate ↑↓]———  [Cancel Esc] [Create �
 - `Button` (shadcn) — footer buttons, all variants
 - `Kbd` (shadcn) — keyboard shortcut badges inside buttons. Supports `variant="default"` (for ghost/secondary buttons) and `variant="inverted"` (for primary buttons)
 - `Input` (shadcn) — search input, name input, hex input
-- Lucide icons: `corner-down-left` (Enter), `delete` (Backspace), `search`, `circle-dot`, `circle-check`, `loader-2`, `tree-pine`, `x`
+- Lucide icons: `corner-down-left` (Enter), `delete` (Backspace), `search`, `circle-dot`, `circle-check`, `loader-2`, `tree-pine`, `x`, `arrow-up`, `arrow-down`, `arrow-left`, `arrow-right` (nav hint arrows)
 
 ## What Is Set in Stone
 
@@ -208,9 +212,12 @@ Layout: `[Back ⌫]  ———[Navigate ↑↓]———  [Cancel Esc] [Create �
 - Arrow navigation in issue list scrolls selected item into view
 - Arrow keys work from any focus within the modal (not just inside step components). Exception: text input focused = arrows control cursor
 - Next button visible on Steps 1, 2, and 3
-- Escape goes back (not close) when text input is focused on any non-first step
+- Escape goes back (not close) when text input is focused on any non-first step. Dialog's own Escape handler is suppressed (`onEscapeKeydown preventDefault`)
+- Enter confirms the current step from **any focus within the modal** (not just inside the step component). Global handler routes to the step's confirm function
+- Step 3 (Worktree): no element is focused on entry — blur active element on mount. Tab cycles through Yes → No → footer buttons
+- Empty name validation: step 2 shows inline error "Issue name is required" when Enter is pressed with empty name. Error clears on typing
 - Dynamic footer buttons: Back/Cancel swap Kbd hints based on text input focus state
-- Navigation hint (arrow Kbd icons + "Navigate" text) shown per step: ↑↓ step 1, hidden step 2, ←→ step 3, ↑↓←→ step 4
+- Navigation hint ("Navigate" text + separate arrow Kbd icons) shown per step: ↑↓ step 1 (always visible), hidden step 2, ←→ step 3, ↑↓←→ step 4 (hidden when hex input focused)
 - Step 1: no preselection on open, arrow nav fills search bar (display only, no search trigger)
 - Issue name excludes issue number, trailing special chars stripped
 - Color swatch text ("A") not selectable (`user-select: none`, `pointer-events: none`)
@@ -270,7 +277,7 @@ The following items were resolved during grilling and are now **set in stone**:
 7. ~~Backspace in text inputs (search, name, hex) must not propagate to wizard navigation~~ ✅ Fixed on dev
 8. ~~Escape in Issue Name step should go back (not close wizard) since Backspace edits text~~ ✅ Fixed on dev
 9. ~~Step header text is not vertically centered and is too small~~ ✅ Fixed on dev
-10. Enter on step 2 (Issue Name) skips step 3 (Worktree), jumping directly to step 4 (Color). Suspected cause: keydown event double-fires across step transition. See #181
-11. Escape with focused input on step 2 may cancel the wizard instead of going back. Button label and actual behavior must match. See #181
-12. Issue name includes the issue number prefix — should be excluded. See #181
-13. Color swatches show double ring (selected + focus-visible outline). See #181
+10. ~~Enter on step 2 (Issue Name) skips step 3 (Worktree), jumping directly to step 4 (Color). Suspected cause: keydown event double-fires across step transition. See #181~~ ✅ Fixed
+11. ~~Escape with focused input on step 2 may cancel the wizard instead of going back. Button label and actual behavior must match. See #181~~ ✅ Fixed — Dialog's `onEscapeKeydown` suppressed, global handler routes correctly
+12. ~~Issue name includes the issue number prefix — should be excluded. See #181~~ ✅ Fixed
+13. ~~Color swatches show double ring (selected + focus-visible outline). See #181~~ ✅ Fixed

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -318,6 +318,7 @@
 	"wizard_assigned_heading": "Přiřazené vám",
 	"wizard_step_name": "Název úkolu",
 	"wizard_name_placeholder": "Název úkolu",
+	"wizard_name_required": "Název issue je povinný",
 	"wizard_branch_preview": "Větev: {branch}",
 	"wizard_step_worktree": "Vytvořit worktree?",
 	"wizard_worktree_yes": "Ano",

--- a/messages/en.json
+++ b/messages/en.json
@@ -334,6 +334,7 @@
 	"wizard_assigned_heading": "Assigned to you",
 	"wizard_step_name": "Issue Name",
 	"wizard_name_placeholder": "Issue name",
+	"wizard_name_required": "Issue name is required",
 	"wizard_branch_preview": "Branch: {branch}",
 	"wizard_step_worktree": "Create Worktree?",
 	"wizard_worktree_yes": "Yes",

--- a/src/lib/components/color-picker/ColorPickerContent.svelte
+++ b/src/lib/components/color-picker/ColorPickerContent.svelte
@@ -105,6 +105,7 @@
 		}
 
 		event.preventDefault();
+		event.stopPropagation();
 		focusedIndex = newIndex;
 		swatchElements[newIndex]?.focus();
 		onSelect(colors[newIndex]);

--- a/src/lib/components/creation-wizard/CreationWizard.svelte
+++ b/src/lib/components/creation-wizard/CreationWizard.svelte
@@ -124,7 +124,12 @@
 	function handleEnter(event: KeyboardEvent) {
 		switch (wizard.currentStep) {
 			case WIZARD_STEPS.GITHUB_SEARCH:
+				event.preventDefault();
+				githubSearchRef?.confirm();
+				break;
 			case WIZARD_STEPS.ISSUE_NAME:
+				event.preventDefault();
+				issueNameRef?.confirm();
 				break;
 			case WIZARD_STEPS.WORKTREE_CHOICE:
 				event.preventDefault();
@@ -319,17 +324,20 @@
 	});
 
 	const navigationHint = $derived.by((): 'vertical' | 'horizontal' | 'grid' | null => {
-		if (textInputFocused) {
-			return null;
-		}
 		switch (wizard.currentStep) {
 			case WIZARD_STEPS.GITHUB_SEARCH:
 				return 'vertical';
 			case WIZARD_STEPS.ISSUE_NAME:
 				return null;
 			case WIZARD_STEPS.WORKTREE_CHOICE:
+				if (textInputFocused) {
+					return null;
+				}
 				return 'horizontal';
 			case WIZARD_STEPS.COLOR_SELECTION:
+				if (textInputFocused) {
+					return null;
+				}
 				return 'grid';
 			default:
 				return null;
@@ -345,7 +353,10 @@
 />
 
 <Dialog.Root open={wizard.open} onOpenChange={handleOpenChange}>
-	<Dialog.Content class="top-[15%] -translate-y-0 max-w-lg">
+	<Dialog.Content
+		class="top-[15%] -translate-y-0 max-w-lg"
+		onEscapeKeydown={(e) => e.preventDefault()}
+	>
 		<Dialog.Header class="flex items-center">
 			<Dialog.Title class="text-base font-semibold text-foreground">
 				{stepLabel}
@@ -399,23 +410,21 @@
 				<div class="flex flex-1 items-center justify-center">
 					{#if navigationHint === 'vertical'}
 						<span class="flex items-center gap-1.5 text-xs text-muted-foreground/60">
-							<Kbd><ArrowUpIcon /></Kbd>
-							<Kbd><ArrowDownIcon /></Kbd>
 							{m.wizard_navigate()}
+							<Kbd><ArrowUpIcon /><ArrowDownIcon /></Kbd>
 						</span>
 					{:else if navigationHint === 'horizontal'}
 						<span class="flex items-center gap-1.5 text-xs text-muted-foreground/60">
-							<Kbd><ArrowLeftIcon /></Kbd>
-							<Kbd><ArrowRightIcon /></Kbd>
 							{m.wizard_navigate()}
+							<Kbd><ArrowLeftIcon /><ArrowRightIcon /></Kbd>
 						</span>
 					{:else if navigationHint === 'grid'}
 						<span class="flex items-center gap-1.5 text-xs text-muted-foreground/60">
-							<Kbd><ArrowUpIcon /></Kbd>
-							<Kbd><ArrowDownIcon /></Kbd>
-							<Kbd><ArrowLeftIcon /></Kbd>
-							<Kbd><ArrowRightIcon /></Kbd>
 							{m.wizard_navigate()}
+							<Kbd
+								><ArrowUpIcon /><ArrowDownIcon /><ArrowLeftIcon /><ArrowRightIcon
+								/></Kbd
+							>
 						</span>
 					{/if}
 				</div>

--- a/src/lib/components/creation-wizard/StepIssueName.svelte
+++ b/src/lib/components/creation-wizard/StepIssueName.svelte
@@ -9,6 +9,7 @@
 
 	let nameValue = $state(wizard.formData.issueName);
 	let inputElement = $state<HTMLInputElement | null>(null);
+	let showError = $state(false);
 
 	const branchPreview = $derived.by(() => {
 		if (wizard.formData.githubIssueNumber !== null) {
@@ -28,7 +29,10 @@
 	export function confirm() {
 		const trimmed = nameValue.trim();
 		if (trimmed) {
+			showError = false;
 			wizard.confirmIssueName(trimmed, branchPreview);
+		} else {
+			showError = true;
 		}
 	}
 
@@ -48,7 +52,11 @@
 		bind:value={nameValue}
 		placeholder={m.wizard_name_placeholder()}
 		onkeydown={handleKeydown}
+		oninput={() => (showError = false)}
 	/>
+	{#if showError}
+		<p class="text-xs text-destructive">{m.wizard_name_required()}</p>
+	{/if}
 	{#if branchPreview}
 		<p class="text-xs text-muted-foreground">
 			{m.wizard_branch_preview({ branch: branchPreview })}

--- a/src/lib/components/creation-wizard/StepWorktreeChoice.svelte
+++ b/src/lib/components/creation-wizard/StepWorktreeChoice.svelte
@@ -1,10 +1,19 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
+	import { onMount } from 'svelte';
 	import { useCreationWizard } from '$lib/modules/creation-wizard';
 	import TreePine from '@lucide/svelte/icons/tree-pine';
 	import X from '@lucide/svelte/icons/x';
 
 	const wizard = useCreationWizard();
+
+	onMount(() => {
+		requestAnimationFrame(() => {
+			if (document.activeElement instanceof HTMLElement) {
+				document.activeElement.blur();
+			}
+		});
+	});
 
 	let selectedChoice = $state<boolean>(true);
 
@@ -22,10 +31,7 @@
 	}
 
 	function handleKeydown(event: KeyboardEvent) {
-		if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
-			event.preventDefault();
-			selectedChoice = !selectedChoice;
-		} else if (event.key === 'Enter') {
+		if (event.key === 'Enter') {
 			event.preventDefault();
 			event.stopPropagation();
 			confirm();

--- a/src/lib/components/ui/kbd/kbd-variants.ts
+++ b/src/lib/components/ui/kbd/kbd-variants.ts
@@ -4,7 +4,7 @@ import type { HTMLAttributes } from 'svelte/elements';
 import { type VariantProps, tv } from 'tailwind-variants';
 
 export const kbdVariants = tv({
-	base: 'inline-flex items-center justify-center min-w-[18px] h-[18px] px-[5px] rounded-[4px] font-mono text-[10.5px] [&_svg:not([class*="size-"])]:size-3 [&_svg]:shrink-0',
+	base: 'inline-flex items-center justify-center gap-px min-w-[18px] h-[18px] px-[5px] rounded-[4px] font-mono text-[10.5px] [&_svg:not([class*="size-"])]:size-3 [&_svg]:shrink-0',
 	variants: {
 		variant: {
 			default: 'bg-surface-2 border border-border text-foreground-muted',


### PR DESCRIPTION
## Description
- Navigation hint always visible on step 1, multi-icon support via gap-px in Kbd component
- Enter key confirms current step from any focus within modal (steps 1, 2, 3)
- Escape goes back (not close wizard) when text input focused — Dialog onEscapeKeydown suppressed
- Empty name validation on step 2 with inline error message
- Step 3 blurs active element on mount to prevent unwanted focus
- Step 3 arrow key handling deduplicated — only global handler routes
- Color swatch arrow keys no longer double-fire with global handler (stopPropagation)
- Design brief and requirements updated to reflect actual UX behavior

## Resolves
Closes #172

## Testing
- [x] All 705 unit tests pass
- [x] Full check suite passes (format + lint + fallow + typecheck + eslint)
- [ ] Manual: Navigation hint always visible on step 1 (not hidden when input focused)
- [ ] Manual: Enter confirms from any focus (step 1, 2, 3)
- [ ] Manual: Escape with focused input goes back; without focus closes
- [ ] Manual: Empty name shows validation error on step 2
- [ ] Manual: Step 3 opens with no element focused
- [ ] Manual: Arrow keys navigate worktree choice (no double-fire from color swatch)