### PR TITLE
fix: issue card UX polish, interaction states, accent color audit

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -201,8 +201,8 @@
 	--primary: var(--moss-700);
 	--primary-fg: oklch(0.985 0.008 130);
 	--primary-soft: oklch(0.92 0.03 135);
-	--accent: var(--amber-500);
-	--accent-fg: oklch(0.16 0.02 50);
+	--accent: var(--moss-500);
+	--accent-fg: oklch(0.985 0.008 130);
 	--ring: var(--moss-600);
 	--sidebar-bg: oklch(0.955 0.01 135);
 	--sidebar-fg: oklch(0.3 0.02 145);
@@ -229,8 +229,8 @@
 	--primary: var(--moss-400);
 	--primary-fg: oklch(0.135 0.02 150);
 	--primary-soft: oklch(0.305 0.045 145);
-	--accent: var(--amber-400);
-	--accent-fg: oklch(0.15 0.02 50);
+	--accent: var(--moss-400);
+	--accent-fg: oklch(0.135 0.02 150);
 	--ring: var(--moss-400);
 	--sidebar-bg: oklch(0.18 0.022 150);
 	--sidebar-fg: oklch(0.77 0.02 140);
@@ -243,10 +243,22 @@
 
 /* ── Accent color overrides ─────────────────────────────────────────────── */
 
+[data-accent='moss'][data-theme='light'] {
+	--accent: var(--moss-500);
+	--accent-fg: oklch(0.985 0.008 130);
+}
+
+[data-accent='moss'][data-theme='dark'] {
+	--accent: var(--moss-400);
+	--accent-fg: oklch(0.135 0.02 150);
+}
+
 [data-accent='amber'][data-theme='light'] {
 	--primary: var(--amber-600);
 	--primary-fg: oklch(0.985 0.008 75);
 	--primary-soft: oklch(0.92 0.065 75);
+	--accent: var(--amber-500);
+	--accent-fg: oklch(0.16 0.02 50);
 	--ring: var(--amber-600);
 }
 
@@ -254,6 +266,8 @@
 	--primary: var(--amber-400);
 	--primary-fg: oklch(0.135 0.02 55);
 	--primary-soft: oklch(0.305 0.07 60);
+	--accent: var(--amber-400);
+	--accent-fg: oklch(0.15 0.02 50);
 	--ring: var(--amber-400);
 }
 
@@ -261,6 +275,8 @@
 	--primary: var(--bark-700);
 	--primary-fg: oklch(0.985 0.008 55);
 	--primary-soft: oklch(0.92 0.03 55);
+	--accent: var(--bark-500);
+	--accent-fg: oklch(0.985 0.008 55);
 	--ring: var(--bark-700);
 }
 
@@ -268,6 +284,8 @@
 	--primary: var(--bark-300);
 	--primary-fg: oklch(0.135 0.02 50);
 	--primary-soft: oklch(0.305 0.04 55);
+	--accent: var(--bark-300);
+	--accent-fg: oklch(0.135 0.02 50);
 	--ring: var(--bark-300);
 }
 
@@ -275,6 +293,8 @@
 	--primary: var(--azure-600);
 	--primary-fg: oklch(0.985 0.008 230);
 	--primary-soft: oklch(0.92 0.04 230);
+	--accent: var(--azure-500);
+	--accent-fg: oklch(0.985 0.008 230);
 	--ring: var(--azure-600);
 }
 
@@ -282,6 +302,8 @@
 	--primary: var(--azure-400);
 	--primary-fg: oklch(0.135 0.02 240);
 	--primary-soft: oklch(0.305 0.055 235);
+	--accent: var(--azure-400);
+	--accent-fg: oklch(0.135 0.02 240);
 	--ring: var(--azure-400);
 }
 

--- a/src/lib/components/BatchActionToolbar.svelte
+++ b/src/lib/components/BatchActionToolbar.svelte
@@ -2,7 +2,6 @@
 	import type { Issue, IssuePriority } from '$lib/modules/issues';
 	import { PRIORITY_OPTIONS } from '$lib/components/issue_card_utils.js';
 	import { Button } from '$lib/components/ui/button/index.js';
-	import Checkbox from '$lib/components/ui/checkbox/Checkbox.svelte';
 	import * as Popover from '$lib/components/ui/popover/index.js';
 	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
 	import ArchiveIcon from '@lucide/svelte/icons/archive';
@@ -15,8 +14,7 @@
 	interface Props {
 		selectedCount: number;
 		selectedIssues: Issue[];
-		selectAllCheckboxState: 'all' | 'some' | 'none';
-		onSelectAll: () => void;
+		isModifierHeld?: boolean;
 		onDeselectAll: () => void;
 		onBatchArchive: () => void;
 		onBatchUnarchive: () => void;
@@ -28,8 +26,7 @@
 	let {
 		selectedCount,
 		selectedIssues,
-		selectAllCheckboxState,
-		onSelectAll,
+		isModifierHeld = false,
 		onDeselectAll,
 		onBatchArchive,
 		onBatchUnarchive,
@@ -43,18 +40,27 @@
 	const hasActiveWorktrees = $derived(selectedIssues.some((i) => i.worktree_state === 'active'));
 	const hasBatchSelection = $derived(selectedCount > 0);
 
-	const checkboxChecked = $derived(selectAllCheckboxState === 'all');
-	const checkboxIndeterminate = $derived(selectAllCheckboxState === 'some');
+	const toolbarBackground = $derived.by(() => {
+		if (hasBatchSelection) {
+			return 'color-mix(in oklch, var(--primary) 10%, var(--surface))';
+		}
+		if (isModifierHeld) {
+			return 'color-mix(in oklch, var(--primary) 8%, var(--surface))';
+		}
+		return 'transparent';
+	});
+
+	const toolbarBorderColor = $derived.by(() => {
+		if (hasBatchSelection) {
+			return 'color-mix(in oklch, var(--primary) 30%, var(--border))';
+		}
+		if (isModifierHeld) {
+			return 'color-mix(in oklch, var(--primary) 22%, var(--border))';
+		}
+		return 'transparent';
+	});
 
 	let priorityPopoverOpen = $state(false);
-
-	function handleCheckboxClick() {
-		if (selectAllCheckboxState === 'all') {
-			onDeselectAll();
-		} else {
-			onSelectAll();
-		}
-	}
 
 	function handlePrioritySelect(priority: IssuePriority | null) {
 		priorityPopoverOpen = false;
@@ -65,21 +71,9 @@
 <Tooltip.Provider>
 	<div
 		class="flex min-h-[42px] items-center gap-3 rounded-[var(--radius-md)] border px-[14px] py-2 text-[13px] font-medium"
-		style="background: color-mix(in oklch, var(--primary) {hasBatchSelection
-			? '10%'
-			: '4%'}, var(--surface)); border-color: color-mix(in oklch, var(--primary) {hasBatchSelection
-			? '30%'
-			: '15%'}, var(--border));"
+		style="background: {toolbarBackground}; border-color: {toolbarBorderColor};"
 	>
 		{#if hasBatchSelection}
-			<!-- Select-all checkbox -->
-			<Checkbox
-				checked={checkboxChecked}
-				indeterminate={checkboxIndeterminate}
-				onclick={handleCheckboxClick}
-				aria-label="Select all issues"
-			/>
-
 			<!-- Count badge + label -->
 			<div class="flex items-center gap-2">
 				<span
@@ -216,14 +210,8 @@
 				</Button>
 			</div>
 		{:else}
-			<!-- Default state: Clean Up Worktrees button -->
-			<div class="flex flex-1 items-center justify-between">
-				<span class="text-muted-foreground">
-					Hold <kbd class="rounded border border-border px-1 py-0.5 text-[10px]">Ctrl</kbd
-					>
-					or <kbd class="rounded border border-border px-1 py-0.5 text-[10px]">Shift</kbd>
-					to select multiple issues
-				</span>
+			<!-- Default state: Clean Up Worktrees button only -->
+			<div class="flex flex-1 items-center justify-end">
 				<Tooltip.Root>
 					<Tooltip.Trigger>
 						{#snippet child({ props })}

--- a/src/lib/components/IssueCard.svelte
+++ b/src/lib/components/IssueCard.svelte
@@ -33,7 +33,6 @@
 		sessionState?: 'executing' | 'hitl' | 'review' | 'error' | 'paused' | 'done' | null;
 		isActive?: boolean;
 		isBatchSelected?: boolean;
-		isSelectionReady?: boolean;
 		onOverflowClick?: () => void;
 		onCardClick?: (event: MouseEvent) => void;
 		onExecuteAction?: (actionId: string, issueId: string) => void;
@@ -54,7 +53,6 @@
 		sessionState = null,
 		isActive = false,
 		isBatchSelected = false,
-		isSelectionReady = false,
 		onOverflowClick,
 		onCardClick,
 		onExecuteAction,
@@ -108,9 +106,6 @@
 		if (isActive) {
 			return CARD_STATE_CLASSES.active;
 		}
-		if (isSelectionReady) {
-			return CARD_STATE_CLASSES.selectionReady;
-		}
 		return '';
 	});
 
@@ -155,9 +150,11 @@
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
-	class="group relative overflow-hidden rounded-lg border border-border shadow-sm transition-all duration-150 {cardStateClass} {isArchived
+	class="group relative overflow-hidden rounded-lg border border-border shadow-sm outline-none transition-all duration-150 focus:outline-none {cardStateClass} {isArchived ||
+	isActive ||
+	isBatchSelected
 		? ''
-		: 'hover:ring-2 hover:ring-[#ffd700] dark:hover:ring-[#d4a017]'}"
+		: 'hover:ring-2 hover:ring-[#ffd700] active:ring-2 active:ring-[#22c55e] dark:hover:ring-[#d4a017] dark:active:ring-[#4ade80]'}"
 	style:--ic={color}
 	style="background: var(--surface);"
 	onclick={handleCardClick}
@@ -168,27 +165,27 @@
 		style="background-color: {color}; color: {headerTextColor};"
 	>
 		<div class="flex min-w-0 flex-1 items-baseline gap-1.5">
-			<span class="shrink-0 font-mono text-[11px] font-semibold opacity-72">
-				#{issue.github_issue_number ?? '—'}
-			</span>
 			{#if issue.github_issue_url}
 				<!-- eslint-disable svelte/no-navigation-without-resolve -- external GitHub link -->
 				<a
 					href={issue.github_issue_url}
 					target="_blank"
 					rel="noopener noreferrer"
-					class="min-w-0 truncate text-[13.5px] font-semibold leading-snug hover:underline hover:underline-offset-2"
+					class="shrink-0 font-mono text-[11px] font-semibold opacity-72 hover:opacity-100"
 					style="color: inherit;"
 					onclick={(event) => event.stopPropagation()}
 				>
-					{issue.name}
+					#{issue.github_issue_number ?? '—'}
 				</a>
 				<!-- eslint-enable svelte/no-navigation-without-resolve -->
 			{:else}
-				<span class="min-w-0 truncate text-[13.5px] font-semibold leading-snug">
-					{issue.name}
+				<span class="shrink-0 font-mono text-[11px] font-semibold opacity-72">
+					#{issue.github_issue_number ?? '—'}
 				</span>
 			{/if}
+			<span class="min-w-0 truncate text-[13.5px] font-semibold leading-snug">
+				{issue.name}
+			</span>
 		</div>
 
 		<div class="flex shrink-0 items-center gap-1.5">
@@ -268,13 +265,9 @@
 		</div>
 
 		<!-- Info rows -->
-		<div class="flex min-w-0 flex-col gap-1">
-			<!-- Branch + state badges row (REQ-7: branch left, badges right) -->
-			<div
-				class="flex min-w-0 flex-wrap items-center gap-1.5"
-				bind:clientWidth={badgeContainerWidth}
-			>
-				<!-- Branch name (left-aligned) -->
+		<div class="flex min-w-0 flex-col gap-1" bind:clientWidth={badgeContainerWidth}>
+			<!-- Row 1: Branch name + worktree state icon + worktree badge -->
+			<div class="flex min-w-0 items-center gap-1.5">
 				<div
 					class="flex min-w-0 flex-1 items-center gap-1.5 font-mono text-[11px] text-muted-foreground"
 				>
@@ -288,9 +281,23 @@
 					{/if}
 					<WorktreeStateIcon worktreeState={issue.worktree_state} />
 				</div>
+				{#if worktreeBadge}
+					<span
+						class="inline-flex shrink-0 items-center gap-1 rounded px-1.5 py-0.5 text-xs {worktreeBadge.class}"
+					>
+						{#if issue.worktree_state === 'pending'}
+							<span
+								class="inline-block size-3 animate-spin rounded-full border-2 border-current border-t-transparent"
+							></span>
+						{/if}
+						{worktreeBadge.label}
+					</span>
+				{/if}
+			</div>
 
-				<!-- State badges (right-aligned) -->
-				<div class="flex shrink-0 flex-wrap items-center justify-end gap-1">
+			<!-- Row 2: GitHub issue badge + PR badge + git status badges -->
+			{#if cache?.github_issue_state != null || cache?.pr_state != null || (issue.branch_name != null && issue.branch_name !== '' && !compactBadges)}
+				<div class="flex flex-wrap items-center gap-1">
 					{#if cache?.github_issue_state}
 						<GitHubIssueBadge
 							state={cache.github_issue_state}
@@ -313,22 +320,10 @@
 							gitStatus={cache ?? undefined}
 						/>
 					{/if}
-					{#if worktreeBadge}
-						<span
-							class="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs {worktreeBadge.class}"
-						>
-							{#if issue.worktree_state === 'pending'}
-								<span
-									class="inline-block size-3 animate-spin rounded-full border-2 border-current border-t-transparent"
-								></span>
-							{/if}
-							{worktreeBadge.label}
-						</span>
-					{/if}
 				</div>
-			</div>
+			{/if}
 
-			<!-- Labels row -->
+			<!-- Row 3: GitHub issue labels -->
 			{#if issue.labels.length > 0}
 				<div class="flex flex-wrap items-center gap-1">
 					{#each issue.labels as label (label.name)}

--- a/src/lib/components/IssueCardContextMenu.svelte
+++ b/src/lib/components/IssueCardContextMenu.svelte
@@ -93,7 +93,7 @@
 						{#if issue.priority === option.value}
 							<CheckIcon class="size-4" />
 						{:else}
-							<span class="size-4"></span>
+							<span class="inline-flex size-4 shrink-0"></span>
 						{/if}
 						{option.label()}
 					</ContextMenu.Item>

--- a/src/lib/components/IssueCardList.svelte
+++ b/src/lib/components/IssueCardList.svelte
@@ -6,7 +6,6 @@
 	import IssueCard from './IssueCard.svelte';
 	import IssueCardContextMenu from './IssueCardContextMenu.svelte';
 	import BatchActionToolbar from './BatchActionToolbar.svelte';
-	import { computeSelectAllCheckboxState } from './batch_selection_utils.js';
 
 	// fallow-ignore-next-line code-duplication
 	interface Props extends IssueCardCallbacks {
@@ -81,10 +80,6 @@
 		flatVisualOrder.filter((issue) => selection.batchSelectedIssueIds.has(issue.id)),
 	);
 
-	const selectAllState = $derived(
-		computeSelectAllCheckboxState(selection.batchCount, flatVisualOrder.length),
-	);
-
 	let isModifierHeld = $state(false);
 
 	function handleCardClick(issue: Issue, event: MouseEvent) {
@@ -127,10 +122,6 @@
 
 	function handleToggleSelect(issueId: string) {
 		selection.toggleBatchSelect(issueId);
-	}
-
-	function handleSelectAll() {
-		selection.batchSelectAll(flatIssueIds);
 	}
 
 	function handleDeselectAll() {
@@ -211,8 +202,7 @@
 		<BatchActionToolbar
 			selectedCount={selection.batchCount}
 			{selectedIssues}
-			selectAllCheckboxState={selectAllState}
-			onSelectAll={handleSelectAll}
+			{isModifierHeld}
 			onDeselectAll={handleDeselectAll}
 			onBatchArchive={handleBatchArchive}
 			onBatchUnarchive={handleBatchUnarchive}
@@ -262,8 +252,6 @@
 					{prioritiesEnabled}
 					isActive={selection.activeIssueId === issue.id}
 					isBatchSelected={selection.batchSelectedIssueIds.has(issue.id)}
-					isSelectionReady={isModifierHeld &&
-						!selection.batchSelectedIssueIds.has(issue.id)}
 					onCardClick={(event) => handleCardClick(issue, event)}
 					{onExecuteAction}
 				/>

--- a/src/lib/components/WorkspaceBottomPanel.svelte
+++ b/src/lib/components/WorkspaceBottomPanel.svelte
@@ -23,8 +23,6 @@
 	import IssueDetail from './IssueDetail.svelte';
 	import GhSetupBanner from './GhSetupBanner.svelte';
 	import AssignedIssuesPanel from './AssignedIssuesPanel.svelte';
-	import ScissorsIcon from '@lucide/svelte/icons/scissors';
-	import { Button } from '$lib/components/ui/button/index.js';
 
 	// fallow-ignore-next-line code-duplication
 	interface Props extends IssueCardCallbacks {
@@ -180,21 +178,6 @@
 					<GhSetupBanner availability={ghAvailability} />
 				{/if}
 
-				<div class="flex items-center justify-between">
-					<div></div>
-					{#if onPrune}
-						<Button
-							variant="ghost"
-							size="sm"
-							title={m.topbar_prune_title()}
-							onclick={onPrune}
-						>
-							<ScissorsIcon size={12} />
-							<span>{m.topbar_prune()}</span>
-						</Button>
-					{/if}
-				</div>
-
 				<IssueCardList
 					{parentIssues}
 					{archivedIssues}
@@ -218,6 +201,7 @@
 					{onRemoveWorktree}
 					{onExecuteAction}
 					{onChangeColor}
+					onBatchPrune={onPrune ? () => onPrune!() : undefined}
 				/>
 
 				{#if assignedIssues.length > 0}

--- a/src/lib/components/batch_selection_utils.test.ts
+++ b/src/lib/components/batch_selection_utils.test.ts
@@ -84,7 +84,6 @@ describe('CARD_STATE_CLASSES', () => {
 		const expectedKeys = [
 			'active',
 			'selected',
-			'selectionReady',
 			'dragging',
 			'loading',
 			'archived',
@@ -107,12 +106,6 @@ describe('CARD_STATE_CLASSES', () => {
 
 	it('selected class uses blue ring-2', () => {
 		expect(CARD_STATE_CLASSES.selected).toBe('ring-2 ring-[#4a9eff] dark:ring-[#3b82f6]');
-	});
-
-	it('selectionReady class uses blue ring-1 with reduced opacity', () => {
-		expect(CARD_STATE_CLASSES.selectionReady).toBe(
-			'ring-1 ring-[#4a9eff]/60 dark:ring-[#3b82f6]/60',
-		);
 	});
 });
 

--- a/src/lib/components/batch_selection_utils.ts
+++ b/src/lib/components/batch_selection_utils.ts
@@ -46,7 +46,6 @@ export function computeSelectAllCheckboxState(
 export const CARD_STATE_CLASSES = {
 	active: 'ring-2 ring-[#22c55e] dark:ring-[#4ade80]',
 	selected: 'ring-2 ring-[#4a9eff] dark:ring-[#3b82f6]',
-	selectionReady: 'ring-1 ring-[#4a9eff]/60 dark:ring-[#3b82f6]/60',
 	dragging: 'rotate-[-1.5deg] scale-[1.02] shadow-lg opacity-92',
 	loading: 'pointer-events-none',
 	archived: 'opacity-70 grayscale-[0.8]',


### PR DESCRIPTION
## Summary

Fixes 10 post-merge issues from PR #186 covering toolbar behavior, card interaction states, badge layout, context menu alignment, focus ring, accent color theming, and selection-ready removal.

- **Accent color fix**: `--accent`/`--accent-fg` now override per `[data-accent]` block so `bg-accent` tracks the user's chosen accent (moss/amber/bark/azure)
- **Toolbar cleanup**: Removed standalone prune button from WorkspaceBottomPanel, removed select-all checkbox, removed Ctrl/Shift hint text
- **Selection-ready removal**: Removed `ring-1` selection-ready state from cards; modifier-held state now shown via toolbar bg/border tint
- **Interaction states**: Hover ring suppressed on active/selected cards; `:active` green flash on mousedown; browser focus ring removed
- **Issue number link**: `#42` is now a clickable `<a>` opening the GitHub issue in a new tab
- **Badge restructure**: 3 distinct rows — branch+worktree, PR/issue/git-status, labels
- **Context menu fix**: Priority submenu checkmark/placeholder alignment fixed with `inline-flex shrink-0`

Closes #187

## Test plan

- [ ] Switch accent to each color (moss, amber, bark, azure) in both themes — verify context menu hover uses correct accent
- [ ] Verify standalone "Clean Up Worktrees" button gone from bottom panel
- [ ] Ctrl+click cards — no checkbox in toolbar
- [ ] Hold Ctrl/Shift — toolbar gains tinted bg/border, cards show no ring-1
- [ ] Hover active/selected card — no gold hover ring
- [ ] Mousedown non-selected card — green flash
- [ ] Click `#42` number — opens GitHub issue in new tab
- [ ] Tab to cards — no browser focus outline
- [ ] Priority submenu — check/placeholder vertically aligned
- [ ] Badge rows: branch row, github/PR/git row, labels row
- [ ] Dark mode dropdown has solid bg and shadow