### PR TITLE
#188 feat: browser back/forward navigation with URL-encoded state

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -3,7 +3,10 @@ declare global {
 		// interface Error {}
 		// interface Locals {}
 		// interface PageData {}
-		// interface PageState {}
+		interface PageState {
+			activeIssueId?: string | null;
+			activeTab?: string | null;
+		}
 		// interface Platform {}
 	}
 }

--- a/src/lib/modules/board/index.ts
+++ b/src/lib/modules/board/index.ts
@@ -16,6 +16,7 @@ export type {
 export { ACCENT_COLORS } from './types.js';
 
 export { setSelectionContext, useSelection } from './selection.context.svelte.js';
+export { initUrlStateSync } from './url_state_sync.svelte.js';
 export {
 	BOTTOM_PANEL_TABS,
 	TAB_BEHAVIOR_MAP,

--- a/src/lib/modules/board/selection.context.svelte.ts
+++ b/src/lib/modules/board/selection.context.svelte.ts
@@ -53,6 +53,13 @@ function createSelectionContext() {
 		hoveredIssueId.current = null;
 	}
 
+	function clearBatchSelection() {
+		batchSelectedIssueIds.clear();
+		individuallySelectedIds.clear();
+		rangeSelectedIds.clear();
+		batchAnchorId.current = null;
+	}
+
 	function activateIssue(issueId: string) {
 		if (activeIssueId.current === issueId) {
 			if (activeTab.current !== BOTTOM_PANEL_TABS.issueDetail) {
@@ -64,10 +71,7 @@ function createSelectionContext() {
 		if (activeTab.current === null && !shouldShowPrdOverview(issueId, prdIssueId.current)) {
 			activeTab.current = BOTTOM_PANEL_TABS.issueDetail;
 		}
-		batchSelectedIssueIds.clear();
-		individuallySelectedIds.clear();
-		rangeSelectedIds.clear();
-		batchAnchorId.current = null;
+		clearBatchSelection();
 	}
 
 	function deactivate() {
@@ -75,12 +79,15 @@ function createSelectionContext() {
 		activeTab.current = null;
 	}
 
+	function restoreFromUrl(issueId: string | null, tab: BottomPanelTab | null) {
+		activeIssueId.current = issueId;
+		activeTab.current = tab;
+		clearBatchSelection();
+	}
+
 	function setActiveTab(tab: BottomPanelTab | null) {
 		activeTab.current = tab;
-		batchSelectedIssueIds.clear();
-		individuallySelectedIds.clear();
-		rangeSelectedIds.clear();
-		batchAnchorId.current = null;
+		clearBatchSelection();
 	}
 
 	function toggleBatchSelect(issueId: string) {
@@ -125,10 +132,7 @@ function createSelectionContext() {
 	}
 
 	function batchDeselectAll() {
-		batchSelectedIssueIds.clear();
-		individuallySelectedIds.clear();
-		rangeSelectedIds.clear();
-		batchAnchorId.current = null;
+		clearBatchSelection();
 	}
 
 	function removeBatchItems(ids: readonly string[]) {
@@ -189,6 +193,7 @@ function createSelectionContext() {
 		unhover,
 		activateIssue,
 		deactivate,
+		restoreFromUrl,
 		setActiveTab,
 		setPrdIssueId,
 		toggleForestCollapsed,

--- a/src/lib/modules/board/url_state.test.ts
+++ b/src/lib/modules/board/url_state.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import { BOTTOM_PANEL_TABS } from './selection.js';
+import {
+	serializeSelectionToParams,
+	parseSelectionFromUrl,
+	selectionMatchesUrl,
+	buildSelectionUrl,
+} from './url_state.js';
+
+describe('serializeSelectionToParams', () => {
+	it('encodes issue and tab', () => {
+		const params = serializeSelectionToParams({ issueId: 'abc-123', tab: 'dependencies' });
+		expect(params.get('issue')).toBe('abc-123');
+		expect(params.get('tab')).toBe('dependencies');
+	});
+
+	it('omits null issue', () => {
+		const params = serializeSelectionToParams({ issueId: null, tab: 'issues' });
+		expect(params.has('issue')).toBe(false);
+		expect(params.get('tab')).toBe('issues');
+	});
+
+	it('omits null tab', () => {
+		const params = serializeSelectionToParams({ issueId: 'abc', tab: null });
+		expect(params.get('issue')).toBe('abc');
+		expect(params.has('tab')).toBe(false);
+	});
+
+	it('both null produces empty params', () => {
+		const params = serializeSelectionToParams({ issueId: null, tab: null });
+		expect(params.toString()).toBe('');
+	});
+});
+
+describe('parseSelectionFromUrl', () => {
+	it('parses valid params', () => {
+		const url = new URL('http://localhost/?issue=abc-123&tab=dependencies');
+		expect(parseSelectionFromUrl(url)).toEqual({ issueId: 'abc-123', tab: 'dependencies' });
+	});
+
+	it('invalid tab returns null tab', () => {
+		const url = new URL('http://localhost/?issue=abc&tab=bogus');
+		expect(parseSelectionFromUrl(url)).toEqual({ issueId: 'abc', tab: null });
+	});
+
+	it('no params returns both null', () => {
+		const url = new URL('http://localhost/');
+		expect(parseSelectionFromUrl(url)).toEqual({ issueId: null, tab: null });
+	});
+
+	it('only issue param', () => {
+		const url = new URL('http://localhost/?issue=abc');
+		expect(parseSelectionFromUrl(url)).toEqual({ issueId: 'abc', tab: null });
+	});
+
+	it('validates all valid tab values', () => {
+		for (const tabValue of Object.values(BOTTOM_PANEL_TABS)) {
+			const url = new URL(`http://localhost/?tab=${tabValue}`);
+			const result = parseSelectionFromUrl(url);
+			expect(result.tab).toBe(tabValue);
+		}
+	});
+});
+
+describe('selectionMatchesUrl', () => {
+	it('returns true when matching', () => {
+		const url = new URL('http://localhost/?issue=abc&tab=issues');
+		expect(selectionMatchesUrl({ issueId: 'abc', tab: 'issues' }, url)).toBe(true);
+	});
+
+	it('returns false when different issue', () => {
+		const url = new URL('http://localhost/?issue=abc&tab=issues');
+		expect(selectionMatchesUrl({ issueId: 'xyz', tab: 'issues' }, url)).toBe(false);
+	});
+
+	it('returns false when different tab', () => {
+		const url = new URL('http://localhost/?issue=abc&tab=issues');
+		expect(selectionMatchesUrl({ issueId: 'abc', tab: 'kanban' }, url)).toBe(false);
+	});
+
+	it('null state matches URL without params', () => {
+		const url = new URL('http://localhost/');
+		expect(selectionMatchesUrl({ issueId: null, tab: null }, url)).toBe(true);
+	});
+
+	it('returns false when state has issue but URL does not', () => {
+		const url = new URL('http://localhost/');
+		expect(selectionMatchesUrl({ issueId: 'abc', tab: null }, url)).toBe(false);
+	});
+
+	it('returns false when URL has issue but state does not', () => {
+		const url = new URL('http://localhost/?issue=abc');
+		expect(selectionMatchesUrl({ issueId: null, tab: null }, url)).toBe(false);
+	});
+});
+
+describe('buildSelectionUrl', () => {
+	it('builds correct URL with params', () => {
+		const base = new URL('http://localhost/');
+		const result = buildSelectionUrl(base, { issueId: 'abc', tab: 'dependencies' });
+		expect(result.href).toBe('http://localhost/?issue=abc&tab=dependencies');
+	});
+
+	it('clears existing params', () => {
+		const base = new URL('http://localhost/?old=param');
+		const result = buildSelectionUrl(base, { issueId: 'abc', tab: null });
+		expect(result.href).toBe('http://localhost/?issue=abc');
+	});
+
+	it('both null produces clean URL', () => {
+		const base = new URL('http://localhost/?issue=abc');
+		const result = buildSelectionUrl(base, { issueId: null, tab: null });
+		expect(result.href).toBe('http://localhost/');
+	});
+});

--- a/src/lib/modules/board/url_state.ts
+++ b/src/lib/modules/board/url_state.ts
@@ -1,0 +1,56 @@
+import { isBottomPanelTab } from './selection.js';
+import type { BottomPanelTab } from './selection.js';
+
+// ─── URL Param Names ────────────────────────────────────────────────────
+
+const PARAM_ISSUE = 'issue';
+const PARAM_TAB = 'tab';
+
+// ─── Types ──────────────────────────────────────────────────────────────
+
+export interface UrlSelectionState {
+	issueId: string | null;
+	tab: BottomPanelTab | null;
+}
+
+// ─── Serialize ──────────────────────────────────────────────────────────
+
+export function serializeSelectionToParams(state: UrlSelectionState): URLSearchParams {
+	const params = new URLSearchParams();
+	if (state.issueId !== null) {
+		params.set(PARAM_ISSUE, state.issueId);
+	}
+	if (state.tab !== null) {
+		params.set(PARAM_TAB, state.tab);
+	}
+	return params;
+}
+
+// ─── Parse ──────────────────────────────────────────────────────────────
+
+export function parseSelectionFromUrl(url: URL): UrlSelectionState {
+	const issueId = url.searchParams.get(PARAM_ISSUE);
+	const tabParam = url.searchParams.get(PARAM_TAB);
+	const tab = isBottomPanelTab(tabParam) ? tabParam : null;
+	return { issueId, tab };
+}
+
+// ─── Match Check ────────────────────────────────────────────────────────
+
+export function selectionMatchesUrl(state: UrlSelectionState, url: URL): boolean {
+	const current = parseSelectionFromUrl(url);
+	return current.issueId === state.issueId && current.tab === state.tab;
+}
+
+// ─── Build URL ──────────────────────────────────────────────────────────
+
+export function buildSelectionUrl(baseUrl: URL, state: UrlSelectionState): URL {
+	const newUrl = new URL(baseUrl);
+	newUrl.search = '';
+	const params = serializeSelectionToParams(state);
+	const paramString = params.toString();
+	if (paramString) {
+		newUrl.search = paramString;
+	}
+	return newUrl;
+}

--- a/src/lib/modules/board/url_state_sync.svelte.ts
+++ b/src/lib/modules/board/url_state_sync.svelte.ts
@@ -1,0 +1,70 @@
+import { onMount } from 'svelte';
+import { pushState, afterNavigate } from '$app/navigation';
+import { resolve } from '$app/paths';
+import { page } from '$app/state';
+import { parseSelectionFromUrl, selectionMatchesUrl, buildSelectionUrl } from './url_state.js';
+import type { UrlSelectionState } from './url_state.js';
+import type { BottomPanelTab } from './selection.js';
+
+const WORKSPACE_ROUTE_ID = '/';
+
+interface SelectionSyncTarget {
+	readonly activeIssueId: string | null;
+	readonly activeTab: BottomPanelTab | null;
+	restoreFromUrl: (issueId: string | null, tab: BottomPanelTab | null) => void;
+}
+
+export function initUrlStateSync(selection: SelectionSyncTarget): void {
+	let isRestoring = false;
+	let initialized = false;
+
+	function pushSelectionToUrl(issueId: string | null, tab: BottomPanelTab | null) {
+		if (isRestoring || !initialized) {
+			return;
+		}
+
+		if (page.route.id !== WORKSPACE_ROUTE_ID) {
+			return;
+		}
+
+		const state: UrlSelectionState = { issueId, tab };
+
+		if (selectionMatchesUrl(state, page.url)) {
+			return;
+		}
+
+		const newUrl = buildSelectionUrl(page.url, state);
+		// eslint-disable-next-line svelte/no-navigation-without-resolve -- URL built with resolve() + dynamic search params
+		pushState(resolve(WORKSPACE_ROUTE_ID) + newUrl.search, {
+			activeIssueId: state.issueId,
+			activeTab: state.tab,
+		});
+	}
+
+	function restoreFromUrlState(url: URL) {
+		isRestoring = true;
+		try {
+			const parsed = parseSelectionFromUrl(url);
+			selection.restoreFromUrl(parsed.issueId, parsed.tab);
+		} finally {
+			isRestoring = false;
+		}
+	}
+
+	$effect(() => {
+		pushSelectionToUrl(selection.activeIssueId, selection.activeTab);
+	});
+
+	onMount(() => {
+		if (page.route.id === WORKSPACE_ROUTE_ID) {
+			restoreFromUrlState(page.url);
+		}
+		initialized = true;
+	});
+
+	afterNavigate((navigation) => {
+		if (navigation.type === 'popstate' && navigation.to?.route?.id === WORKSPACE_ROUTE_ID) {
+			restoreFromUrlState(navigation.to.url);
+		}
+	});
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -12,6 +12,7 @@
 	import {
 		setBoardContext,
 		setSelectionContext,
+		initUrlStateSync,
 		type CreateDashboardRequest,
 		type UpdateDashboardRequest,
 	} from '$lib/modules/board';
@@ -35,7 +36,8 @@
 
 	const windowCtx = setWindowContext();
 	const boardStore = setBoardContext();
-	setSelectionContext();
+	const selectionCtx = setSelectionContext();
+	initUrlStateSync(selectionCtx);
 	const notificationsCtx = setNotificationsContext();
 	const sessionStore = setSessionsContext(notificationsCtx);
 	setIssuesContext();


### PR DESCRIPTION
## Description
- Adds browser history integration so Back/Forward buttons navigate between in-app states
- Encodes active issue ID and active tab in URL search params for deep linking and refresh persistence
- Pure URL state utility module with 18 unit tests for serialize, parse, dedup, and build operations
- Svelte integration layer using $effect + onMount + afterNavigate for bidirectional URL ↔ selection state sync
- Selection context gains `restoreFromUrl` method; extracted `clearBatchSelection` DRY helper
- Route-scoped: only syncs URL on workspace route (`/`)

## Resolves
Closes #188

## Testing
- [x] 18 unit tests for URL state serialization/parsing
- [x] Manual testing of back/forward navigation