### PR TITLE
#188 fix: browser back/forward navigation with SvelteKit shallow routing

### DIFF
--- a/src/lib/modules/board/url_state_sync.svelte.ts
+++ b/src/lib/modules/board/url_state_sync.svelte.ts
@@ -1,8 +1,9 @@
-import { onMount } from 'svelte';
-import { pushState, afterNavigate } from '$app/navigation';
+import { onMount, untrack } from 'svelte';
+import { pushState } from '$app/navigation';
 import { resolve } from '$app/paths';
 import { page } from '$app/state';
 import { parseSelectionFromUrl, selectionMatchesUrl, buildSelectionUrl } from './url_state.js';
+import { isBottomPanelTab } from './selection.js';
 import type { UrlSelectionState } from './url_state.js';
 import type { BottomPanelTab } from './selection.js';
 
@@ -17,6 +18,7 @@ interface SelectionSyncTarget {
 export function initUrlStateSync(selection: SelectionSyncTarget): void {
 	let isRestoring = false;
 	let initialized = false;
+	let lastPushedState: UrlSelectionState | null = null;
 
 	function pushSelectionToUrl(issueId: string | null, tab: BottomPanelTab | null) {
 		if (isRestoring || !initialized) {
@@ -29,10 +31,19 @@ export function initUrlStateSync(selection: SelectionSyncTarget): void {
 
 		const state: UrlSelectionState = { issueId, tab };
 
+		if (
+			lastPushedState &&
+			lastPushedState.issueId === state.issueId &&
+			lastPushedState.tab === state.tab
+		) {
+			return;
+		}
+
 		if (selectionMatchesUrl(state, page.url)) {
 			return;
 		}
 
+		lastPushedState = state;
 		const newUrl = buildSelectionUrl(page.url, state);
 		// eslint-disable-next-line svelte/no-navigation-without-resolve -- URL built with resolve() + dynamic search params
 		pushState(resolve(WORKSPACE_ROUTE_ID) + newUrl.search, {
@@ -41,30 +52,58 @@ export function initUrlStateSync(selection: SelectionSyncTarget): void {
 		});
 	}
 
-	function restoreFromUrlState(url: URL) {
-		isRestoring = true;
-		try {
-			const parsed = parseSelectionFromUrl(url);
-			selection.restoreFromUrl(parsed.issueId, parsed.tab);
-		} finally {
-			isRestoring = false;
-		}
-	}
-
+	// Push selection changes to URL
 	$effect(() => {
-		pushSelectionToUrl(selection.activeIssueId, selection.activeTab);
+		const issueId = selection.activeIssueId;
+		const tab = selection.activeTab;
+		untrack(() => pushSelectionToUrl(issueId, tab));
+	});
+
+	// Restore selection from page.state on back/forward (shallow routing popstate)
+	$effect(() => {
+		const pageState = page.state as App.PageState;
+		untrack(() => {
+			if (!initialized || isRestoring) {
+				return;
+			}
+
+			if (page.route.id !== WORKSPACE_ROUTE_ID) {
+				return;
+			}
+
+			const issueId =
+				typeof pageState.activeIssueId === 'string' ? pageState.activeIssueId : null;
+			const tab = isBottomPanelTab(pageState.activeTab) ? pageState.activeTab : null;
+
+			if (
+				lastPushedState &&
+				lastPushedState.issueId === issueId &&
+				lastPushedState.tab === tab
+			) {
+				return;
+			}
+
+			isRestoring = true;
+			try {
+				selection.restoreFromUrl(issueId, tab);
+				lastPushedState = { issueId, tab };
+			} finally {
+				isRestoring = false;
+			}
+		});
 	});
 
 	onMount(() => {
 		if (page.route.id === WORKSPACE_ROUTE_ID) {
-			restoreFromUrlState(page.url);
+			isRestoring = true;
+			try {
+				const parsed = parseSelectionFromUrl(page.url);
+				selection.restoreFromUrl(parsed.issueId, parsed.tab);
+				lastPushedState = parsed;
+			} finally {
+				isRestoring = false;
+			}
 		}
 		initialized = true;
-	});
-
-	afterNavigate((navigation) => {
-		if (navigation.type === 'popstate' && navigation.to?.route?.id === WORKSPACE_ROUTE_ID) {
-			restoreFromUrlState(navigation.to.url);
-		}
 	});
 }


### PR DESCRIPTION
## Description
- Fixed circular state push on popstate events caused by $effect tracking page.url (stale state was pushed back before restoration)
- Replaced afterNavigate watcher with reactive page.state $effect since afterNavigate doesn't fire for shallow routing popstate events
- Fixed state deduplication logic by tracking lastPushedState instead of comparing against page.url which lacks search params in shallow routing
- Verified with Chrome DevTools: back/forward now correctly restores both URL and UI state with zero spurious history pushes

## Resolves
Closes #188

## Testing
- Browser back/forward navigation with URL state preservation verified in Chrome DevTools
- No spurious history entries on navigation or state changes