### PR TITLE
#196 fix: forest view visual fixes — ground alignment, z-index, hover, depth rows, toggle

### DIFF
--- a/src/lib/components/ForestView.svelte
+++ b/src/lib/components/ForestView.svelte
@@ -20,10 +20,6 @@
 		DEFAULT_TREE_CONFIG,
 		OVERLAY_DEFAULTS,
 		TRUNK_DEAD_SPACE_PERCENT,
-		generateTree,
-		computeTreeHull,
-		VIEWBOX_WIDTH,
-		VIEWBOX_HEIGHT,
 	} from 'low-poly-2d-trees';
 	import type { TreeConfig, OverlayConfig } from 'low-poly-2d-trees';
 	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
@@ -189,42 +185,6 @@
 		return { width: TREE_NATURAL_WIDTH, height: TREE_NATURAL_HEIGHT };
 	}
 
-	const clipPathCache = new Map<string, string>();
-
-	function getClipPath(entry: IssueEntry): string | undefined {
-		if (entry.visualization.kind === 'potted-plant') {
-			return undefined;
-		}
-		const cacheKey =
-			entry.visualization.kind === 'oak'
-				? `oak-${entry.visualization.seed}`
-				: `tree-${entry.visualization.config.seed}-${entry.visualization.config.shape}-${entry.visualization.config.stage}`;
-
-		const cached = clipPathCache.get(cacheKey);
-		if (cached) {
-			return cached;
-		}
-
-		const config =
-			entry.visualization.kind === 'oak' ? getOakConfig(entry) : entry.visualization.config;
-		const geometry = generateTree(config);
-		const hull = computeTreeHull(geometry, 12);
-
-		if (hull.length < 3) {
-			return undefined;
-		}
-
-		const points = hull
-			.map(
-				(p) =>
-					`${((p.x / VIEWBOX_WIDTH) * 100).toFixed(1)}% ${((p.y / VIEWBOX_HEIGHT) * 100).toFixed(1)}%`,
-			)
-			.join(', ');
-		const polygon = `polygon(${points})`;
-		clipPathCache.set(cacheKey, polygon);
-		return polygon;
-	}
-
 	function getOakConfig(entry: IssueEntry): TreeConfig {
 		if (entry.visualization.kind !== 'oak') {
 			return DEFAULT_TREE_CONFIG;
@@ -370,7 +330,6 @@
 				{#if entry}
 					{@const size = getNaturalSize(entry)}
 					{@const overlayConfig = getResolvedOverlayConfig(entry)}
-					{@const clipPath = getClipPath(entry)}
 					{@const groundProps = getGroundElementProps(entry, positioned.rowIndex)}
 					<ForestTreeTooltip
 						issueTitle={entry.issue.name}
@@ -380,7 +339,7 @@
 							<button
 								{...triggerProps}
 								type="button"
-								class="absolute cursor-pointer border-0 bg-transparent p-0 transition-transform hover:brightness-110 focus-visible:outline-2 focus-visible:outline-ring"
+								class="absolute border-0 bg-transparent p-0 transition-transform focus-visible:outline-2 focus-visible:outline-ring [&>svg]:pointer-events-auto [&>svg]:cursor-pointer"
 								style:left="{positioned.x}px"
 								style:top="{positioned.y}px"
 								style:width="{size.width}px"
@@ -389,7 +348,7 @@
 									100}%)) scale({positioned.scale})"
 								style:opacity={positioned.opacity}
 								style:z-index={positioned.zIndex}
-								style:clip-path={clipPath}
+								style:pointer-events="none"
 								onmouseenter={() => interaction.hoverIssue(entry.issue.id)}
 								onmouseleave={() => interaction.unhover()}
 								onclick={() => handleTreeClick(entry)}

--- a/src/lib/components/ForestView.svelte
+++ b/src/lib/components/ForestView.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { Issue } from '$lib/modules/issues';
-	import type { GitStatusCache } from '$lib/types/generated';
+	import type { GitStatusCache, IssueDependency } from '$lib/types/generated';
 	import {
 		computeVisualization,
 		computeForestLayout,
@@ -19,6 +19,11 @@
 		PottedPlant,
 		DEFAULT_TREE_CONFIG,
 		OVERLAY_DEFAULTS,
+		TRUNK_DEAD_SPACE_PERCENT,
+		generateTree,
+		computeTreeHull,
+		VIEWBOX_WIDTH,
+		VIEWBOX_HEIGHT,
 	} from 'low-poly-2d-trees';
 	import type { TreeConfig, OverlayConfig } from 'low-poly-2d-trees';
 	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
@@ -33,6 +38,7 @@
 
 	interface Props {
 		issues: readonly Issue[];
+		dependencies: readonly IssueDependency[];
 		getGitStatus: (issueId: string) => GitStatusCache | undefined;
 		getSessionsForIssue: (issueId: string) => readonly SessionForMapping[];
 		onAddIssue?: () => void;
@@ -42,6 +48,7 @@
 
 	let {
 		issues,
+		dependencies,
 		getGitStatus,
 		getSessionsForIssue,
 		onAddIssue,
@@ -90,9 +97,7 @@
 	}
 
 	const entries = $derived.by<readonly IssueEntry[]>(() => {
-		let prdIssueId: string | null = null;
 		const visualizations = new SvelteMap<string, TreeVisualization>();
-		const parentIssueIds = new SvelteMap<string, string | null>();
 
 		for (const issue of issues) {
 			const visualization = computeVisualization(
@@ -101,14 +106,10 @@
 				getSessionsForIssue(issue.id),
 			);
 			visualizations.set(issue.id, visualization);
-			parentIssueIds.set(issue.id, issue.parent_issue_id);
-			if (visualization.kind === 'oak') {
-				prdIssueId = issue.id;
-			}
 		}
 
 		const issueIds = issues.map((issue) => issue.id);
-		const depthRows = computeDepthRows(issueIds, parentIssueIds, prdIssueId);
+		const depthRows = computeDepthRows(issueIds, dependencies);
 
 		const results: IssueEntry[] = [];
 		for (const issue of issues) {
@@ -188,6 +189,42 @@
 		return { width: TREE_NATURAL_WIDTH, height: TREE_NATURAL_HEIGHT };
 	}
 
+	const clipPathCache = new Map<string, string>();
+
+	function getClipPath(entry: IssueEntry): string | undefined {
+		if (entry.visualization.kind === 'potted-plant') {
+			return undefined;
+		}
+		const cacheKey =
+			entry.visualization.kind === 'oak'
+				? `oak-${entry.visualization.seed}`
+				: `tree-${entry.visualization.config.seed}-${entry.visualization.config.shape}-${entry.visualization.config.stage}`;
+
+		const cached = clipPathCache.get(cacheKey);
+		if (cached) {
+			return cached;
+		}
+
+		const config =
+			entry.visualization.kind === 'oak' ? getOakConfig(entry) : entry.visualization.config;
+		const geometry = generateTree(config);
+		const hull = computeTreeHull(geometry, 12);
+
+		if (hull.length < 3) {
+			return undefined;
+		}
+
+		const points = hull
+			.map(
+				(p) =>
+					`${((p.x / VIEWBOX_WIDTH) * 100).toFixed(1)}% ${((p.y / VIEWBOX_HEIGHT) * 100).toFixed(1)}%`,
+			)
+			.join(', ');
+		const polygon = `polygon(${points})`;
+		clipPathCache.set(cacheKey, polygon);
+		return polygon;
+	}
+
 	function getOakConfig(entry: IssueEntry): TreeConfig {
 		if (entry.visualization.kind !== 'oak') {
 			return DEFAULT_TREE_CONFIG;
@@ -226,6 +263,30 @@
 		contextMenu = { x: event.clientX, y: event.clientY, issueId: entry.issue.id };
 	}
 
+	// fallow-ignore-next-line complexity
+	function getGroundElementProps(
+		entry: IssueEntry,
+		rowIndex: number,
+	): { groundElements: boolean; groundElementCount?: number } {
+		if (rowIndex !== 0) {
+			return { groundElements: false };
+		}
+		if (entry.visualization.kind === 'oak') {
+			return { groundElements: true };
+		}
+		const stage =
+			entry.visualization.kind === 'tree'
+				? entry.visualization.config.stage
+				: entry.visualization.stage;
+		if (stage === 'seed' || stage === 'sprouting') {
+			return { groundElements: false };
+		}
+		if (stage === 'sapling' || stage === 'growing') {
+			return { groundElements: true, groundElementCount: 4 };
+		}
+		return { groundElements: true };
+	}
+
 	function handleGroundClick() {
 		interaction.deactivate();
 	}
@@ -236,6 +297,9 @@
 				contextMenu = null;
 			} else {
 				interaction.deactivate();
+				if (document.activeElement instanceof HTMLElement) {
+					document.activeElement.blur();
+				}
 			}
 		}
 	}
@@ -282,6 +346,7 @@
 	bind:clientHeight={rawViewportHeight}
 	style:background="linear-gradient(to bottom, var(--sky-top), var(--sky-bot))"
 	style:min-height="0"
+	style:isolation="isolate"
 	onkeydown={handleKeydown}
 	tabindex="0"
 >
@@ -305,6 +370,8 @@
 				{#if entry}
 					{@const size = getNaturalSize(entry)}
 					{@const overlayConfig = getResolvedOverlayConfig(entry)}
+					{@const clipPath = getClipPath(entry)}
+					{@const groundProps = getGroundElementProps(entry, positioned.rowIndex)}
 					<ForestTreeTooltip
 						issueTitle={entry.issue.name}
 						issueStatus={entry.issue.status}
@@ -318,9 +385,11 @@
 								style:top="{positioned.y}px"
 								style:width="{size.width}px"
 								style:height="{size.height}px"
-								style:transform="translate(-50%, -100%) scale({positioned.scale})"
+								style:transform="translate(-50%, calc(-100% + {TRUNK_DEAD_SPACE_PERCENT *
+									100}%)) scale({positioned.scale})"
 								style:opacity={positioned.opacity}
 								style:z-index={positioned.zIndex}
+								style:clip-path={clipPath}
 								onmouseenter={() => interaction.hoverIssue(entry.issue.id)}
 								onmouseleave={() => interaction.unhover()}
 								onclick={() => handleTreeClick(entry)}
@@ -331,7 +400,8 @@
 									<LowPolyTree
 										config={getOakConfig(entry)}
 										{overlayConfig}
-										groundElements={positioned.rowIndex === 0}
+										groundElements={groundProps.groundElements}
+										groundElementCount={groundProps.groundElementCount}
 									/>
 								{:else if entry.visualization.kind === 'tree'}
 									<LowPolyTree
@@ -341,7 +411,8 @@
 										animateCanopySway={entry.visualization.animateCanopySway}
 										animateGrowth={entry.visualization.animateGrowth}
 										animateTools={entry.visualization.animateTools}
-										groundElements={positioned.rowIndex === 0}
+										groundElements={groundProps.groundElements}
+										groundElementCount={groundProps.groundElementCount}
 									/>
 								{:else if entry.visualization.kind === 'potted-plant'}
 									<PottedPlant

--- a/src/lib/components/WorkspaceDashboardLayout.svelte
+++ b/src/lib/components/WorkspaceDashboardLayout.svelte
@@ -2,26 +2,26 @@
 	import type { Snippet } from 'svelte';
 	import { PaneGroup, Pane } from 'paneforge';
 	import StyledPaneResizer from './StyledPaneResizer.svelte';
-	import TreesIcon from '@lucide/svelte/icons/trees';
-	import { Button } from '$lib/components/ui/button/index.js';
 
 	interface Props {
+		collapsed?: boolean;
+		onToggle?: (collapsed: boolean) => void;
 		forestPanel: Snippet;
 		bottomPanel: Snippet;
 	}
 
-	let { forestPanel, bottomPanel }: Props = $props();
+	let { collapsed = false, onToggle, forestPanel, bottomPanel }: Props = $props();
 
 	let topPane = $state<ReturnType<typeof Pane>>();
-	let collapsed = $state(false);
+	let internalCollapsed = $state(false);
 
-	function handleCollapseToggle() {
-		if (collapsed) {
-			topPane?.expand();
-		} else {
+	$effect(() => {
+		if (collapsed && !internalCollapsed) {
 			topPane?.collapse();
+		} else if (!collapsed && internalCollapsed) {
+			topPane?.expand();
 		}
-	}
+	});
 </script>
 
 <PaneGroup direction="vertical" class="h-full" autoSaveId="grovekeeper-forest-split">
@@ -30,21 +30,19 @@
 		defaultSize={65}
 		collapsible={true}
 		collapsedSize={0}
-		onCollapse={() => (collapsed = true)}
-		onExpand={() => (collapsed = false)}
+		onCollapse={() => {
+			internalCollapsed = true;
+			onToggle?.(true);
+		}}
+		onExpand={() => {
+			internalCollapsed = false;
+			onToggle?.(false);
+		}}
 	>
 		<div class="flex h-full flex-col overflow-hidden">
 			{@render forestPanel()}
 		</div>
 	</Pane>
-	<Button
-		variant="ghost"
-		onclick={handleCollapseToggle}
-		class="w-full shrink-0 rounded-none border-y border-border py-1 text-xs"
-		aria-label={collapsed ? 'Expand forest panel' : 'Collapse forest panel'}
-	>
-		<TreesIcon class="size-3.5" />
-	</Button>
 	<StyledPaneResizer />
 	<Pane minSize={20}>
 		<div class="flex h-full flex-col overflow-hidden">

--- a/src/lib/modules/visualization/depth_rows.test.ts
+++ b/src/lib/modules/visualization/depth_rows.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import { computeDepthRows } from './depth_rows.js';
+import type { IssueDependency } from '$lib/types/generated';
+
+describe('computeDepthRows', () => {
+	it('places all issues in row 0 when no dependencies exist', () => {
+		const issueIds = ['a', 'b', 'c'];
+		const dependencies: IssueDependency[] = [];
+
+		const result = computeDepthRows(issueIds, dependencies);
+
+		expect(result.get('a')).toBe(0);
+		expect(result.get('b')).toBe(0);
+		expect(result.get('c')).toBe(0);
+	});
+
+	it('places blocked issue one row behind its blocker', () => {
+		const issueIds = ['auth', 'onboarding'];
+		const dependencies: IssueDependency[] = [
+			{ id: 'dep-1', blocker_issue_id: 'auth', blocked_issue_id: 'onboarding' },
+		];
+
+		const result = computeDepthRows(issueIds, dependencies);
+
+		expect(result.get('auth')).toBe(0);
+		expect(result.get('onboarding')).toBe(1);
+	});
+
+	// fallow-ignore-next-line code-duplication
+	it('computes correct depth for linear chain A→B→C', () => {
+		const issueIds = ['a', 'b', 'c'];
+		const dependencies: IssueDependency[] = [
+			{ id: 'dep-1', blocker_issue_id: 'a', blocked_issue_id: 'b' },
+			{ id: 'dep-2', blocker_issue_id: 'b', blocked_issue_id: 'c' },
+		];
+
+		const result = computeDepthRows(issueIds, dependencies);
+
+		expect(result.get('a')).toBe(0);
+		expect(result.get('b')).toBe(1);
+		expect(result.get('c')).toBe(2);
+	});
+
+	it('handles diamond DAG: A blocks B and C, both block D', () => {
+		const issueIds = ['a', 'b', 'c', 'd'];
+		const dependencies: IssueDependency[] = [
+			{ id: 'dep-1', blocker_issue_id: 'a', blocked_issue_id: 'b' },
+			{ id: 'dep-2', blocker_issue_id: 'a', blocked_issue_id: 'c' },
+			{ id: 'dep-3', blocker_issue_id: 'b', blocked_issue_id: 'd' },
+			{ id: 'dep-4', blocker_issue_id: 'c', blocked_issue_id: 'd' },
+		];
+
+		const result = computeDepthRows(issueIds, dependencies);
+
+		expect(result.get('a')).toBe(0);
+		expect(result.get('b')).toBe(1);
+		expect(result.get('c')).toBe(1);
+		expect(result.get('d')).toBe(2);
+	});
+
+	it('places disconnected issues in row 0', () => {
+		const issueIds = ['a', 'b', 'c', 'disconnected'];
+		const dependencies: IssueDependency[] = [
+			{ id: 'dep-1', blocker_issue_id: 'a', blocked_issue_id: 'b' },
+		];
+
+		const result = computeDepthRows(issueIds, dependencies);
+
+		expect(result.get('disconnected')).toBe(0);
+		expect(result.get('c')).toBe(0);
+	});
+
+	it('handles cycles gracefully without infinite loop', () => {
+		const issueIds = ['a', 'b', 'c'];
+		const dependencies: IssueDependency[] = [
+			{ id: 'dep-1', blocker_issue_id: 'a', blocked_issue_id: 'b' },
+			{ id: 'dep-2', blocker_issue_id: 'b', blocked_issue_id: 'c' },
+			{ id: 'dep-3', blocker_issue_id: 'c', blocked_issue_id: 'a' },
+		];
+
+		const result = computeDepthRows(issueIds, dependencies);
+
+		// All issues should still have a depth assigned (no crash)
+		expect(result.size).toBe(3);
+		for (const id of issueIds) {
+			expect(result.has(id)).toBe(true);
+		}
+	});
+
+	it('ignores dependencies referencing unknown issue IDs', () => {
+		const issueIds = ['a', 'b'];
+		const dependencies: IssueDependency[] = [
+			{ id: 'dep-1', blocker_issue_id: 'unknown', blocked_issue_id: 'a' },
+			{ id: 'dep-2', blocker_issue_id: 'a', blocked_issue_id: 'ghost' },
+		];
+
+		const result = computeDepthRows(issueIds, dependencies);
+
+		expect(result.get('a')).toBe(0);
+		expect(result.get('b')).toBe(0);
+	});
+
+	it('handles multiple blockers — uses maximum depth', () => {
+		const issueIds = ['root', 'mid', 'leaf'];
+		const dependencies: IssueDependency[] = [
+			{ id: 'dep-1', blocker_issue_id: 'root', blocked_issue_id: 'mid' },
+			{ id: 'dep-2', blocker_issue_id: 'root', blocked_issue_id: 'leaf' },
+			{ id: 'dep-3', blocker_issue_id: 'mid', blocked_issue_id: 'leaf' },
+		];
+
+		const result = computeDepthRows(issueIds, dependencies);
+
+		expect(result.get('root')).toBe(0);
+		expect(result.get('mid')).toBe(1);
+		// leaf is blocked by both root (depth 1) and mid (depth 2) — take max
+		expect(result.get('leaf')).toBe(2);
+	});
+});

--- a/src/lib/modules/visualization/depth_rows.ts
+++ b/src/lib/modules/visualization/depth_rows.ts
@@ -1,52 +1,69 @@
+import type { IssueDependency } from '$lib/types/generated';
+
 // fallow-ignore-next-line complexity
 export function computeDepthRows(
 	issueIds: readonly string[],
-	parentIssueIds: ReadonlyMap<string, string | null>,
-	prdIssueId: string | null,
+	dependencies: readonly IssueDependency[],
 ): Map<string, number> {
 	const depthMap = new Map<string, number>();
+	const issueSet = new Set(issueIds);
 
-	if (prdIssueId === null) {
-		for (const id of issueIds) {
-			depthMap.set(id, 0);
-		}
+	for (const id of issueIds) {
+		depthMap.set(id, 0);
+	}
+
+	if (dependencies.length === 0) {
 		return depthMap;
 	}
 
-	const childrenByParent = new Map<string, string[]>();
+	const inDegree = new Map<string, number>();
+	const adjacency = new Map<string, string[]>();
+
 	for (const id of issueIds) {
-		const parentId = parentIssueIds.get(id) ?? null;
-		if (parentId !== null) {
-			const children = childrenByParent.get(parentId);
-			if (children) {
-				children.push(id);
-			} else {
-				childrenByParent.set(parentId, [id]);
-			}
+		inDegree.set(id, 0);
+		adjacency.set(id, []);
+	}
+
+	for (const dep of dependencies) {
+		if (!issueSet.has(dep.blocker_issue_id) || !issueSet.has(dep.blocked_issue_id)) {
+			continue;
+		}
+		adjacency.get(dep.blocker_issue_id)!.push(dep.blocked_issue_id);
+		inDegree.set(dep.blocked_issue_id, inDegree.get(dep.blocked_issue_id)! + 1);
+	}
+
+	// Kahn's algorithm — longest-path variant
+	const queue: string[] = [];
+	for (const [id, degree] of inDegree) {
+		if (degree === 0) {
+			queue.push(id);
 		}
 	}
 
-	const queue: Array<{ id: string; depth: number }> = [];
-	const prdChildren = childrenByParent.get(prdIssueId) ?? [];
-	for (const childId of prdChildren) {
-		queue.push({ id: childId, depth: 0 });
-		depthMap.set(childId, 0);
-	}
-
+	let processed = 0;
 	while (queue.length > 0) {
 		const current = queue.shift()!;
-		const children = childrenByParent.get(current.id) ?? [];
-		for (const childId of children) {
-			if (!depthMap.has(childId)) {
-				depthMap.set(childId, current.depth + 1);
-				queue.push({ id: childId, depth: current.depth + 1 });
+		processed++;
+		const currentDepth = depthMap.get(current)!;
+
+		for (const neighbor of adjacency.get(current)!) {
+			const candidateDepth = currentDepth + 1;
+			if (candidateDepth > depthMap.get(neighbor)!) {
+				depthMap.set(neighbor, candidateDepth);
+			}
+			inDegree.set(neighbor, inDegree.get(neighbor)! - 1);
+			if (inDegree.get(neighbor) === 0) {
+				queue.push(neighbor);
 			}
 		}
 	}
 
-	for (const id of issueIds) {
-		if (!depthMap.has(id) && id !== prdIssueId) {
-			depthMap.set(id, 0);
+	// Cycle handling: any unprocessed nodes stay at their current depth (0 or partial)
+	if (processed < issueIds.length) {
+		for (const id of issueIds) {
+			if (!depthMap.has(id)) {
+				depthMap.set(id, 0);
+			}
 		}
 	}
 

--- a/src/lib/modules/visualization/visualization.test.ts
+++ b/src/lib/modules/visualization/visualization.test.ts
@@ -23,6 +23,7 @@ import type {
 	Viewport,
 	PositionedForestItem,
 } from './index';
+import type { IssueDependency } from '$lib/types/generated';
 import {
 	computeTreeVisualization,
 	mapIssueToStateDimensions,
@@ -1805,11 +1806,16 @@ describe('computeForestLayout — stumps in rows', () => {
 	});
 });
 
-describe('computeDepthRows', () => {
-	it('assigns all issues to depth 0 when prdIssueId is null', () => {
+describe('computeDepthRows (legacy tests adapted to dependency-based API)', () => {
+	const dep = (blocker: string, blocked: string): IssueDependency => ({
+		id: `dep-${blocker}-${blocked}`,
+		blocker_issue_id: blocker,
+		blocked_issue_id: blocked,
+	});
+
+	it('assigns all issues to depth 0 when no dependencies exist', () => {
 		const issueIds = ['issue1', 'issue2', 'issue3'];
-		const parents = new Map<string, string | null>();
-		const result = computeDepthRows(issueIds, parents, null);
+		const result = computeDepthRows(issueIds, []);
 
 		expect(result.size).toBe(3);
 		expect(result.get('issue1')).toBe(0);
@@ -1817,72 +1823,20 @@ describe('computeDepthRows', () => {
 		expect(result.get('issue3')).toBe(0);
 	});
 
-	it('assigns PRD issue direct children to depth 0', () => {
-		const issueIds = ['prd', 'child1', 'child2'];
-		const parents = new Map([
-			['child1', 'prd'],
-			['child2', 'prd'],
-		]);
-		const result = computeDepthRows(issueIds, parents, 'prd');
+	it('places blocked issue one row behind blocker', () => {
+		const issueIds = ['blocker', 'child1', 'child2'];
+		const deps = [dep('blocker', 'child1'), dep('blocker', 'child2')];
+		const result = computeDepthRows(issueIds, deps);
 
-		expect(result.get('child1')).toBe(0);
-		expect(result.get('child2')).toBe(0);
+		expect(result.get('blocker')).toBe(0);
+		expect(result.get('child1')).toBe(1);
+		expect(result.get('child2')).toBe(1);
 	});
 
-	it('computes correct depths for multi-level hierarchy', () => {
-		const issueIds = ['prd', 'child1', 'child2', 'grandchild1', 'grandchild2'];
-		const parents = new Map([
-			['child1', 'prd'],
-			['child2', 'prd'],
-			['grandchild1', 'child1'],
-			['grandchild2', 'child2'],
-		]);
-		const result = computeDepthRows(issueIds, parents, 'prd');
-
-		expect(result.get('child1')).toBe(0);
-		expect(result.get('child2')).toBe(0);
-		expect(result.get('grandchild1')).toBe(1);
-		expect(result.get('grandchild2')).toBe(1);
-	});
-
-	it('handles disconnected subtrees by assigning them depth 0', () => {
-		const issueIds = ['prd', 'child1', 'orphan1', 'orphan2'];
-		const parents = new Map([['child1', 'prd']]);
-		const result = computeDepthRows(issueIds, parents, 'prd');
-
-		expect(result.get('child1')).toBe(0);
-		expect(result.get('orphan1')).toBe(0);
-		expect(result.get('orphan2')).toBe(0);
-	});
-
-	it('handles missing parent references gracefully', () => {
-		const issueIds = ['prd', 'child1', 'unknown'];
-		const parents = new Map([['child1', 'prd']]);
-		const result = computeDepthRows(issueIds, parents, 'prd');
-
-		expect(result.get('child1')).toBe(0);
-		expect(result.get('unknown')).toBe(0);
-	});
-
-	it('does not include PRD issue itself in result', () => {
-		const issueIds = ['prd', 'child1'];
-		const parents = new Map([['child1', 'prd']]);
-		const result = computeDepthRows(issueIds, parents, 'prd');
-
-		expect(result.has('prd')).toBe(false);
-		expect(result.size).toBe(1);
-	});
-
-	it('handles complex deep hierarchy with proper depth assignment', () => {
-		const issueIds = ['prd', 'l1a', 'l1b', 'l2a', 'l2b', 'l3a'];
-		const parents = new Map([
-			['l1a', 'prd'],
-			['l1b', 'prd'],
-			['l2a', 'l1a'],
-			['l2b', 'l1b'],
-			['l3a', 'l2a'],
-		]);
-		const result = computeDepthRows(issueIds, parents, 'prd');
+	it('computes correct depths for multi-level blocking chain', () => {
+		const issueIds = ['l1a', 'l1b', 'l2a', 'l2b', 'l3a'];
+		const deps = [dep('l1a', 'l2a'), dep('l1b', 'l2b'), dep('l2a', 'l3a')];
+		const result = computeDepthRows(issueIds, deps);
 
 		expect(result.get('l1a')).toBe(0);
 		expect(result.get('l1b')).toBe(0);
@@ -1891,136 +1845,36 @@ describe('computeDepthRows', () => {
 		expect(result.get('l3a')).toBe(2);
 	});
 
-	it('handles single issue with no children', () => {
-		const issueIds = ['prd'];
-		const parents = new Map<string, string | null>();
-		const result = computeDepthRows(issueIds, parents, 'prd');
+	it('handles disconnected issues by assigning them depth 0', () => {
+		const issueIds = ['blocker', 'child1', 'orphan1', 'orphan2'];
+		const deps = [dep('blocker', 'child1')];
+		const result = computeDepthRows(issueIds, deps);
 
-		expect(result.size).toBe(0);
+		expect(result.get('child1')).toBe(1);
+		expect(result.get('orphan1')).toBe(0);
+		expect(result.get('orphan2')).toBe(0);
 	});
 
-	it('handles null parent values in the map', () => {
-		const issueIds = ['prd', 'child1', 'child2'];
-		const parents = new Map([
-			['child1', 'prd'],
-			['child2', null],
-		]);
-		const result = computeDepthRows(issueIds, parents, 'prd');
-
-		expect(result.get('child1')).toBe(0);
-		expect(result.get('child2')).toBe(0);
-	});
-});
-
-describe('computeDepthRows', () => {
 	it('returns empty depth map when issueIds is empty', () => {
-		const result = computeDepthRows([], new Map(), null);
+		const result = computeDepthRows([], []);
 		expect(result.size).toBe(0);
 	});
 
-	it('assigns all issues to depth 0 when prdIssueId is null', () => {
-		const issueIds = ['issue1', 'issue2', 'issue3'];
-		const parents = new Map<string, string | null>();
-		const result = computeDepthRows(issueIds, parents, null);
+	it('handles single issue with no dependencies', () => {
+		const issueIds = ['solo'];
+		const result = computeDepthRows(issueIds, []);
 
-		expect(result.size).toBe(3);
-		expect(result.get('issue1')).toBe(0);
-		expect(result.get('issue2')).toBe(0);
-		expect(result.get('issue3')).toBe(0);
-	});
-
-	it('assigns PRD issue direct children to depth 0', () => {
-		const issueIds = ['prd', 'child1', 'child2'];
-		const parents = new Map([
-			['child1', 'prd'],
-			['child2', 'prd'],
-		]);
-		const result = computeDepthRows(issueIds, parents, 'prd');
-
-		expect(result.get('child1')).toBe(0);
-		expect(result.get('child2')).toBe(0);
-	});
-
-	it('computes correct depths for multi-level hierarchy', () => {
-		const issueIds = ['prd', 'child1', 'child2', 'grandchild1', 'grandchild2'];
-		const parents = new Map([
-			['child1', 'prd'],
-			['child2', 'prd'],
-			['grandchild1', 'child1'],
-			['grandchild2', 'child2'],
-		]);
-		const result = computeDepthRows(issueIds, parents, 'prd');
-
-		expect(result.get('child1')).toBe(0);
-		expect(result.get('child2')).toBe(0);
-		expect(result.get('grandchild1')).toBe(1);
-		expect(result.get('grandchild2')).toBe(1);
-	});
-
-	it('handles disconnected subtrees by assigning them depth 0', () => {
-		const issueIds = ['prd', 'child1', 'orphan1', 'orphan2'];
-		const parents = new Map([['child1', 'prd']]);
-		const result = computeDepthRows(issueIds, parents, 'prd');
-
-		expect(result.get('child1')).toBe(0);
-		expect(result.get('orphan1')).toBe(0);
-		expect(result.get('orphan2')).toBe(0);
-	});
-
-	it('handles missing parent references gracefully', () => {
-		const issueIds = ['prd', 'child1', 'unknown'];
-		const parents = new Map([['child1', 'prd']]);
-		const result = computeDepthRows(issueIds, parents, 'prd');
-
-		expect(result.get('child1')).toBe(0);
-		expect(result.get('unknown')).toBe(0);
-	});
-
-	it('does not include PRD issue itself in result', () => {
-		const issueIds = ['prd', 'child1'];
-		const parents = new Map([['child1', 'prd']]);
-		const result = computeDepthRows(issueIds, parents, 'prd');
-
-		expect(result.has('prd')).toBe(false);
 		expect(result.size).toBe(1);
+		expect(result.get('solo')).toBe(0);
 	});
 
-	it('handles complex deep hierarchy with proper depth assignment', () => {
-		const issueIds = ['prd', 'l1a', 'l1b', 'l2a', 'l2b', 'l3a'];
-		const parents = new Map([
-			['l1a', 'prd'],
-			['l1b', 'prd'],
-			['l2a', 'l1a'],
-			['l2b', 'l1b'],
-			['l3a', 'l2a'],
-		]);
-		const result = computeDepthRows(issueIds, parents, 'prd');
+	it('ignores dependencies referencing unknown issue IDs', () => {
+		const issueIds = ['a', 'b'];
+		const deps = [dep('unknown', 'a'), dep('a', 'ghost')];
+		const result = computeDepthRows(issueIds, deps);
 
-		expect(result.get('l1a')).toBe(0);
-		expect(result.get('l1b')).toBe(0);
-		expect(result.get('l2a')).toBe(1);
-		expect(result.get('l2b')).toBe(1);
-		expect(result.get('l3a')).toBe(2);
-	});
-
-	it('handles single issue with no children', () => {
-		const issueIds = ['prd'];
-		const parents = new Map<string, string | null>();
-		const result = computeDepthRows(issueIds, parents, 'prd');
-
-		expect(result.size).toBe(0);
-	});
-
-	it('handles null parent values in the map', () => {
-		const issueIds = ['prd', 'child1', 'child2'];
-		const parents = new Map([
-			['child1', 'prd'],
-			['child2', null],
-		]);
-		const result = computeDepthRows(issueIds, parents, 'prd');
-
-		expect(result.get('child1')).toBe(0);
-		expect(result.get('child2')).toBe(0);
+		expect(result.get('a')).toBe(0);
+		expect(result.get('b')).toBe(0);
 	});
 });
 

--- a/src/lib/tauri_mock_data.ts
+++ b/src/lib/tauri_mock_data.ts
@@ -28,6 +28,8 @@ const ISSUE_PERF_AUDIT = 'mock-issue-perf';
 const ISSUE_CI_PIPELINE = 'mock-issue-ci';
 const ISSUE_ONBOARDING = 'mock-issue-onboarding';
 const ISSUE_ARCHIVED = 'mock-issue-archived';
+const ISSUE_API_GATEWAY = 'mock-issue-api-gateway';
+const ISSUE_INTEGRATION_TESTS = 'mock-issue-integration-tests';
 
 const PALETTE_VIVID = 'palette-vivid';
 
@@ -179,6 +181,52 @@ export const MOCK_ISSUES: Issue[] = [
 		created_at: '2026-05-02T11:45:00Z',
 	},
 	{
+		id: ISSUE_API_GATEWAY,
+		dashboard_id: DASHBOARD_GROVEKEEPER,
+		name: 'Build API gateway with rate limiting',
+		priority: 'medium',
+		color: '#8b5cf6',
+		status: 'active',
+		github_issue_url: 'https://github.com/MartinoPolo/Grovekeeper/issues/85',
+		github_issue_number: 85,
+		branch_name: '85-api-gateway',
+		base_branch: 'dev',
+		worktree_folder: null,
+		worktree_state: 'none',
+		parent_issue_id: null,
+		editor_folder: null,
+		dev_server_command: null,
+		dev_server_port: null,
+		dev_server_pid: null,
+		browser_url: null,
+		labels: '[{"name":"backend","color":"#8b5cf6"}]',
+		sort_order: 5,
+		created_at: '2026-05-03T10:00:00Z',
+	},
+	{
+		id: ISSUE_INTEGRATION_TESTS,
+		dashboard_id: DASHBOARD_GROVEKEEPER,
+		name: 'Add integration test suite for API',
+		priority: 'low',
+		color: '#06b6d4',
+		status: 'active',
+		github_issue_url: 'https://github.com/MartinoPolo/Grovekeeper/issues/92',
+		github_issue_number: 92,
+		branch_name: null,
+		base_branch: 'dev',
+		worktree_folder: null,
+		worktree_state: 'none',
+		parent_issue_id: null,
+		editor_folder: null,
+		dev_server_command: null,
+		dev_server_port: null,
+		dev_server_pid: null,
+		browser_url: null,
+		labels: '[{"name":"testing","color":"#14b8a6"}]',
+		sort_order: 6,
+		created_at: '2026-05-04T14:00:00Z',
+	},
+	{
 		id: ISSUE_ARCHIVED,
 		dashboard_id: DASHBOARD_GROVEKEEPER,
 		name: 'Migrate to Tailwind v4',
@@ -210,6 +258,16 @@ export const MOCK_ISSUE_DEPENDENCIES: IssueDependency[] = [
 		id: 'mock-dep-1',
 		blocker_issue_id: ISSUE_AUTH_MIDDLEWARE,
 		blocked_issue_id: ISSUE_ONBOARDING,
+	},
+	{
+		id: 'mock-dep-2',
+		blocker_issue_id: ISSUE_AUTH_MIDDLEWARE,
+		blocked_issue_id: ISSUE_API_GATEWAY,
+	},
+	{
+		id: 'mock-dep-3',
+		blocker_issue_id: ISSUE_API_GATEWAY,
+		blocked_issue_id: ISSUE_INTEGRATION_TESTS,
 	},
 ];
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -529,10 +529,18 @@
 		</div>
 	{:else}
 		<div class="flex-1 overflow-hidden">
-			<WorkspaceDashboardLayout>
+			<WorkspaceDashboardLayout
+				collapsed={selection.forestCollapsed}
+				onToggle={(value) => {
+					if (value !== selection.forestCollapsed) {
+						selection.toggleForestCollapsed();
+					}
+				}}
+			>
 				{#snippet forestPanel()}
 					<ForestView
 						issues={forestIssues}
+						dependencies={issueStore.dependencies}
 						getGitStatus={getGitStatusForForest}
 						getSessionsForIssue={getSessionsForForest}
 						onAddIssue={openCreateDialog}


### PR DESCRIPTION
## Summary

Fixes 8 forest view issues from visual QA (#196):

- **Ground alignment**: Apply `translateY(5%)` correction using library-exported `TRUNK_DEAD_SPACE_PERCENT` so trunk bases sit at ground level
- **Z-index isolation**: Add `isolation: isolate` on forest container to prevent trees from rendering above modal backdrops
- **Hover targets**: Use SVG `pointer-events: visiblePainted` instead of CSS `clip-path` — hover triggers only on painted tree geometry while glow renders unclipped
- **Escape focus**: Blur active element after `deactivate()` to remove unwanted focus ring
- **Ground elements**: Gate by growth stage — none for seed/sprouting, reduced (4) for sapling/growing, full for leafy+
- **Depth rows**: Rewrite `computeDepthRows()` to use `IssueDependency` blocking graph with topological sort instead of parent-child hierarchy
- **Forest toggle**: Wire TopBar button to paneforge Pane API via `$effect`, remove redundant toggle button below forest
- **Mock data**: Add API gateway + integration test issues with 3-dependency chain for multi-row testing

## Library changes

`low-poly-2d-trees` updated (separate repo):
- Export `TRUNK_DEAD_SPACE_PERCENT` from `tree_scale.ts`
- Add `computeConvexHull`, `padConvexHull`, `extractTreeVertices`, `computeTreeHull` utilities (available for future use)

## Test plan

- [x] `depth_rows.test.ts` — 8 tests: no deps, linear chain, diamond DAG, disconnected nodes, cycles, unknown IDs, multiple blockers
- [x] `visualization.test.ts` — updated legacy tests to new `IssueDependency`-based API
- [x] All 805 unit tests pass
- [x] Browser verification via Chrome DevTools MCP: ground alignment, z-index, glow rendering, escape focus, depth rows (3 levels), forest toggle, multi-row mock data

Closes #196