### PR TITLE
#161 feat(session): implement Codex provider via stdio JSON IPC

### DIFF
--- a/src-tauri/src/commands/session_commands.rs
+++ b/src-tauri/src/commands/session_commands.rs
@@ -63,10 +63,7 @@ pub async fn spawn_session(
         env_vars: HashMap::new(),
     };
 
-    let provider_str = match provider_kind {
-        ProviderKind::ClaudeCode => "claude-code",
-        ProviderKind::OpenCode => "open-code",
-    };
+    let provider_str = provider_kind.as_str();
 
     let database_connection = open_actor_database_connection(&app_handle)?;
 

--- a/src-tauri/src/session/codex_event_parser.rs
+++ b/src-tauri/src/session/codex_event_parser.rs
@@ -1,0 +1,945 @@
+use std::collections::HashMap;
+
+use serde_json::Value;
+
+use super::provider::{ProviderError, SessionEvent};
+
+fn extract_error_message(raw: &Value) -> String {
+    raw.get("error")
+        .and_then(|v| v.as_str())
+        .or_else(|| raw.get("message").and_then(|v| v.as_str()))
+        .unwrap_or("unknown error")
+        .to_string()
+}
+
+/// Stateful parser that maps Codex exec JSONL events to unified SessionEvents.
+///
+/// Codex `exec --json` emits newline-delimited JSON with top-level `type` fields:
+/// `thread.started`, `turn.started`, `turn.completed`, `turn.failed`,
+/// `item.started`, `item.completed`, `error`.
+pub struct CodexEventParser {
+    tool_names: HashMap<String, String>,
+}
+
+impl CodexEventParser {
+    pub fn new() -> Self {
+        Self {
+            tool_names: HashMap::new(),
+        }
+    }
+
+    pub fn map_event(&mut self, raw: &Value) -> Result<Vec<SessionEvent>, ProviderError> {
+        let event_type = raw
+            .get("type")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown");
+
+        match event_type {
+            "thread.started" => self.parse_thread_started(raw),
+            "turn.started" => self.parse_turn_started(),
+            "turn.completed" => self.parse_turn_completed(raw),
+            "turn.failed" => self.parse_turn_failed(raw),
+            "item.started" => self.parse_item_event(raw, false),
+            "item.completed" => self.parse_item_event(raw, true),
+            "error" => self.parse_top_level_error(raw),
+            _ => Ok(vec![SessionEvent::Raw {
+                source: "codex_stdout".into(),
+                data: raw.clone(),
+            }]),
+        }
+    }
+
+    fn parse_thread_started(
+        &self,
+        raw: &Value,
+    ) -> Result<Vec<SessionEvent>, ProviderError> {
+        let thread_id = raw
+            .get("thread_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+
+        Ok(vec![
+            SessionEvent::SessionInit {
+                session_id: thread_id,
+                model: String::new(),
+                tools: vec![],
+            },
+            SessionEvent::RunState {
+                state: "running".into(),
+                error: None,
+            },
+        ])
+    }
+
+    fn parse_turn_started(&self) -> Result<Vec<SessionEvent>, ProviderError> {
+        Ok(vec![SessionEvent::RunState {
+            state: "running".into(),
+            error: None,
+        }])
+    }
+
+    fn parse_turn_completed(
+        &self,
+        raw: &Value,
+    ) -> Result<Vec<SessionEvent>, ProviderError> {
+        let mut events = Vec::new();
+
+        if let Some(usage) = raw.get("usage") {
+            let input_tokens = usage
+                .get("input_tokens")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            let output_tokens = usage
+                .get("output_tokens")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            let cost_usd = usage
+                .get("cost_usd")
+                .and_then(|v| v.as_f64())
+                .unwrap_or(0.0);
+
+            if input_tokens > 0 || output_tokens > 0 || cost_usd > 0.0 {
+                events.push(SessionEvent::UsageUpdate {
+                    input_tokens,
+                    output_tokens,
+                    cost_usd,
+                });
+            }
+        }
+
+        events.push(SessionEvent::RunState {
+            state: "idle".into(),
+            error: None,
+        });
+
+        Ok(events)
+    }
+
+    fn parse_turn_failed(
+        &self,
+        raw: &Value,
+    ) -> Result<Vec<SessionEvent>, ProviderError> {
+        Ok(vec![SessionEvent::RunState {
+            state: "failed".into(),
+            error: Some(extract_error_message(raw)),
+        }])
+    }
+
+    fn parse_top_level_error(
+        &self,
+        raw: &Value,
+    ) -> Result<Vec<SessionEvent>, ProviderError> {
+        Ok(vec![SessionEvent::RunState {
+            state: "failed".into(),
+            error: Some(extract_error_message(raw)),
+        }])
+    }
+
+    fn parse_item_event(
+        &mut self,
+        raw: &Value,
+        is_completed: bool,
+    ) -> Result<Vec<SessionEvent>, ProviderError> {
+        let item = raw.get("item").unwrap_or(raw);
+        let item_type = item
+            .get("type")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown");
+
+        match item_type {
+            "agent_message" | "agentMessage" => self.parse_agent_message(item, is_completed),
+            "command_execution" | "commandExecution" => {
+                self.parse_command_execution(item, is_completed)
+            }
+            "file_change" | "fileChange" => self.parse_file_change(item, is_completed),
+            "reasoning" => self.parse_reasoning(item),
+            "mcp_tool_call" | "mcpToolCall" => self.parse_mcp_tool_call(item, is_completed),
+            "context_compaction" | "contextCompaction" => self.parse_context_compaction(),
+            _ => Ok(vec![SessionEvent::Raw {
+                source: "codex_item".into(),
+                data: raw.clone(),
+            }]),
+        }
+    }
+
+    fn parse_agent_message(
+        &self,
+        item: &Value,
+        is_completed: bool,
+    ) -> Result<Vec<SessionEvent>, ProviderError> {
+        let text = item
+            .get("text")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let item_id = item
+            .get("id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+
+        if is_completed {
+            Ok(vec![SessionEvent::MessageComplete {
+                text,
+                message_id: item_id,
+            }])
+        } else {
+            Ok(vec![SessionEvent::MessageDelta { text }])
+        }
+    }
+
+    fn parse_command_execution(
+        &mut self,
+        item: &Value,
+        is_completed: bool,
+    ) -> Result<Vec<SessionEvent>, ProviderError> {
+        let item_id = item
+            .get("id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let command = item
+            .get("command")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+
+        if is_completed {
+            let output = item
+                .get("aggregatedOutput")
+                .or_else(|| item.get("output"))
+                .cloned()
+                .unwrap_or(Value::Null);
+            let exit_code = item.get("exitCode").and_then(|v| v.as_i64());
+            let is_error = exit_code.map(|c| c != 0).unwrap_or(false);
+            let tool_name = self
+                .tool_names
+                .get(&item_id)
+                .cloned()
+                .unwrap_or_else(|| "command_execution".into());
+
+            Ok(vec![SessionEvent::ToolEnd {
+                tool_use_id: item_id,
+                tool_name,
+                output,
+                is_error,
+            }])
+        } else {
+            self.tool_names
+                .insert(item_id.clone(), "command_execution".into());
+
+            Ok(vec![SessionEvent::ToolStart {
+                tool_use_id: item_id,
+                tool_name: "command_execution".into(),
+                input: Value::String(command),
+            }])
+        }
+    }
+
+    fn parse_file_change(
+        &mut self,
+        item: &Value,
+        is_completed: bool,
+    ) -> Result<Vec<SessionEvent>, ProviderError> {
+        let item_id = item
+            .get("id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+
+        if is_completed {
+            let changes = item.get("changes").cloned().unwrap_or(Value::Null);
+            let tool_name = self
+                .tool_names
+                .get(&item_id)
+                .cloned()
+                .unwrap_or_else(|| "file_change".into());
+
+            Ok(vec![SessionEvent::ToolEnd {
+                tool_use_id: item_id,
+                tool_name,
+                output: changes,
+                is_error: false,
+            }])
+        } else {
+            self.tool_names
+                .insert(item_id.clone(), "file_change".into());
+
+            let changes = item.get("changes").cloned().unwrap_or(Value::Null);
+            Ok(vec![SessionEvent::ToolStart {
+                tool_use_id: item_id,
+                tool_name: "file_change".into(),
+                input: changes,
+            }])
+        }
+    }
+
+    fn parse_reasoning(
+        &self,
+        item: &Value,
+    ) -> Result<Vec<SessionEvent>, ProviderError> {
+        let summary = item
+            .get("summary")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str())
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            })
+            .unwrap_or_default();
+
+        let text = if summary.is_empty() {
+            item.get("content")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str())
+                        .collect::<Vec<_>>()
+                        .join("\n")
+                })
+                .unwrap_or_default()
+        } else {
+            summary
+        };
+
+        if text.is_empty() {
+            return Ok(vec![]);
+        }
+
+        Ok(vec![SessionEvent::ThinkingDelta { text }])
+    }
+
+    fn parse_mcp_tool_call(
+        &mut self,
+        item: &Value,
+        is_completed: bool,
+    ) -> Result<Vec<SessionEvent>, ProviderError> {
+        let item_id = item
+            .get("id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let server = item
+            .get("server")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let tool = item
+            .get("tool")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let tool_name = format!("{server}/{tool}");
+
+        if is_completed {
+            let result = item.get("result").cloned().unwrap_or(Value::Null);
+            let has_error = item.get("error").is_some();
+            let stored_name = self
+                .tool_names
+                .get(&item_id)
+                .cloned()
+                .unwrap_or(tool_name);
+
+            Ok(vec![SessionEvent::ToolEnd {
+                tool_use_id: item_id,
+                tool_name: stored_name,
+                output: result,
+                is_error: has_error,
+            }])
+        } else {
+            self.tool_names.insert(item_id.clone(), tool_name.clone());
+            let arguments = item.get("arguments").cloned().unwrap_or(Value::Null);
+
+            Ok(vec![SessionEvent::ToolStart {
+                tool_use_id: item_id,
+                tool_name,
+                input: arguments,
+            }])
+        }
+    }
+
+    fn parse_context_compaction(&self) -> Result<Vec<SessionEvent>, ProviderError> {
+        Ok(vec![SessionEvent::CompactBoundary {
+            trigger: "codex_context_compaction".into(),
+        }])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn assert_event_type(events: &[SessionEvent], index: usize, expected_type: &str) {
+        let event = &events[index];
+        let json = serde_json::to_value(event).unwrap();
+        assert_eq!(
+            json.get("type").and_then(|v| v.as_str()).unwrap(),
+            expected_type,
+            "Event at index {index} should be {expected_type}, got: {json}"
+        );
+    }
+
+    // --- thread lifecycle ---
+
+    #[test]
+    fn thread_started_produces_session_init_and_run_state() {
+        let mut parser = CodexEventParser::new();
+        let raw = json!({
+            "type": "thread.started",
+            "thread_id": "0199a213-81c0-7800-8aa1-bbab2a035a53"
+        });
+
+        let events = parser.map_event(&raw).unwrap();
+
+        assert_eq!(events.len(), 2);
+        assert_event_type(&events, 0, "session_init");
+        assert_event_type(&events, 1, "run_state");
+
+        if let SessionEvent::SessionInit { session_id, .. } = &events[0] {
+            assert_eq!(session_id, "0199a213-81c0-7800-8aa1-bbab2a035a53");
+        } else {
+            panic!("Expected SessionInit");
+        }
+    }
+
+    #[test]
+    fn turn_started_produces_run_state_running() {
+        let mut parser = CodexEventParser::new();
+        let events = parser.map_event(&json!({"type": "turn.started"})).unwrap();
+
+        assert_eq!(events.len(), 1);
+        if let SessionEvent::RunState { state, error } = &events[0] {
+            assert_eq!(state, "running");
+            assert!(error.is_none());
+        } else {
+            panic!("Expected RunState running");
+        }
+    }
+
+    #[test]
+    fn turn_completed_produces_usage_and_run_state_idle() {
+        let mut parser = CodexEventParser::new();
+        let raw = json!({
+            "type": "turn.completed",
+            "usage": {
+                "input_tokens": 24763,
+                "cached_input_tokens": 24448,
+                "output_tokens": 122,
+                "reasoning_output_tokens": 0
+            }
+        });
+
+        let events = parser.map_event(&raw).unwrap();
+
+        assert_eq!(events.len(), 2);
+        assert_event_type(&events, 0, "usage_update");
+        assert_event_type(&events, 1, "run_state");
+
+        if let SessionEvent::UsageUpdate { input_tokens, output_tokens, .. } = &events[0] {
+            assert_eq!(*input_tokens, 24763);
+            assert_eq!(*output_tokens, 122);
+        } else {
+            panic!("Expected UsageUpdate");
+        }
+
+        if let SessionEvent::RunState { state, .. } = &events[1] {
+            assert_eq!(state, "idle");
+        } else {
+            panic!("Expected RunState idle");
+        }
+    }
+
+    #[test]
+    fn turn_completed_zero_usage_skips_usage_event() {
+        let mut parser = CodexEventParser::new();
+        let raw = json!({
+            "type": "turn.completed",
+            "usage": {
+                "input_tokens": 0,
+                "output_tokens": 0
+            }
+        });
+
+        let events = parser.map_event(&raw).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_event_type(&events, 0, "run_state");
+    }
+
+    #[test]
+    fn turn_failed_produces_run_state_failed() {
+        let mut parser = CodexEventParser::new();
+        let raw = json!({
+            "type": "turn.failed",
+            "error": "Rate limit exceeded"
+        });
+
+        let events = parser.map_event(&raw).unwrap();
+
+        assert_eq!(events.len(), 1);
+        if let SessionEvent::RunState { state, error } = &events[0] {
+            assert_eq!(state, "failed");
+            assert_eq!(error.as_deref(), Some("Rate limit exceeded"));
+        } else {
+            panic!("Expected RunState failed");
+        }
+    }
+
+    // --- agent message items ---
+
+    #[test]
+    fn item_started_agent_message_produces_message_delta() {
+        let mut parser = CodexEventParser::new();
+        let raw = json!({
+            "type": "item.started",
+            "item": {
+                "id": "item_1",
+                "type": "agent_message",
+                "text": "Working on it..."
+            }
+        });
+
+        let events = parser.map_event(&raw).unwrap();
+        assert_eq!(events.len(), 1);
+        if let SessionEvent::MessageDelta { text } = &events[0] {
+            assert_eq!(text, "Working on it...");
+        } else {
+            panic!("Expected MessageDelta");
+        }
+    }
+
+    #[test]
+    fn item_completed_agent_message_produces_message_complete() {
+        let mut parser = CodexEventParser::new();
+        let raw = json!({
+            "type": "item.completed",
+            "item": {
+                "id": "item_3",
+                "type": "agent_message",
+                "text": "Repo contains docs, sdk, and examples directories."
+            }
+        });
+
+        let events = parser.map_event(&raw).unwrap();
+        assert_eq!(events.len(), 1);
+        if let SessionEvent::MessageComplete { text, message_id } = &events[0] {
+            assert_eq!(text, "Repo contains docs, sdk, and examples directories.");
+            assert_eq!(message_id, "item_3");
+        } else {
+            panic!("Expected MessageComplete");
+        }
+    }
+
+    // --- command execution items ---
+
+    #[test]
+    fn item_started_command_execution_produces_tool_start() {
+        let mut parser = CodexEventParser::new();
+        let raw = json!({
+            "type": "item.started",
+            "item": {
+                "id": "item_1",
+                "type": "command_execution",
+                "command": "bash -lc ls",
+                "status": "in_progress"
+            }
+        });
+
+        let events = parser.map_event(&raw).unwrap();
+        assert_eq!(events.len(), 1);
+        if let SessionEvent::ToolStart { tool_use_id, tool_name, input } = &events[0] {
+            assert_eq!(tool_use_id, "item_1");
+            assert_eq!(tool_name, "command_execution");
+            assert_eq!(input.as_str().unwrap(), "bash -lc ls");
+        } else {
+            panic!("Expected ToolStart");
+        }
+    }
+
+    #[test]
+    fn item_completed_command_execution_produces_tool_end() {
+        let mut parser = CodexEventParser::new();
+
+        // Start first to register tool name
+        let start = json!({
+            "type": "item.started",
+            "item": { "id": "item_1", "type": "command_execution", "command": "ls", "status": "in_progress" }
+        });
+        parser.map_event(&start).unwrap();
+
+        let raw = json!({
+            "type": "item.completed",
+            "item": {
+                "id": "item_1",
+                "type": "command_execution",
+                "command": "ls",
+                "aggregatedOutput": "file1.txt\nfile2.txt",
+                "exitCode": 0,
+                "status": "completed"
+            }
+        });
+
+        let events = parser.map_event(&raw).unwrap();
+        assert_eq!(events.len(), 1);
+        if let SessionEvent::ToolEnd { tool_use_id, tool_name, output, is_error } = &events[0] {
+            assert_eq!(tool_use_id, "item_1");
+            assert_eq!(tool_name, "command_execution");
+            assert_eq!(output.as_str().unwrap(), "file1.txt\nfile2.txt");
+            assert!(!is_error);
+        } else {
+            panic!("Expected ToolEnd");
+        }
+    }
+
+    #[test]
+    fn item_completed_command_execution_with_nonzero_exit_is_error() {
+        let mut parser = CodexEventParser::new();
+        let raw = json!({
+            "type": "item.completed",
+            "item": {
+                "id": "item_2",
+                "type": "command_execution",
+                "command": "false",
+                "aggregatedOutput": "",
+                "exitCode": 1,
+                "status": "completed"
+            }
+        });
+
+        let events = parser.map_event(&raw).unwrap();
+        assert_eq!(events.len(), 1);
+        if let SessionEvent::ToolEnd { is_error, .. } = &events[0] {
+            assert!(is_error);
+        } else {
+            panic!("Expected ToolEnd with error");
+        }
+    }
+
+    // --- file change items ---
+
+    #[test]
+    fn item_started_file_change_produces_tool_start() {
+        let mut parser = CodexEventParser::new();
+        let raw = json!({
+            "type": "item.started",
+            "item": {
+                "id": "item_5",
+                "type": "file_change",
+                "changes": [{"path": "src/main.rs", "type": "edit"}],
+                "status": "in_progress"
+            }
+        });
+
+        let events = parser.map_event(&raw).unwrap();
+        assert_eq!(events.len(), 1);
+        if let SessionEvent::ToolStart { tool_use_id, tool_name, .. } = &events[0] {
+            assert_eq!(tool_use_id, "item_5");
+            assert_eq!(tool_name, "file_change");
+        } else {
+            panic!("Expected ToolStart");
+        }
+    }
+
+    #[test]
+    fn item_completed_file_change_produces_tool_end() {
+        let mut parser = CodexEventParser::new();
+
+        let start = json!({
+            "type": "item.started",
+            "item": { "id": "item_5", "type": "file_change", "changes": [], "status": "in_progress" }
+        });
+        parser.map_event(&start).unwrap();
+
+        let raw = json!({
+            "type": "item.completed",
+            "item": {
+                "id": "item_5",
+                "type": "file_change",
+                "changes": [{"path": "src/main.rs", "type": "edit", "diff": "+line"}],
+                "status": "completed"
+            }
+        });
+
+        let events = parser.map_event(&raw).unwrap();
+        assert_eq!(events.len(), 1);
+        if let SessionEvent::ToolEnd { tool_use_id, is_error, .. } = &events[0] {
+            assert_eq!(tool_use_id, "item_5");
+            assert!(!is_error);
+        } else {
+            panic!("Expected ToolEnd");
+        }
+    }
+
+    // --- reasoning items ---
+
+    #[test]
+    fn item_started_reasoning_with_summary_produces_thinking_delta() {
+        let mut parser = CodexEventParser::new();
+        let raw = json!({
+            "type": "item.started",
+            "item": {
+                "id": "item_r1",
+                "type": "reasoning",
+                "summary": ["Analyzing the codebase", "Looking at file structure"]
+            }
+        });
+
+        let events = parser.map_event(&raw).unwrap();
+        assert_eq!(events.len(), 1);
+        if let SessionEvent::ThinkingDelta { text } = &events[0] {
+            assert_eq!(text, "Analyzing the codebase\nLooking at file structure");
+        } else {
+            panic!("Expected ThinkingDelta");
+        }
+    }
+
+    #[test]
+    fn item_reasoning_with_content_fallback() {
+        let mut parser = CodexEventParser::new();
+        let raw = json!({
+            "type": "item.started",
+            "item": {
+                "id": "item_r2",
+                "type": "reasoning",
+                "content": ["Step 1: read files"]
+            }
+        });
+
+        let events = parser.map_event(&raw).unwrap();
+        assert_eq!(events.len(), 1);
+        if let SessionEvent::ThinkingDelta { text } = &events[0] {
+            assert_eq!(text, "Step 1: read files");
+        } else {
+            panic!("Expected ThinkingDelta");
+        }
+    }
+
+    #[test]
+    fn item_reasoning_empty_produces_no_events() {
+        let mut parser = CodexEventParser::new();
+        let raw = json!({
+            "type": "item.started",
+            "item": { "id": "item_r3", "type": "reasoning" }
+        });
+
+        let events = parser.map_event(&raw).unwrap();
+        assert!(events.is_empty());
+    }
+
+    // --- MCP tool call items ---
+
+    #[test]
+    fn item_started_mcp_tool_call_produces_tool_start() {
+        let mut parser = CodexEventParser::new();
+        let raw = json!({
+            "type": "item.started",
+            "item": {
+                "id": "item_m1",
+                "type": "mcp_tool_call",
+                "server": "github",
+                "tool": "create_issue",
+                "arguments": {"title": "Fix bug"},
+                "status": "in_progress"
+            }
+        });
+
+        let events = parser.map_event(&raw).unwrap();
+        assert_eq!(events.len(), 1);
+        if let SessionEvent::ToolStart { tool_use_id, tool_name, input } = &events[0] {
+            assert_eq!(tool_use_id, "item_m1");
+            assert_eq!(tool_name, "github/create_issue");
+            assert_eq!(input["title"], "Fix bug");
+        } else {
+            panic!("Expected ToolStart");
+        }
+    }
+
+    #[test]
+    fn item_completed_mcp_tool_call_with_error() {
+        let mut parser = CodexEventParser::new();
+
+        let start = json!({
+            "type": "item.started",
+            "item": { "id": "item_m2", "type": "mcp_tool_call", "server": "db", "tool": "query", "arguments": {}, "status": "in_progress" }
+        });
+        parser.map_event(&start).unwrap();
+
+        let raw = json!({
+            "type": "item.completed",
+            "item": {
+                "id": "item_m2",
+                "type": "mcp_tool_call",
+                "server": "db",
+                "tool": "query",
+                "arguments": {},
+                "status": "failed",
+                "error": {"message": "Connection refused"}
+            }
+        });
+
+        let events = parser.map_event(&raw).unwrap();
+        assert_eq!(events.len(), 1);
+        if let SessionEvent::ToolEnd { is_error, .. } = &events[0] {
+            assert!(is_error);
+        } else {
+            panic!("Expected ToolEnd with error");
+        }
+    }
+
+    // --- context compaction ---
+
+    #[test]
+    fn context_compaction_produces_compact_boundary() {
+        let mut parser = CodexEventParser::new();
+        let raw = json!({
+            "type": "item.started",
+            "item": { "id": "item_c1", "type": "context_compaction" }
+        });
+
+        let events = parser.map_event(&raw).unwrap();
+        assert_eq!(events.len(), 1);
+        if let SessionEvent::CompactBoundary { trigger } = &events[0] {
+            assert_eq!(trigger, "codex_context_compaction");
+        } else {
+            panic!("Expected CompactBoundary");
+        }
+    }
+
+    // --- error event ---
+
+    #[test]
+    fn top_level_error_produces_run_state_failed() {
+        let mut parser = CodexEventParser::new();
+        let raw = json!({
+            "type": "error",
+            "message": "API key invalid"
+        });
+
+        let events = parser.map_event(&raw).unwrap();
+        assert_eq!(events.len(), 1);
+        if let SessionEvent::RunState { state, error } = &events[0] {
+            assert_eq!(state, "failed");
+            assert_eq!(error.as_deref(), Some("API key invalid"));
+        } else {
+            panic!("Expected RunState failed");
+        }
+    }
+
+    // --- camelCase item types ---
+
+    #[test]
+    fn camel_case_agent_message_handled() {
+        let mut parser = CodexEventParser::new();
+        let raw = json!({
+            "type": "item.completed",
+            "item": { "id": "item_cc", "type": "agentMessage", "text": "Done." }
+        });
+
+        let events = parser.map_event(&raw).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_event_type(&events, 0, "message_complete");
+    }
+
+    #[test]
+    fn camel_case_command_execution_handled() {
+        let mut parser = CodexEventParser::new();
+        let raw = json!({
+            "type": "item.started",
+            "item": { "id": "item_cc2", "type": "commandExecution", "command": "echo hi", "status": "in_progress" }
+        });
+
+        let events = parser.map_event(&raw).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_event_type(&events, 0, "tool_start");
+    }
+
+    // --- unknown event fallback ---
+
+    #[test]
+    fn unknown_event_type_produces_raw_fallback() {
+        let mut parser = CodexEventParser::new();
+        let raw = json!({
+            "type": "some_future_event",
+            "data": "whatever"
+        });
+
+        let events = parser.map_event(&raw).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_event_type(&events, 0, "raw");
+    }
+
+    #[test]
+    fn unknown_item_type_produces_raw_fallback() {
+        let mut parser = CodexEventParser::new();
+        let raw = json!({
+            "type": "item.started",
+            "item": { "id": "item_u1", "type": "future_tool" }
+        });
+
+        let events = parser.map_event(&raw).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_event_type(&events, 0, "raw");
+    }
+
+    // --- coverage for fallback paths ---
+
+    #[test]
+    fn turn_failed_uses_message_field_fallback() {
+        let mut parser = CodexEventParser::new();
+        let raw = json!({
+            "type": "turn.failed",
+            "message": "Context window exceeded"
+        });
+
+        let events = parser.map_event(&raw).unwrap();
+        assert_eq!(events.len(), 1);
+        if let SessionEvent::RunState { state, error } = &events[0] {
+            assert_eq!(state, "failed");
+            assert_eq!(error.as_deref(), Some("Context window exceeded"));
+        } else {
+            panic!("Expected RunState failed");
+        }
+    }
+
+    #[test]
+    fn turn_completed_without_usage_key_produces_only_run_state() {
+        let mut parser = CodexEventParser::new();
+        let raw = json!({"type": "turn.completed"});
+
+        let events = parser.map_event(&raw).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_event_type(&events, 0, "run_state");
+
+        if let SessionEvent::RunState { state, .. } = &events[0] {
+            assert_eq!(state, "idle");
+        } else {
+            panic!("Expected RunState idle");
+        }
+    }
+
+    #[test]
+    fn camel_case_file_change_handled() {
+        let mut parser = CodexEventParser::new();
+        let raw = json!({
+            "type": "item.started",
+            "item": { "id": "item_fc", "type": "fileChange", "changes": [], "status": "in_progress" }
+        });
+
+        let events = parser.map_event(&raw).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_event_type(&events, 0, "tool_start");
+    }
+
+    #[test]
+    fn camel_case_mcp_tool_call_handled() {
+        let mut parser = CodexEventParser::new();
+        let raw = json!({
+            "type": "item.started",
+            "item": { "id": "item_mc", "type": "mcpToolCall", "server": "test", "tool": "ping", "arguments": {}, "status": "in_progress" }
+        });
+
+        let events = parser.map_event(&raw).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_event_type(&events, 0, "tool_start");
+    }
+}

--- a/src-tauri/src/session/codex_provider.rs
+++ b/src-tauri/src/session/codex_provider.rs
@@ -1,0 +1,422 @@
+use std::path::PathBuf;
+
+use async_trait::async_trait;
+use serde_json::Value;
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::Command;
+use tokio::sync::mpsc;
+
+use super::codex_event_parser::CodexEventParser;
+use super::provider::{
+    ApprovalDecision, ProviderAdapter, ProviderCapabilities, ProviderError, SessionEvent,
+    SessionHandle, SessionTransport, SpawnConfig,
+};
+
+pub struct CodexProvider;
+
+impl CodexProvider {
+    pub fn new() -> Self {
+        Self
+    }
+
+    fn build_exec_command(
+        prompt: &str,
+        working_directory: &PathBuf,
+        model: &Option<String>,
+        sandbox: &Option<String>,
+        resume_thread_id: Option<&str>,
+    ) -> Command {
+        let mut cmd = Command::new("codex");
+
+        if let Some(thread_id) = resume_thread_id {
+            cmd.arg("exec").arg("resume").arg(thread_id);
+        } else {
+            cmd.arg("exec").arg(prompt);
+        }
+
+        cmd.arg("--json");
+
+        if let Some(ref model) = model {
+            cmd.arg("--model").arg(model);
+        }
+
+        if let Some(ref sandbox) = sandbox {
+            cmd.arg("--sandbox").arg(sandbox);
+        }
+
+        cmd.current_dir(working_directory);
+
+        cmd.stdin(std::process::Stdio::piped());
+        cmd.stdout(std::process::Stdio::piped());
+        cmd.stderr(std::process::Stdio::piped());
+
+        #[cfg(windows)]
+        {
+            cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
+        }
+
+        cmd
+    }
+
+    fn spawn_stdout_reader(
+        stdout: tokio::process::ChildStdout,
+        event_sender: mpsc::Sender<SessionEvent>,
+        thread_id_sender: Option<tokio::sync::oneshot::Sender<String>>,
+    ) {
+        tokio::spawn(async move {
+            let mut parser = CodexEventParser::new();
+            let mut reader = BufReader::new(stdout).lines();
+            let mut thread_id_tx = thread_id_sender;
+
+            while let Ok(Some(line)) = reader.next_line().await {
+                if let Ok(raw) = serde_json::from_str::<Value>(&line) {
+                    if raw.get("type").and_then(|v| v.as_str()) == Some("thread.started") {
+                        if let Some(id) = raw.get("thread_id").and_then(|v| v.as_str()) {
+                            if let Some(tx) = thread_id_tx.take() {
+                                let _ = tx.send(id.to_string());
+                            }
+                        }
+                    }
+
+                    match parser.map_event(&raw) {
+                        Ok(events) => {
+                            for event in events {
+                                if event_sender.send(event).await.is_err() {
+                                    return;
+                                }
+                            }
+                        }
+                        Err(e) => log::warn!("Codex parse error: {e}"),
+                    }
+                }
+            }
+        });
+    }
+
+    fn spawn_stderr_reader(
+        stderr: tokio::process::ChildStderr,
+        event_sender: mpsc::Sender<SessionEvent>,
+    ) {
+        tokio::spawn(async move {
+            let mut reader = BufReader::new(stderr).lines();
+            while let Ok(Some(line)) = reader.next_line().await {
+                let raw_event = SessionEvent::Raw {
+                    source: "stderr".into(),
+                    data: Value::String(line),
+                };
+                if event_sender.send(raw_event).await.is_err() {
+                    return;
+                }
+            }
+        });
+    }
+}
+
+#[async_trait]
+impl ProviderAdapter for CodexProvider {
+    async fn spawn(
+        &self,
+        config: SpawnConfig,
+    ) -> Result<(SessionHandle, mpsc::Receiver<SessionEvent>), ProviderError> {
+        let sandbox = config.permission_mode.clone();
+        let model = config.model.clone();
+        let working_directory = config.working_directory.clone();
+
+        let mut cmd = Self::build_exec_command(
+            &config.prompt,
+            &working_directory,
+            &model,
+            &sandbox,
+            config.resume_session_id.as_deref(),
+        );
+
+        for (key, value) in &config.env_vars {
+            cmd.env(key, value);
+        }
+
+        let mut child = cmd.spawn().map_err(|e| {
+            ProviderError::SpawnFailed(format!("Failed to spawn codex CLI: {e}"))
+        })?;
+
+        let pid = child.id().unwrap_or(0);
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| ProviderError::SpawnFailed("Failed to capture stdout".into()))?;
+        let stderr = child.stderr.take();
+
+        let (event_sender, event_receiver) = mpsc::channel::<SessionEvent>(256);
+
+        // Channel to receive thread_id from the stdout reader
+        let (thread_id_tx, thread_id_rx) = tokio::sync::oneshot::channel::<String>();
+
+        Self::spawn_stdout_reader(stdout, event_sender.clone(), Some(thread_id_tx));
+
+        if let Some(stderr) = stderr {
+            Self::spawn_stderr_reader(stderr, event_sender.clone());
+        }
+
+        // Wait briefly for thread_id (non-blocking fallback if not received)
+        let thread_id = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            thread_id_rx,
+        )
+        .await
+        .ok()
+        .and_then(|r| r.ok());
+
+        let handle = SessionHandle {
+            child,
+            pid,
+            transport: SessionTransport::CodexExec {
+                thread_id,
+                event_sender,
+                working_directory,
+                model,
+                sandbox,
+            },
+        };
+
+        Ok((handle, event_receiver))
+    }
+
+    async fn send_turn(
+        &self,
+        handle: &mut SessionHandle,
+        message: &str,
+    ) -> Result<(), ProviderError> {
+        let SessionTransport::CodexExec {
+            thread_id,
+            event_sender,
+            working_directory,
+            model,
+            sandbox,
+        } = &handle.transport
+        else {
+            return Err(ProviderError::NotRunning);
+        };
+
+        let tid = thread_id
+            .as_deref()
+            .ok_or(ProviderError::NotRunning)?;
+
+        let mut cmd = Self::build_exec_command(
+            message,
+            working_directory,
+            model,
+            sandbox,
+            Some(tid),
+        );
+
+        let mut new_child = cmd.spawn().map_err(|e| {
+            ProviderError::SpawnFailed(format!("Failed to spawn codex resume: {e}"))
+        })?;
+
+        let new_pid = new_child.id().unwrap_or(0);
+        let stdout = new_child
+            .stdout
+            .take()
+            .ok_or_else(|| ProviderError::SpawnFailed("Failed to capture stdout".into()))?;
+        let stderr = new_child.stderr.take();
+
+        let sender = event_sender.clone();
+
+        Self::spawn_stdout_reader(stdout, sender.clone(), None);
+
+        if let Some(stderr) = stderr {
+            Self::spawn_stderr_reader(stderr, sender);
+        }
+
+        let _ = handle.child.kill().await;
+        handle.child = new_child;
+        handle.pid = new_pid;
+
+        Ok(())
+    }
+
+    async fn respond_to_request(
+        &self,
+        _handle: &mut SessionHandle,
+        _request_id: &str,
+        _decision: &ApprovalDecision,
+    ) -> Result<(), ProviderError> {
+        // Codex exec mode handles approvals via --sandbox flag, not interactive prompts
+        Err(ProviderError::NotRunning)
+    }
+
+    async fn respond_to_user_input(
+        &self,
+        _handle: &mut SessionHandle,
+        _request_id: &str,
+        _answers: &Value,
+    ) -> Result<(), ProviderError> {
+        Err(ProviderError::NotRunning)
+    }
+
+    fn capabilities(&self) -> ProviderCapabilities {
+        ProviderCapabilities {
+            supports_spawn: true,
+            supports_discovery: false,
+            supports_mid_session_mode_switch: false,
+            supports_mid_session_model_switch: false,
+            supported_image_types: vec![],
+            available_permission_modes: vec![
+                "read-only".into(),
+                "workspace-write".into(),
+                "danger-full-access".into(),
+            ],
+        }
+    }
+
+    async fn interrupt(&self, handle: &mut SessionHandle) -> Result<(), ProviderError> {
+        let _ = handle.child.kill().await;
+        Ok(())
+    }
+
+    async fn terminate(&self, handle: &mut SessionHandle) -> Result<(), ProviderError> {
+        handle.child.kill().await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn codex_capabilities_returns_correct_values() {
+        let provider = CodexProvider::new();
+        let caps = provider.capabilities();
+        assert!(caps.supports_spawn);
+        assert!(!caps.supports_discovery);
+        assert!(!caps.supports_mid_session_mode_switch);
+        assert!(!caps.supports_mid_session_model_switch);
+        assert!(caps.supported_image_types.is_empty());
+        assert_eq!(
+            caps.available_permission_modes,
+            vec!["read-only", "workspace-write", "danger-full-access"]
+        );
+    }
+
+    #[test]
+    fn build_exec_command_basic() {
+        let cmd = CodexProvider::build_exec_command(
+            "hello world",
+            &PathBuf::from("/tmp"),
+            &None,
+            &None,
+            None,
+        );
+        let prog = cmd.as_std().get_program().to_str().unwrap();
+        assert_eq!(prog, "codex");
+
+        let args: Vec<&str> = cmd
+            .as_std()
+            .get_args()
+            .filter_map(|a| a.to_str())
+            .collect();
+        assert_eq!(args, vec!["exec", "hello world", "--json"]);
+    }
+
+    #[test]
+    fn build_exec_command_with_model_and_sandbox() {
+        let cmd = CodexProvider::build_exec_command(
+            "fix bug",
+            &PathBuf::from("/tmp"),
+            &Some("gpt-4.1".into()),
+            &Some("workspace-write".into()),
+            None,
+        );
+        let args: Vec<&str> = cmd
+            .as_std()
+            .get_args()
+            .filter_map(|a| a.to_str())
+            .collect();
+        assert!(args.contains(&"--model"));
+        assert!(args.contains(&"gpt-4.1"));
+        assert!(args.contains(&"--sandbox"));
+        assert!(args.contains(&"workspace-write"));
+    }
+
+    #[test]
+    fn build_exec_command_resume() {
+        let cmd = CodexProvider::build_exec_command(
+            "continue",
+            &PathBuf::from("/tmp"),
+            &None,
+            &None,
+            Some("thread-abc-123"),
+        );
+        let args: Vec<&str> = cmd
+            .as_std()
+            .get_args()
+            .filter_map(|a| a.to_str())
+            .collect();
+        assert_eq!(args[0], "exec");
+        assert_eq!(args[1], "resume");
+        assert_eq!(args[2], "thread-abc-123");
+        assert!(args.contains(&"--json"));
+    }
+
+    #[tokio::test]
+    async fn respond_to_request_returns_not_running() {
+        let provider = CodexProvider::new();
+        let child = tokio::process::Command::new("cmd")
+            .args(["/C", "echo test"])
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .unwrap();
+        let pid = child.id().unwrap_or(0);
+        let (tx, _rx) = mpsc::channel(1);
+        let mut handle = SessionHandle {
+            child,
+            pid,
+            transport: SessionTransport::CodexExec {
+                thread_id: None,
+                event_sender: tx,
+                working_directory: PathBuf::from("."),
+                model: None,
+                sandbox: None,
+            },
+        };
+
+        let result = provider
+            .respond_to_request(&mut handle, "req_x", &ApprovalDecision::Allow)
+            .await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().to_string(), "session not running");
+    }
+
+    #[tokio::test]
+    async fn respond_to_user_input_returns_not_running() {
+        let provider = CodexProvider::new();
+        let child = tokio::process::Command::new("cmd")
+            .args(["/C", "echo test"])
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .unwrap();
+        let pid = child.id().unwrap_or(0);
+        let (tx, _rx) = mpsc::channel(1);
+        let mut handle = SessionHandle {
+            child,
+            pid,
+            transport: SessionTransport::CodexExec {
+                thread_id: None,
+                event_sender: tx,
+                working_directory: PathBuf::from("."),
+                model: None,
+                sandbox: None,
+            },
+        };
+
+        let result = provider
+            .respond_to_user_input(&mut handle, "req_y", &serde_json::json!({}))
+            .await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().to_string(), "session not running");
+    }
+}

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -6,6 +6,7 @@ use tauri::AppHandle;
 use tokio::sync::{mpsc, Mutex};
 
 use super::claude_code_provider::ClaudeCodeProvider;
+use super::codex_provider::CodexProvider;
 use super::opencode_provider::OpenCodeProvider;
 use super::provider::{ActorCommand, ProviderAdapter, ProviderKind, SpawnConfig};
 use super::session_actor;
@@ -26,6 +27,7 @@ impl SessionManager {
         match kind {
             ProviderKind::ClaudeCode => Box::new(ClaudeCodeProvider::new()),
             ProviderKind::OpenCode => Box::new(OpenCodeProvider::new()),
+            ProviderKind::Codex => Box::new(CodexProvider::new()),
         }
     }
 

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -1,4 +1,6 @@
 pub mod claude_code_provider;
+pub mod codex_event_parser;
+pub mod codex_provider;
 pub mod discovery;
 pub mod discovery_polling;
 pub mod manager;

--- a/src-tauri/src/session/provider.rs
+++ b/src-tauri/src/session/provider.rs
@@ -15,11 +15,22 @@ use ts_rs::TS;
 pub enum ProviderKind {
     ClaudeCode,
     OpenCode,
+    Codex,
 }
 
 impl Default for ProviderKind {
     fn default() -> Self {
         Self::ClaudeCode
+    }
+}
+
+impl ProviderKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::ClaudeCode => "claude-code",
+            Self::OpenCode => "open-code",
+            Self::Codex => "codex",
+        }
     }
 }
 
@@ -79,6 +90,13 @@ pub enum SessionTransport {
         base_url: String,
         opencode_session_id: String,
         http_client: reqwest::Client,
+    },
+    CodexExec {
+        thread_id: Option<String>,
+        event_sender: mpsc::Sender<SessionEvent>,
+        working_directory: PathBuf,
+        model: Option<String>,
+        sandbox: Option<String>,
     },
 }
 

--- a/src/lib/modules/sessions/sessions.context.svelte.ts
+++ b/src/lib/modules/sessions/sessions.context.svelte.ts
@@ -8,6 +8,7 @@ import type {
 	DiscoveredSession,
 	DiscoveredSessionsPayload,
 	NotificationEventType,
+	ProviderKind,
 } from '$lib/types/generated';
 import { computeSessionEventEffects, type NotificationAction } from './session_events.js';
 import { SvelteMap } from 'svelte/reactivity';
@@ -20,7 +21,7 @@ interface SpawnSessionRequest {
 	issue_id?: string | null;
 	permission_mode?: string | null;
 	model?: string | null;
-	provider?: 'claude-code' | 'open-code' | null;
+	provider?: ProviderKind | null;
 }
 
 interface AdoptSessionRequest {

--- a/src/lib/tauri_mock_data.ts
+++ b/src/lib/tauri_mock_data.ts
@@ -425,6 +425,24 @@ export const MOCK_SESSIONS: Session[] = [
 		source: 'adopted',
 		working_directory: 'C:/_MP_projects/worktrees/71-ci-timeout-fix',
 	},
+	{
+		id: 'mock-session-codex',
+		issue_id: ISSUE_DARK_MODE,
+		provider: 'codex',
+		state: 'running',
+		pid: 12347,
+		cli_session_id: 'thread_0199a213',
+		started_at: '2026-05-04T10:00:00Z',
+		ended_at: null,
+		cost_usd: 0.15,
+		token_count: 5400,
+		original_intent: 'Generate unit tests for dark mode toggle',
+		last_prompt: 'Add tests for theme persistence',
+		last_response_summary: 'Writing vitest specs for localStorage theme save/load...',
+		execution_phase: 'tdd',
+		source: 'spawned',
+		working_directory: 'C:/_MP_projects/worktrees/55-dark-mode-toggle',
+	},
 ];
 
 // ─── Actions ──────────────────────────────────────────────────────────────────

--- a/src/lib/types/generated/ProviderKind.ts
+++ b/src/lib/types/generated/ProviderKind.ts
@@ -3,4 +3,4 @@
 /**
  * Which provider backend to use for a session.
  */
-export type ProviderKind = "claude-code" | "open-code";
+export type ProviderKind = "claude-code" | "open-code" | "codex";

--- a/src/lib/types/generated/index.ts
+++ b/src/lib/types/generated/index.ts
@@ -27,6 +27,7 @@ export type { NotificationEventType } from './NotificationEventType';
 export type { OverviewWorkspaceData } from './OverviewWorkspaceData';
 export type { PortfolioDashboardPointer } from './PortfolioDashboardPointer';
 export type { ProviderCapabilities } from './ProviderCapabilities';
+export type { ProviderKind } from './ProviderKind';
 export type { PrunableIssue } from './PrunableIssue';
 export type { PullRequestState } from './PullRequestState';
 export type { SearchedGithubIssue } from './SearchedGithubIssue';


### PR DESCRIPTION
## Description
- Adds CodexProvider implementing ProviderAdapter that spawns `codex exec --json` and parses JSONL events from stdout
- New CodexEventParser maps Codex events (thread lifecycle, agent messages, command executions, file changes, reasoning, MCP tool calls, context compaction) to unified SessionEvents
- Multi-turn support via `codex exec resume <thread_id>` with new process per turn for long-running sessions
- New `SessionTransport::CodexExec` variant persists thread_id and event_sender across turns
- DRY refactor: `ProviderKind::as_str()` helper replaces match-based string mapping in session_commands
- Frontend types updated: ProviderKind includes "codex" variant, mock session added for browser mode
- 33 unit tests: 25 for CodexEventParser, 8 for CodexProvider covering event parsing, thread lifecycle, and provider state management

## Resolves
Closes #161