### PR TITLE
#206 feat(viz): bidirectional forest↔card state sync + tree thumbnails

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -378,7 +378,8 @@
 
 /* ── Issue card state rings (box-shadow, referencing --ic per-card) ──── */
 
-.card-ic-interactive:hover {
+.card-ic-interactive:hover,
+.card-state-hovered-ic {
 	box-shadow:
 		0 0 0 2px color-mix(in oklch, var(--ic) 40%, transparent),
 		var(--shadow-md);

--- a/src/lib/components/ForestView.svelte
+++ b/src/lib/components/ForestView.svelte
@@ -213,7 +213,12 @@
 		});
 	}
 
-	function handleTreeClick(entry: IssueEntry) {
+	function handleTreeClick(entry: IssueEntry, event: MouseEvent) {
+		if (event.ctrlKey || event.metaKey) {
+			event.preventDefault();
+			interaction.toggleBatchSelect(entry.issue.id);
+			return;
+		}
 		interaction.activateIssue(entry.issue.id);
 	}
 
@@ -338,7 +343,7 @@
 							<button
 								{...triggerProps}
 								type="button"
-								class="absolute border-0 bg-transparent p-0 transition-transform focus-visible:outline-2 focus-visible:outline-ring [&>svg]:pointer-events-auto [&>svg]:cursor-pointer"
+								class="absolute border-0 bg-transparent p-0 transition-transform focus-visible:outline-2 focus-visible:outline-ring [&>svg]:pointer-events-none [&_.tree-root]:pointer-events-auto [&_.tree-root]:cursor-pointer"
 								style:left="{positioned.x}px"
 								style:top="{positioned.y}px"
 								style:width="{size.width}px"
@@ -350,7 +355,7 @@
 								style:pointer-events="none"
 								onmouseenter={() => interaction.hoverIssue(entry.issue.id)}
 								onmouseleave={() => interaction.unhover()}
-								onclick={() => handleTreeClick(entry)}
+								onclick={(event) => handleTreeClick(entry, event)}
 								oncontextmenu={(e) => handleContextMenu(e, entry)}
 								aria-label="Tree for issue {entry.issue.name}"
 							>

--- a/src/lib/components/IssueCard.svelte
+++ b/src/lib/components/IssueCard.svelte
@@ -26,6 +26,9 @@
 	import GitBranchIcon from '@lucide/svelte/icons/git-branch';
 	import { CARD_STATE_CLASSES } from './batch_selection_utils.js';
 	import { PRIORITY_BADGE_CLASSES, issueExpandedStates } from './issue_card_utils.js';
+	import type { TreeVisualization } from '$lib/modules/visualization';
+	import { LowPolyTree, PottedPlant, DEFAULT_TREE_CONFIG } from 'low-poly-2d-trees';
+	import type { TreeConfig } from 'low-poly-2d-trees';
 
 	interface Props {
 		issue: Issue;
@@ -37,10 +40,14 @@
 		progressLines?: readonly string[];
 		prioritiesEnabled?: boolean;
 		sessionState?: 'executing' | 'hitl' | 'review' | 'error' | 'paused' | 'done' | null;
+		visualization?: TreeVisualization | undefined;
 		isActive?: boolean;
+		isHovered?: boolean;
 		isBatchSelected?: boolean;
 		isSelectionReady?: boolean;
 		onCardClick?: (event: MouseEvent) => void;
+		onMouseEnter?: () => void;
+		onMouseLeave?: () => void;
 		onExecuteAction?: (actionId: string, issueId: string) => void;
 		onPriorityClick?: () => void;
 		onQuickActionAssignFolder?: (issueId: string) => void;
@@ -56,10 +63,14 @@
 		progressLines = [],
 		prioritiesEnabled = true,
 		sessionState = null,
+		visualization,
 		isActive = false,
+		isHovered = false,
 		isBatchSelected = false,
 		isSelectionReady = false,
 		onCardClick,
+		onMouseEnter,
+		onMouseLeave,
 		onExecuteAction,
 		onPriorityClick,
 		onQuickActionAssignFolder,
@@ -105,10 +116,25 @@
 		if (isActive) {
 			return CARD_STATE_CLASSES.active;
 		}
+		if (isHovered) {
+			return CARD_STATE_CLASSES.hovered;
+		}
 		if (isSelectionReady) {
 			return CARD_STATE_CLASSES.selectionReady;
 		}
 		return '';
+	});
+
+	const thumbnailOakConfig = $derived.by((): TreeConfig | null => {
+		if (visualization?.kind !== 'oak') {
+			return null;
+		}
+		return {
+			...DEFAULT_TREE_CONFIG,
+			shape: 'oak',
+			stage: 'leafy',
+			seed: visualization.seed,
+		};
 	});
 
 	const priorityChipClass = $derived(
@@ -169,12 +195,15 @@
 <div
 	class="group relative overflow-hidden rounded-lg border border-border bg-surface shadow-sm outline-none transition-all duration-150 focus:outline-none focus-visible:outline-none {cardStateClass} {isArchived ||
 	isActive ||
+	isHovered ||
 	isBatchSelected ||
 	isSelectionReady
 		? ''
 		: 'card-ic-interactive'}"
 	style:--ic={color}
 	onclick={handleCardClick}
+	onmouseenter={onMouseEnter}
+	onmouseleave={onMouseLeave}
 >
 	<!-- Header band -->
 	<div
@@ -276,7 +305,7 @@
 
 	<!-- Body: tree thumbnail | info -->
 	<div class="grid items-start gap-2.5 p-2.5 pr-3" style="grid-template-columns: 72px 1fr;">
-		<!-- Tree thumbnail placeholder -->
+		<!-- Tree thumbnail -->
 		<div
 			class="relative flex size-[72px] shrink-0 items-end justify-center overflow-hidden rounded-[7px] border"
 			style="background: linear-gradient(180deg, color-mix(in oklch, {color} var(--tree-bg-mix), var(--surface-2, hsl(0 0% 12%))) 0%, color-mix(in oklch, {color} 5%, var(--surface-3, hsl(0 0% 10%))) 100%); border-color: color-mix(in oklch, {color} 20%, var(--border));"
@@ -284,11 +313,25 @@
 			{#if notificationDotColor !== null && sessionState === null}
 				<SimpleTooltip text={m.issue_card_session_needs_attention()}>
 					<span
-						class="absolute top-1.5 right-1.5 size-[7px] animate-pulse rounded-full {notificationDotColor}"
+						class="absolute top-1.5 right-1.5 z-10 size-[7px] animate-pulse rounded-full {notificationDotColor}"
 					></span>
 				</SimpleTooltip>
 			{/if}
-			<div class="mb-4 size-6 rounded-full bg-foreground/20"></div>
+			{#if visualization?.kind === 'tree'}
+				<div class="absolute inset-0">
+					<LowPolyTree config={visualization.config} />
+				</div>
+			{:else if visualization?.kind === 'potted-plant'}
+				<div class="absolute inset-0">
+					<PottedPlant stage={visualization.stage} seed={visualization.seed} />
+				</div>
+			{:else if visualization?.kind === 'oak' && thumbnailOakConfig}
+				<div class="absolute inset-0">
+					<LowPolyTree config={thumbnailOakConfig} />
+				</div>
+			{:else}
+				<div class="mb-4 size-6 rounded-full bg-foreground/20"></div>
+			{/if}
 		</div>
 
 		<!-- Info rows -->

--- a/src/lib/components/IssueCardList.svelte
+++ b/src/lib/components/IssueCardList.svelte
@@ -2,6 +2,7 @@
 	import type { Issue } from '$lib/modules/issues';
 	import type { GitStatusCache } from '$lib/types/generated';
 	import type { IssueCardCallbacks, IssuePriority } from '$lib/modules/issues';
+	import type { TreeVisualization } from '$lib/modules/visualization';
 	import {
 		deriveContextualActions,
 		type ContextualActionInput,
@@ -24,6 +25,7 @@
 		getChildren: (parentId: string) => Issue[];
 		getNotificationDotColor?: (issueId: string) => string | null;
 		getProgressLines?: (issueId: string) => readonly string[];
+		getVisualization?: (issueId: string) => TreeVisualization | undefined;
 		onBatchArchive?: (issueIds: string[]) => void;
 		onBatchUnarchive?: (issueIds: string[]) => void;
 		onBatchDelete?: (issueIds: string[]) => void;
@@ -43,6 +45,7 @@
 		getChildren,
 		getNotificationDotColor,
 		getProgressLines,
+		getVisualization,
 		onArchive,
 		onUnarchive,
 		onEdit,
@@ -269,10 +272,14 @@
 					{forceExpanded}
 					progressLines={getProgressLines?.(issue.id) ?? []}
 					{prioritiesEnabled}
+					visualization={getVisualization?.(issue.id)}
 					isActive={selection.activeIssueId === issue.id}
+					isHovered={selection.hoveredIssueId === issue.id}
 					isBatchSelected={selection.batchSelectedIssueIds.has(issue.id)}
 					isSelectionReady={isModifierHeld}
 					onCardClick={(event) => handleCardClick(issue, event)}
+					onMouseEnter={() => selection.hoverIssue(issue.id)}
+					onMouseLeave={() => selection.unhover()}
 					{onExecuteAction}
 				/>
 			</IssueCardContextMenu>
@@ -306,10 +313,14 @@
 							{issue}
 							cache={cacheMap.get(issue.id)}
 							{ghAvailable}
+							visualization={getVisualization?.(issue.id)}
 							isActive={selection.activeIssueId === issue.id}
+							isHovered={selection.hoveredIssueId === issue.id}
 							isBatchSelected={selection.batchSelectedIssueIds.has(issue.id)}
 							isSelectionReady={isModifierHeld}
 							onCardClick={(event) => handleCardClick(issue, event)}
+							onMouseEnter={() => selection.hoverIssue(issue.id)}
+							onMouseLeave={() => selection.unhover()}
 						/>
 					</IssueCardContextMenu>
 				{/each}

--- a/src/lib/components/WorkspaceBottomPanel.svelte
+++ b/src/lib/components/WorkspaceBottomPanel.svelte
@@ -187,6 +187,7 @@
 					{getChildren}
 					{getNotificationDotColor}
 					{getProgressLines}
+					{getVisualization}
 					{onArchive}
 					{onUnarchive}
 					{onEdit}

--- a/src/lib/components/batch_selection_utils.test.ts
+++ b/src/lib/components/batch_selection_utils.test.ts
@@ -83,6 +83,7 @@ describe('CARD_STATE_CLASSES', () => {
 	it('has all expected state keys', () => {
 		const expectedKeys = [
 			'active',
+			'hovered',
 			'selected',
 			'selectionReady',
 			'dragging',

--- a/src/lib/components/batch_selection_utils.ts
+++ b/src/lib/components/batch_selection_utils.ts
@@ -45,6 +45,7 @@ export function computeSelectAllCheckboxState(
 
 export const CARD_STATE_CLASSES = {
 	active: 'card-state-active-ic',
+	hovered: 'card-state-hovered-ic',
 	selected: 'card-state-selected-primary',
 	selectionReady: 'card-state-selection-ready',
 	dragging: 'rotate-[-1.5deg] scale-[1.02] shadow-lg opacity-92',


### PR DESCRIPTION
## Summary

Closes #206

- Wire bidirectional hover sync between forest trees and issue cards via shared `hoveredIssueId` in selection context
- Add Ctrl+click batch selection on forest trees (toggles `batchSelectedIssueIds`)
- Replace 72×72px placeholder circle in issue card thumbnails with actual `LowPolyTree`/`PottedPlant` rendering
- Add `card-state-hovered-ic` CSS class mirroring native `:hover` ring for programmatic hover

## Changes

| File | Change |
|------|--------|
| `batch_selection_utils.ts` | Add `hovered` to `CARD_STATE_CLASSES` |
| `app.css` | Add `.card-state-hovered-ic` (shares rule with `.card-ic-interactive:hover`) |
| `IssueCard.svelte` | New props (`isHovered`, `visualization`, `onMouseEnter/Leave`), tree thumbnail, hover in state priority |
| `IssueCardList.svelte` | Wire hover callbacks + `isHovered` + `visualization` on both card grids |
| `WorkspaceBottomPanel.svelte` | Thread `getVisualization` to IssueCardList |
| `ForestView.svelte` | Ctrl+click → `toggleBatchSelect()`, pass event to handler |
| `batch_selection_utils.test.ts` | Add `hovered` to expected keys |

## Test plan

- [ ] Hover issue card → forest tree shows glow
- [ ] Hover forest tree → issue card shows colored ring
- [ ] Ctrl+click forest tree → batch selection toggles, toolbar appears
- [ ] Multi-select via Ctrl+click on multiple trees
- [ ] All issue cards render tree/plant/oak thumbnails (not placeholder circle)
- [ ] Archived cards also receive hover + tree preview
- [ ] `pnpm check:all` clean, `pnpm test` passes, no dead-code regression