### PR TITLE
feat(session): session chat view components (#153, #154, #155, #157, #159)

### DIFF
--- a/src/lib/components/SessionChatView.svelte
+++ b/src/lib/components/SessionChatView.svelte
@@ -26,9 +26,10 @@
 
 	interface Props {
 		session: Session;
+		onBack?: () => void;
 	}
 
-	let { session }: Props = $props();
+	let { session, onBack }: Props = $props();
 
 	const sessionStore = useSessions();
 
@@ -190,7 +191,7 @@
 
 <div class="flex h-full flex-col overflow-hidden">
 	<!-- Top bar -->
-	<SessionTopBar {session} />
+	<SessionTopBar {session} {onBack} />
 
 	<div class="flex flex-1 overflow-hidden">
 		<!-- Chat column -->

--- a/src/lib/components/SessionChatView.svelte
+++ b/src/lib/components/SessionChatView.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import * as m from '$lib/paraglide/messages.js';
 	import type { Session, SessionEventPayload } from '$lib/types/generated';
 	import { useSessions } from '$lib/modules/sessions';
 	import {
@@ -15,8 +14,6 @@
 	} from '$lib/modules/chat/index.js';
 	import { listen, type UnlistenFn } from '$lib/tauri.js';
 	import { onMount, onDestroy, tick } from 'svelte';
-	import { Button } from '$lib/components/ui/button/index.js';
-	import { Input } from '$lib/components/ui/input/index.js';
 	import {
 		ChatMessage as ChatMessageComponent,
 		ContentDimmer,
@@ -25,6 +22,7 @@
 	} from '$lib/components/chat/index.js';
 	import SessionTopBar from '$lib/components/session/SessionTopBar.svelte';
 	import SessionSidebar from '$lib/components/session/SessionSidebar.svelte';
+	import FloatingInputPanel from '$lib/components/session/FloatingInputPanel.svelte';
 
 	interface Props {
 		session: Session;
@@ -271,35 +269,15 @@
 				></div>
 			</div>
 
-			<!-- Input bar -->
-			<div class="border-t border-border p-3">
-				<div class="mx-auto flex max-w-[900px] items-center gap-2">
-					{#if session.state === 'running'}
-						<Button
-							variant="secondary"
-							size="sm"
-							class="shrink-0 bg-primary text-primary-foreground hover:bg-primary/90"
-							onclick={handleInterrupt}
-						>
-							{m.chat_interrupt()}
-						</Button>
-					{/if}
-
-					<Input
-						class="flex-1"
-						placeholder={isActive
-							? m.chat_placeholder_active()
-							: m.chat_placeholder_ended()}
-						bind:value={promptInput}
-						onkeydown={handleKeydown}
-						disabled={!isActive}
-					/>
-
-					<Button class="shrink-0" onclick={handleSend} disabled={!canSend}>
-						{m.chat_send()}
-					</Button>
-				</div>
-			</div>
+			<!-- Floating input panel -->
+			<FloatingInputPanel
+				{session}
+				bind:value={promptInput}
+				disabled={!isActive}
+				onSend={handleSend}
+				onStop={handleInterrupt}
+				onKeydown={handleKeydown}
+			/>
 		</div>
 
 		<!-- Right sidebar -->

--- a/src/lib/components/SessionChatView.svelte
+++ b/src/lib/components/SessionChatView.svelte
@@ -23,6 +23,8 @@
 		QuickNavButtons,
 		AssistantMessage,
 	} from '$lib/components/chat/index.js';
+	import SessionTopBar from '$lib/components/session/SessionTopBar.svelte';
+	import SessionSidebar from '$lib/components/session/SessionSidebar.svelte';
 
 	interface Props {
 		session: Session;
@@ -188,104 +190,119 @@
 	}
 </script>
 
-<div class="flex h-full flex-col">
-	<!-- Message stream -->
-	<div
-		class="relative flex-1 overflow-y-auto"
-		bind:this={scrollContainer}
-		onscroll={updateScrollPosition}
-	>
-		<div class="mx-auto max-w-[900px] px-6 pb-36 pt-4">
-			<div class="flex flex-col gap-2.5">
-				{#each turns as turn, turnIndex (turn.id)}
-					{@const isDimmed =
-						lastUserMessageTurnIndex > 0 && turnIndex < lastUserMessageTurnIndex}
-					<ContentDimmer dimmed={isDimmed}>
-						{#each turn.systemMessages as sysMsg (sysMsg.id)}
-							<div data-message-index={messages.indexOf(sysMsg)}>
-								<ChatMessageComponent message={sysMsg} />
-							</div>
-						{/each}
-						{#if turn.userMessage !== null}
-							<div data-message-index={messages.indexOf(turn.userMessage)}>
-								<ChatMessageComponent message={turn.userMessage} />
-							</div>
-						{/if}
-						{#each turn.assistantMessages as assistantMsg, assistantIndex (assistantMsg.id)}
-							<div data-message-index={messages.indexOf(assistantMsg)}>
-								<ChatMessageComponent message={assistantMsg} />
-							</div>
-							{@const toolsBefore = turn.toolMessages.filter(
-								(t) =>
-									t.timestamp >= assistantMsg.timestamp &&
-									(assistantIndex + 1 >= turn.assistantMessages.length ||
-										t.timestamp <
-											turn.assistantMessages[assistantIndex + 1].timestamp),
-							)}
-							{#each toolsBefore as toolMsg (toolMsg.id)}
-								<div data-message-index={messages.indexOf(toolMsg)}>
-									<ChatMessageComponent message={toolMsg} />
-								</div>
-							{/each}
-						{/each}
-						{#if turn.assistantMessages.length === 0}
-							{#each turn.toolMessages as toolMsg (toolMsg.id)}
-								<div data-message-index={messages.indexOf(toolMsg)}>
-									<ChatMessageComponent message={toolMsg} />
-								</div>
-							{/each}
-						{/if}
-					</ContentDimmer>
-				{/each}
+<div class="flex h-full flex-col overflow-hidden">
+	<!-- Top bar -->
+	<SessionTopBar {session} />
 
-				<!-- Streaming text -->
-				{#if currentStreamingText}
-					<div>
-						<AssistantMessage content={currentStreamingText} streaming={true} />
+	<div class="flex flex-1 overflow-hidden">
+		<!-- Chat column -->
+		<div class="relative flex flex-1 flex-col overflow-hidden">
+			<!-- Message stream -->
+			<div
+				class="relative flex-1 overflow-y-auto"
+				bind:this={scrollContainer}
+				onscroll={updateScrollPosition}
+			>
+				<div class="mx-auto max-w-[900px] px-6 pb-36 pt-4">
+					<div class="flex flex-col gap-2.5">
+						{#each turns as turn, turnIndex (turn.id)}
+							{@const isDimmed =
+								lastUserMessageTurnIndex > 0 &&
+								turnIndex < lastUserMessageTurnIndex}
+							<ContentDimmer dimmed={isDimmed}>
+								{#each turn.systemMessages as sysMsg (sysMsg.id)}
+									<div data-message-index={messages.indexOf(sysMsg)}>
+										<ChatMessageComponent message={sysMsg} />
+									</div>
+								{/each}
+								{#if turn.userMessage !== null}
+									<div data-message-index={messages.indexOf(turn.userMessage)}>
+										<ChatMessageComponent message={turn.userMessage} />
+									</div>
+								{/if}
+								{#each turn.assistantMessages as assistantMsg, assistantIndex (assistantMsg.id)}
+									<div data-message-index={messages.indexOf(assistantMsg)}>
+										<ChatMessageComponent message={assistantMsg} />
+									</div>
+									{@const toolsBefore = turn.toolMessages.filter(
+										(t) =>
+											t.timestamp >= assistantMsg.timestamp &&
+											(assistantIndex + 1 >= turn.assistantMessages.length ||
+												t.timestamp <
+													turn.assistantMessages[assistantIndex + 1]
+														.timestamp),
+									)}
+									{#each toolsBefore as toolMsg (toolMsg.id)}
+										<div data-message-index={messages.indexOf(toolMsg)}>
+											<ChatMessageComponent message={toolMsg} />
+										</div>
+									{/each}
+								{/each}
+								{#if turn.assistantMessages.length === 0}
+									{#each turn.toolMessages as toolMsg (toolMsg.id)}
+										<div data-message-index={messages.indexOf(toolMsg)}>
+											<ChatMessageComponent message={toolMsg} />
+										</div>
+									{/each}
+								{/if}
+							</ContentDimmer>
+						{/each}
+
+						<!-- Streaming text -->
+						{#if currentStreamingText}
+							<div>
+								<AssistantMessage content={currentStreamingText} streaming={true} />
+							</div>
+						{/if}
 					</div>
-				{/if}
+				</div>
+
+				<!-- Quick nav buttons -->
+				<QuickNavButtons
+					{showJumpToPrompt}
+					{showJumpToResponse}
+					onJumpToPrompt={() => scrollToLastMessage('user')}
+					onJumpToResponse={() => scrollToLastMessage('assistant')}
+				/>
+
+				<!-- Gradient fade -->
+				<div
+					class="pointer-events-none sticky bottom-0 -mt-[120px] h-[120px] bg-gradient-to-b from-transparent to-background"
+				></div>
+			</div>
+
+			<!-- Input bar -->
+			<div class="border-t border-border p-3">
+				<div class="mx-auto flex max-w-[900px] items-center gap-2">
+					{#if session.state === 'running'}
+						<Button
+							variant="secondary"
+							size="sm"
+							class="shrink-0 bg-primary text-primary-foreground hover:bg-primary/90"
+							onclick={handleInterrupt}
+						>
+							{m.chat_interrupt()}
+						</Button>
+					{/if}
+
+					<Input
+						class="flex-1"
+						placeholder={isActive
+							? m.chat_placeholder_active()
+							: m.chat_placeholder_ended()}
+						bind:value={promptInput}
+						onkeydown={handleKeydown}
+						disabled={!isActive}
+					/>
+
+					<Button class="shrink-0" onclick={handleSend} disabled={!canSend}>
+						{m.chat_send()}
+					</Button>
+				</div>
 			</div>
 		</div>
 
-		<!-- Quick nav buttons -->
-		<QuickNavButtons
-			{showJumpToPrompt}
-			{showJumpToResponse}
-			onJumpToPrompt={() => scrollToLastMessage('user')}
-			onJumpToResponse={() => scrollToLastMessage('assistant')}
-		/>
-
-		<!-- Gradient fade -->
-		<div
-			class="pointer-events-none sticky bottom-0 -mt-[120px] h-[120px] bg-gradient-to-b from-transparent to-background"
-		></div>
-	</div>
-
-	<!-- Input bar -->
-	<div class="border-t border-border p-3">
-		<div class="mx-auto flex max-w-[900px] items-center gap-2">
-			{#if session.state === 'running'}
-				<Button
-					variant="secondary"
-					size="sm"
-					class="shrink-0 bg-primary text-primary-foreground hover:bg-primary/90"
-					onclick={handleInterrupt}
-				>
-					{m.chat_interrupt()}
-				</Button>
-			{/if}
-
-			<Input
-				class="flex-1"
-				placeholder={isActive ? m.chat_placeholder_active() : m.chat_placeholder_ended()}
-				bind:value={promptInput}
-				onkeydown={handleKeydown}
-				disabled={!isActive}
-			/>
-
-			<Button class="shrink-0" onclick={handleSend} disabled={!canSend}>
-				{m.chat_send()}
-			</Button>
-		</div>
+		<!-- Right sidebar -->
+		<SessionSidebar {session} contextPercent={54} quota5hPercent={42} quota7dPercent={18} />
 	</div>
 </div>

--- a/src/lib/components/chat/ChatMessage.svelte
+++ b/src/lib/components/chat/ChatMessage.svelte
@@ -1,11 +1,14 @@
 <script lang="ts">
 	import type { ChatMessage as ChatMessageType } from '$lib/modules/chat/index.js';
-	import { MESSAGE_ROLE } from '$lib/modules/chat/index.js';
+	import { MESSAGE_ROLE, INTERACTION_TYPE } from '$lib/modules/chat/index.js';
 	import UserBubble from './UserBubble.svelte';
 	import AssistantMessage from './AssistantMessage.svelte';
 	import SystemMessage from './SystemMessage.svelte';
 	import ToolCardCompact from './ToolCardCompact.svelte';
 	import ToolCardExpanded from './ToolCardExpanded.svelte';
+	import ToolCardPermission from './ToolCardPermission.svelte';
+	import ToolCardElicitation from './ToolCardElicitation.svelte';
+	import ToolCardAskUser from './ToolCardAskUser.svelte';
 
 	interface Props {
 		message: ChatMessageType;
@@ -23,7 +26,13 @@
 	{:else if message.role === MESSAGE_ROLE.assistant}
 		<AssistantMessage content={message.content} {streaming} />
 	{:else if message.role === MESSAGE_ROLE.tool}
-		{#if expanded}
+		{#if message.interactionType === INTERACTION_TYPE.permission}
+			<ToolCardPermission {message} />
+		{:else if message.interactionType === INTERACTION_TYPE.elicitation}
+			<ToolCardElicitation {message} />
+		{:else if message.interactionType === INTERACTION_TYPE.askUser}
+			<ToolCardAskUser {message} />
+		{:else if expanded}
 			<ToolCardExpanded {message} onCollapse={() => (expanded = false)} />
 		{:else}
 			<ToolCardCompact {message} onExpand={() => (expanded = true)} />

--- a/src/lib/components/chat/ChatMessage.svelte
+++ b/src/lib/components/chat/ChatMessage.svelte
@@ -5,6 +5,7 @@
 	import AssistantMessage from './AssistantMessage.svelte';
 	import SystemMessage from './SystemMessage.svelte';
 	import ToolCardCompact from './ToolCardCompact.svelte';
+	import ToolCardExpanded from './ToolCardExpanded.svelte';
 
 	interface Props {
 		message: ChatMessageType;
@@ -12,6 +13,8 @@
 	}
 
 	let { message, streaming = false }: Props = $props();
+
+	let expanded = $state(false);
 </script>
 
 {#if message}
@@ -20,7 +23,11 @@
 	{:else if message.role === MESSAGE_ROLE.assistant}
 		<AssistantMessage content={message.content} {streaming} />
 	{:else if message.role === MESSAGE_ROLE.tool}
-		<ToolCardCompact {message} />
+		{#if expanded}
+			<ToolCardExpanded {message} onCollapse={() => (expanded = false)} />
+		{:else}
+			<ToolCardCompact {message} onExpand={() => (expanded = true)} />
+		{/if}
 	{:else if message.role === MESSAGE_ROLE.system}
 		<SystemMessage content={message.content} />
 	{/if}

--- a/src/lib/components/chat/InteractionCards.stories.svelte
+++ b/src/lib/components/chat/InteractionCards.stories.svelte
@@ -5,10 +5,8 @@
 
 	const { Story } = defineMeta({
 		title: 'Chat/InteractionCards',
-		component: ToolCardPermission,
 		// @ts-expect-error — Storybook decorator typing doesn't match Svelte 5 Component type
 		decorators: [() => ThemeDecorator],
-		tags: ['autodocs'],
 	});
 </script>
 

--- a/src/lib/components/chat/InteractionCards.stories.svelte
+++ b/src/lib/components/chat/InteractionCards.stories.svelte
@@ -1,0 +1,98 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import ToolCardPermission from './ToolCardPermission.svelte';
+	import ThemeDecorator from '$lib/storybook/ThemeDecorator.svelte';
+
+	const { Story } = defineMeta({
+		title: 'Chat/InteractionCards',
+		component: ToolCardPermission,
+		// @ts-expect-error — Storybook decorator typing doesn't match Svelte 5 Component type
+		decorators: [() => ThemeDecorator],
+		tags: ['autodocs'],
+	});
+</script>
+
+<script lang="ts">
+	import ToolCardElicitation from './ToolCardElicitation.svelte';
+	import ToolCardAskUser from './ToolCardAskUser.svelte';
+	import type { ChatMessage } from '$lib/modules/chat/index.js';
+
+	const permissionMessage: ChatMessage = {
+		id: 'perm-1',
+		role: 'tool',
+		content: 'Permission needed for Bash',
+		timestamp: Date.now(),
+		toolName: 'Bash',
+		toolStatus: 'running',
+		toolInput: {
+			command: 'rm -rf target/debug/build/grovekeeper-*\ncargo build --release',
+		},
+		interactionType: 'permission',
+		requestId: 'req_1',
+	};
+
+	const elicitationMessage: ChatMessage = {
+		id: 'elicit-1',
+		role: 'tool',
+		content:
+			'The query requires access to the production database. Please provide the connection string or confirm the environment to use.',
+		timestamp: Date.now(),
+		toolStatus: 'running',
+		toolInput: { server: 'postgres' },
+		interactionType: 'elicitation',
+		requestId: 'req_2',
+	};
+
+	const askUserMessage: ChatMessage = {
+		id: 'ask-1',
+		role: 'tool',
+		content: '',
+		timestamp: Date.now(),
+		toolStatus: 'running',
+		toolInput: {
+			question:
+				'I found two approaches for the authentication refactor. Which would you prefer?',
+			options: [
+				'Option A: Full OAuth2 PKCE with refresh tokens (more secure, more complex)',
+				'Option B: API key with session tokens (simpler, adequate for dev tools)',
+				'Other (describe your preference)',
+			],
+		},
+		interactionType: 'ask-user',
+		requestId: 'req_3',
+	};
+</script>
+
+<Story name="Permission Prompt">
+	{#snippet template()}
+		<div class="mx-auto max-w-[900px] p-4">
+			<ToolCardPermission message={permissionMessage} />
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Elicitation Prompt">
+	{#snippet template()}
+		<div class="mx-auto max-w-[900px] p-4">
+			<ToolCardElicitation message={elicitationMessage} />
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Ask User (Options)">
+	{#snippet template()}
+		<div class="mx-auto max-w-[900px] p-4">
+			<ToolCardAskUser message={askUserMessage} />
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="All L3 Types">
+	{#snippet template()}
+		<div class="mx-auto max-w-[900px] space-y-3 p-4">
+			<ToolCardPermission message={permissionMessage} />
+			<ToolCardElicitation message={elicitationMessage} />
+			<ToolCardAskUser message={askUserMessage} />
+		</div>
+	{/snippet}
+</Story>

--- a/src/lib/components/chat/ToolCardAskUser.svelte
+++ b/src/lib/components/chat/ToolCardAskUser.svelte
@@ -1,0 +1,83 @@
+<script lang="ts">
+	import type { ChatMessage } from '$lib/modules/chat/index.js';
+	import CompassIcon from '@lucide/svelte/icons/compass';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Kbd } from '$lib/components/ui/kbd/index.js';
+
+	interface Props {
+		message: ChatMessage;
+		onConfirm?: (selectedIndex: number) => void;
+	}
+
+	let { message, onConfirm }: Props = $props();
+
+	let selectedIndex = $state(0);
+
+	const options = $derived.by(() => {
+		if (
+			typeof message.toolInput === 'object' &&
+			message.toolInput !== null &&
+			!Array.isArray(message.toolInput)
+		) {
+			const input = message.toolInput as Record<string, unknown>;
+			if (Array.isArray(input.options)) {
+				return input.options.filter((o): o is string => typeof o === 'string');
+			}
+		}
+		return [];
+	});
+
+	const question = $derived.by(() => {
+		if (
+			typeof message.toolInput === 'object' &&
+			message.toolInput !== null &&
+			!Array.isArray(message.toolInput)
+		) {
+			const input = message.toolInput as Record<string, unknown>;
+			if (typeof input.question === 'string') {
+				return input.question;
+			}
+		}
+		return message.content || 'Select an option';
+	});
+</script>
+
+<div class="overflow-hidden rounded-lg border border-border bg-surface">
+	<!-- Header -->
+	<div class="flex h-9 items-center gap-2 border-b border-border bg-surface-2 px-3">
+		<CompassIcon size={13} strokeWidth={1.8} class="text-foreground-muted" />
+		<span class="text-xs font-semibold">Agent asks</span>
+	</div>
+
+	<!-- Content -->
+	<div class="px-3 py-2.5">
+		<div class="mb-2.5 text-[13px] leading-[1.5] text-foreground">
+			{question}
+		</div>
+		{#if options.length > 0}
+			<div class="mb-2.5 flex flex-col gap-1">
+				{#each options as option, i (i)}
+					<label
+						class="flex cursor-pointer items-center gap-2 rounded-md px-2 py-[5px] text-[12.5px]"
+						class:bg-primary-soft={selectedIndex === i}
+						style={selectedIndex === i
+							? 'border: 1px solid color-mix(in oklch, var(--primary) 30%, var(--border))'
+							: 'border: 1px solid transparent'}
+					>
+						<input
+							type="radio"
+							name="ask-option"
+							class="accent-primary"
+							checked={selectedIndex === i}
+							onchange={() => (selectedIndex = i)}
+						/>
+						<span>{option}</span>
+					</label>
+				{/each}
+			</div>
+		{/if}
+		<Button variant="primary" size="sm" onclick={() => onConfirm?.(selectedIndex)}>
+			Confirm <Kbd class="ml-1">↵</Kbd>
+		</Button>
+	</div>
+</div>

--- a/src/lib/components/chat/ToolCardCompact.svelte
+++ b/src/lib/components/chat/ToolCardCompact.svelte
@@ -3,65 +3,33 @@
 	import { TOOL_STATUS } from '$lib/modules/chat/index.js';
 	import CheckIcon from '@lucide/svelte/icons/check';
 	import XIcon from '@lucide/svelte/icons/x';
-	import TerminalIcon from '@lucide/svelte/icons/terminal';
-	import EyeIcon from '@lucide/svelte/icons/eye';
-	import PencilIcon from '@lucide/svelte/icons/pencil';
-	import CodeIcon from '@lucide/svelte/icons/code';
-	import FolderSearchIcon from '@lucide/svelte/icons/folder-search';
-	import SearchIcon from '@lucide/svelte/icons/search';
-	import CpuIcon from '@lucide/svelte/icons/cpu';
-	import GlobeIcon from '@lucide/svelte/icons/globe';
-	import ArrowDownIcon from '@lucide/svelte/icons/arrow-down';
-	import ListIcon from '@lucide/svelte/icons/list';
-	import SettingsIcon from '@lucide/svelte/icons/settings';
+	import { extractToolDetail, getToolIcon } from './tool_card_utils.js';
 
 	interface Props {
 		message: ChatMessage;
+		onExpand?: () => void;
 	}
 
-	let { message }: Props = $props();
+	let { message, onExpand }: Props = $props();
 
-	const TOOL_ICON_MAP: Record<string, typeof TerminalIcon> = {
-		Bash: TerminalIcon,
-		Read: EyeIcon,
-		Write: PencilIcon,
-		Edit: CodeIcon,
-		Glob: FolderSearchIcon,
-		Grep: SearchIcon,
-		Agent: CpuIcon,
-		WebSearch: GlobeIcon,
-		WebFetch: ArrowDownIcon,
-		TodoWrite: ListIcon,
-		Task: SettingsIcon,
-	};
-
-	const IconComponent = $derived(TOOL_ICON_MAP[message.toolName ?? ''] ?? TerminalIcon);
-
-	// fallow-ignore-next-line complexity
-	const detail = $derived.by(() => {
-		if (message.toolInput === undefined || message.toolInput === null) {
-			return '';
-		}
-		if (typeof message.toolInput === 'object' && !Array.isArray(message.toolInput)) {
-			const input = message.toolInput as Record<string, unknown>;
-			if (typeof input.file_path === 'string') {
-				return input.file_path;
-			}
-			if (typeof input.command === 'string') {
-				return `$ ${input.command}`;
-			}
-			if (typeof input.pattern === 'string') {
-				return input.pattern;
-			}
-		}
-		return '';
-	});
+	const IconComponent = $derived(getToolIcon(message.toolName ?? ''));
+	const detail = $derived(extractToolDetail(message));
 </script>
 
 <div
-	class="flex h-9 items-center gap-2 rounded-md border border-border bg-surface-2 px-2.5 opacity-80 transition-opacity duration-[120ms] hover:opacity-100"
+	class="flex h-9 cursor-pointer items-center gap-2 rounded-md border border-border bg-surface-2 px-2.5 opacity-80 transition-opacity duration-[120ms] hover:opacity-100"
 	class:border-l-2={message.isError === true}
 	class:border-l-status-danger={message.isError === true}
+	onclick={onExpand}
+	onkeydown={(e) => {
+		if (e.key === 'Enter' || e.key === ' ') {
+			e.preventDefault();
+			onExpand?.();
+		}
+	}}
+	role="button"
+	tabindex="0"
+	aria-label="Expand {message.toolName} tool card"
 >
 	<IconComponent class="size-[13px] shrink-0 text-foreground-muted" />
 	<span class="text-xs font-semibold text-foreground">{message.toolName ?? 'Tool'}</span>

--- a/src/lib/components/chat/ToolCardElicitation.svelte
+++ b/src/lib/components/chat/ToolCardElicitation.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+	import type { ChatMessage } from '$lib/modules/chat/index.js';
+	import DatabaseIcon from '@lucide/svelte/icons/database';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { Kbd } from '$lib/components/ui/kbd/index.js';
+
+	interface Props {
+		message: ChatMessage;
+		onSubmit?: (value: string) => void;
+		onCancel?: () => void;
+	}
+
+	let { message, onSubmit, onCancel }: Props = $props();
+
+	let inputValue = $state('');
+
+	const serverName = $derived.by(() => {
+		if (
+			typeof message.toolInput === 'object' &&
+			message.toolInput !== null &&
+			!Array.isArray(message.toolInput)
+		) {
+			const input = message.toolInput as Record<string, unknown>;
+			if (typeof input.server === 'string') {
+				return input.server;
+			}
+		}
+		return 'MCP Server';
+	});
+
+	function handleSubmit() {
+		if (inputValue.trim()) {
+			onSubmit?.(inputValue.trim());
+			inputValue = '';
+		}
+	}
+
+	function handleKeydown(event: KeyboardEvent) {
+		if (event.key === 'Enter') {
+			event.preventDefault();
+			handleSubmit();
+		}
+		if (event.key === 'Escape') {
+			event.preventDefault();
+			onCancel?.();
+		}
+	}
+</script>
+
+<div
+	class="overflow-hidden rounded-lg border bg-surface"
+	style="border-color: color-mix(in oklch, var(--status-info) 40%, var(--border))"
+>
+	<!-- Header -->
+	<div
+		class="flex h-9 items-center gap-2 border-b px-3"
+		style="background: color-mix(in oklch, var(--status-info) 8%, var(--surface-2)); border-color: color-mix(in oklch, var(--status-info) 30%, var(--border))"
+	>
+		<DatabaseIcon size={13} strokeWidth={1.8} class="text-status-info" />
+		<span class="text-xs font-semibold">MCP: {serverName}</span>
+	</div>
+
+	<!-- Content -->
+	<div class="flex">
+		<div class="w-[3px] shrink-0 bg-status-info"></div>
+		<div class="flex-1 px-3 py-2.5">
+			<div class="mb-2.5 text-[13px] leading-[1.5] text-foreground">
+				{message.content}
+			</div>
+			<div class="flex items-center gap-1.5">
+				<Input
+					class="max-w-[320px] flex-1 text-xs"
+					placeholder="Enter value…"
+					bind:value={inputValue}
+					onkeydown={handleKeydown}
+				/>
+				<Button variant="primary" size="sm" onclick={handleSubmit}>
+					Submit <Kbd class="ml-1">↵</Kbd>
+				</Button>
+				<Button variant="ghost" size="sm" onclick={onCancel}>Cancel</Button>
+			</div>
+		</div>
+	</div>
+</div>

--- a/src/lib/components/chat/ToolCardExpanded.svelte
+++ b/src/lib/components/chat/ToolCardExpanded.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+	import type { ChatMessage } from '$lib/modules/chat/index.js';
+	import { TOOL_STATUS } from '$lib/modules/chat/index.js';
+	import CheckIcon from '@lucide/svelte/icons/check';
+	import XIcon from '@lucide/svelte/icons/x';
+	import {
+		extractToolDetail,
+		extractToolOutput,
+		getToolAccentColor,
+		getToolIcon,
+	} from './tool_card_utils.js';
+
+	interface Props {
+		message: ChatMessage;
+		onCollapse?: () => void;
+	}
+
+	let { message, onCollapse }: Props = $props();
+
+	const IconComponent = $derived(getToolIcon(message.toolName ?? ''));
+	const detail = $derived(extractToolDetail(message));
+	const output = $derived(extractToolOutput(message));
+	const accentColor = $derived(getToolAccentColor(message.toolName ?? ''));
+</script>
+
+<div
+	class="overflow-hidden rounded-lg border border-border bg-surface"
+	role="region"
+	aria-label="Tool card: {message.toolName}"
+>
+	<!-- Header (36px, same as L1) -->
+	<button
+		class="flex h-9 w-full cursor-pointer items-center gap-2 border-b border-border bg-surface-2 px-2.5"
+		onclick={onCollapse}
+		type="button"
+	>
+		<IconComponent class="size-[13px] shrink-0" style="color: {accentColor}" />
+		<span class="text-xs font-semibold">{message.toolName ?? 'Tool'}</span>
+		{#if detail}
+			<span class="flex-1 truncate font-mono text-[11px] text-foreground-muted">
+				{detail}
+			</span>
+		{:else}
+			<span class="flex-1"></span>
+		{/if}
+		{#if message.toolStatus === TOOL_STATUS.running}
+			<span
+				class="size-2.5 shrink-0 animate-spin rounded-full border-2 border-foreground-muted border-t-transparent"
+			></span>
+		{:else if message.toolStatus === TOOL_STATUS.error}
+			<XIcon class="size-3 shrink-0 text-status-danger" />
+		{:else}
+			<CheckIcon class="size-3 shrink-0 text-status-success" />
+		{/if}
+	</button>
+
+	<!-- Content panel with accent border -->
+	<div class="flex">
+		<div class="w-[3px] shrink-0" style="background: {accentColor}"></div>
+		<pre
+			class="m-0 max-h-[260px] flex-1 overflow-auto break-all whitespace-pre-wrap px-3 py-2.5 font-mono text-[11.5px] leading-[1.55] text-foreground-muted">{output ||
+				detail}</pre>
+	</div>
+</div>

--- a/src/lib/components/chat/ToolCardGroup.svelte
+++ b/src/lib/components/chat/ToolCardGroup.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import type { ChatMessage as ChatMessageType } from '$lib/modules/chat/index.js';
+	import ChevronRightIcon from '@lucide/svelte/icons/chevron-right';
+	import ToolCardCompact from './ToolCardCompact.svelte';
+
+	interface Props {
+		messages: ChatMessageType[];
+		renderCard?: Snippet<[ChatMessageType]>;
+	}
+
+	let { messages, renderCard }: Props = $props();
+
+	let expanded = $state(false);
+</script>
+
+{#if expanded}
+	<div class="flex flex-col gap-1.5">
+		<button
+			class="flex cursor-pointer items-center gap-1.5 px-2.5 py-1 text-[11px] font-medium text-foreground-subtle"
+			onclick={() => (expanded = false)}
+			type="button"
+		>
+			<ChevronRightIcon size={12} strokeWidth={2} class="rotate-90 transition-transform" />
+			<span>{messages.length} tool calls</span>
+			<div class="h-px flex-1 bg-border"></div>
+		</button>
+		{#each messages as message (message.id)}
+			{#if renderCard}
+				{@render renderCard(message)}
+			{:else}
+				<ToolCardCompact {message} />
+			{/if}
+		{/each}
+	</div>
+{:else}
+	<button
+		class="flex cursor-pointer items-center gap-1.5 px-2.5 py-1 text-[11px] font-medium text-foreground-subtle"
+		onclick={() => (expanded = true)}
+		type="button"
+	>
+		<ChevronRightIcon size={12} strokeWidth={2} />
+		<span>{messages.length} tool calls</span>
+		<div class="h-px flex-1 bg-border"></div>
+	</button>
+{/if}

--- a/src/lib/components/chat/ToolCardPermission.svelte
+++ b/src/lib/components/chat/ToolCardPermission.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+	import type { ChatMessage } from '$lib/modules/chat/index.js';
+	import AlertTriangleIcon from '@lucide/svelte/icons/alert-triangle';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Kbd } from '$lib/components/ui/kbd/index.js';
+	import { extractToolDetail, getToolAccentColor, getToolIcon } from './tool_card_utils.js';
+
+	interface Props {
+		message: ChatMessage;
+		onAllow?: () => void;
+		onAllowAlways?: () => void;
+		onDeny?: () => void;
+	}
+
+	let { message, onAllow, onAllowAlways, onDeny }: Props = $props();
+
+	const toolName = $derived(message.toolName ?? 'Tool');
+	const detail = $derived(extractToolDetail(message));
+	const accentColor = $derived(getToolAccentColor(toolName));
+</script>
+
+<div
+	class="overflow-hidden rounded-lg border bg-surface"
+	style="border-color: color-mix(in oklch, var(--status-warning) 40%, var(--border))"
+>
+	<!-- Header -->
+	<div
+		class="flex h-9 items-center gap-2 border-b px-3"
+		style="background: color-mix(in oklch, var(--status-warning) 8%, var(--surface-2)); border-color: color-mix(in oklch, var(--status-warning) 30%, var(--border))"
+	>
+		<AlertTriangleIcon size={13} strokeWidth={2} class="text-status-warning" />
+		<span class="text-xs font-semibold">
+			Agent wants to use <strong style="color: {accentColor}">{toolName}</strong>
+		</span>
+	</div>
+
+	<!-- Content -->
+	<div class="flex">
+		<div class="w-[3px] shrink-0 bg-status-warning"></div>
+		<div class="flex-1 px-3 py-2.5">
+			{#if detail}
+				<pre
+					class="m-0 mb-3 whitespace-pre-wrap font-mono text-[11.5px] leading-[1.5] text-foreground-muted">{detail}</pre>
+			{/if}
+			<div class="flex gap-1.5">
+				<Button
+					size="sm"
+					class="bg-status-success text-white hover:bg-status-success/90"
+					onclick={onAllow}
+				>
+					Allow <Kbd class="ml-1">↵</Kbd>
+				</Button>
+				<Button variant="secondary" size="sm" onclick={onAllowAlways}>
+					Allow Always <Kbd class="ml-1">⌃↵</Kbd>
+				</Button>
+				<Button variant="danger" size="sm" onclick={onDeny}>
+					Deny <Kbd class="ml-1">Esc</Kbd>
+				</Button>
+			</div>
+		</div>
+	</div>
+</div>

--- a/src/lib/components/chat/ToolCardPermission.svelte
+++ b/src/lib/components/chat/ToolCardPermission.svelte
@@ -3,7 +3,7 @@
 	import AlertTriangleIcon from '@lucide/svelte/icons/alert-triangle';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Kbd } from '$lib/components/ui/kbd/index.js';
-	import { extractToolDetail, getToolAccentColor, getToolIcon } from './tool_card_utils.js';
+	import { extractToolDetail, getToolAccentColor } from './tool_card_utils.js';
 
 	interface Props {
 		message: ChatMessage;

--- a/src/lib/components/chat/ToolCards.stories.svelte
+++ b/src/lib/components/chat/ToolCards.stories.svelte
@@ -5,10 +5,8 @@
 
 	const { Story } = defineMeta({
 		title: 'Chat/ToolCards',
-		component: ToolCardExpanded,
 		// @ts-expect-error — Storybook decorator typing doesn't match Svelte 5 Component type
 		decorators: [() => ThemeDecorator],
-		tags: ['autodocs'],
 	});
 </script>
 

--- a/src/lib/components/chat/ToolCards.stories.svelte
+++ b/src/lib/components/chat/ToolCards.stories.svelte
@@ -1,0 +1,123 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import ToolCardExpanded from './ToolCardExpanded.svelte';
+	import ThemeDecorator from '$lib/storybook/ThemeDecorator.svelte';
+
+	const { Story } = defineMeta({
+		title: 'Chat/ToolCards',
+		component: ToolCardExpanded,
+		// @ts-expect-error — Storybook decorator typing doesn't match Svelte 5 Component type
+		decorators: [() => ThemeDecorator],
+		tags: ['autodocs'],
+	});
+</script>
+
+<script lang="ts">
+	import ToolCardCompact from './ToolCardCompact.svelte';
+	import ToolCardGroup from './ToolCardGroup.svelte';
+	import type { ChatMessage } from '$lib/modules/chat/index.js';
+
+	function makeTool(overrides: Partial<ChatMessage>): ChatMessage {
+		return {
+			id: crypto.randomUUID(),
+			role: 'tool',
+			content: '',
+			timestamp: Date.now(),
+			toolName: 'Bash',
+			toolUseId: crypto.randomUUID(),
+			toolStatus: 'success',
+			...overrides,
+		};
+	}
+
+	const bashRunning = makeTool({
+		toolName: 'Bash',
+		toolStatus: 'running',
+		toolInput: { command: 'cargo test --workspace' },
+		toolOutput:
+			'   Compiling grovekeeper v0.8.0\n   Compiling grovekeeper-providers v0.8.0\n     Running unittests src/lib.rs\nrunning 24 tests...\ntest providers::claude_code::tests::test_spawn ... ok',
+	});
+
+	const bashError = makeTool({
+		toolName: 'Bash',
+		toolStatus: 'error',
+		isError: true,
+		toolInput: { command: 'cargo build --release' },
+		toolOutput:
+			'error[E0308]: mismatched types\n  --> src/providers/opencode.rs:42:12\n   |\n42 |     return Ok(session);\n   |            ^^^^^^^^^^^ expected `Result<Session, Error>`,\n   |                        found `Result<Session, AuthError>`',
+	});
+
+	const readFile = makeTool({
+		toolName: 'Read',
+		toolStatus: 'success',
+		toolInput: { file_path: 'src/providers/mod.rs' },
+		toolOutput:
+			'mod claude_code;\nmod opencode;\nmod cursor;\nmod codex;\n\npub use claude_code::ClaudeCode;\npub use opencode::OpenCode;\n\npub trait Provider: Send + Sync {\n    fn spawn(&self, config: &Config) -> Result<Session>;\n}',
+	});
+
+	const grepResult = makeTool({
+		toolName: 'Grep',
+		toolStatus: 'success',
+		toolInput: { pattern: 'impl Provider' },
+		toolOutput:
+			'src/providers/claude_code.rs:24:  impl Provider for ClaudeCode {\nsrc/providers/opencode.rs:18:    impl Provider for OpenCode {\nsrc/providers/cursor.rs:31:      impl Provider for Cursor {',
+	});
+
+	const groupMessages = Array.from({ length: 7 }, (_, i) =>
+		makeTool({
+			id: `group-${i}`,
+			toolName: ['Read', 'Grep', 'Edit', 'Bash', 'Read', 'Write', 'Glob'][i],
+			toolInput: { file_path: `src/file_${i}.rs` },
+		}),
+	);
+</script>
+
+<Story name="L2 — Bash Running">
+	{#snippet template()}
+		<div class="mx-auto max-w-[900px] p-4">
+			<ToolCardExpanded message={bashRunning} />
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="L2 — Bash Error">
+	{#snippet template()}
+		<div class="mx-auto max-w-[900px] p-4">
+			<ToolCardExpanded message={bashError} />
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="L2 — Read File">
+	{#snippet template()}
+		<div class="mx-auto max-w-[900px] p-4">
+			<ToolCardExpanded message={readFile} />
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="L2 — Grep Matches">
+	{#snippet template()}
+		<div class="mx-auto max-w-[900px] p-4">
+			<ToolCardExpanded message={grepResult} />
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="L1 Compact (click to expand)">
+	{#snippet template()}
+		<div class="mx-auto max-w-[900px] space-y-1.5 p-4">
+			<ToolCardCompact message={readFile} />
+			<ToolCardCompact message={bashRunning} />
+			<ToolCardCompact message={bashError} />
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Tool Group (collapsed)">
+	{#snippet template()}
+		<div class="mx-auto max-w-[900px] p-4">
+			<ToolCardGroup messages={groupMessages} />
+		</div>
+	{/snippet}
+</Story>

--- a/src/lib/components/chat/index.ts
+++ b/src/lib/components/chat/index.ts
@@ -11,6 +11,12 @@ export { default as ToolCardExpanded } from './ToolCardExpanded.svelte';
 // fallow-ignore-next-line unused-export
 export { default as ToolCardGroup } from './ToolCardGroup.svelte';
 // fallow-ignore-next-line unused-export
+export { default as ToolCardPermission } from './ToolCardPermission.svelte';
+// fallow-ignore-next-line unused-export
+export { default as ToolCardElicitation } from './ToolCardElicitation.svelte';
+// fallow-ignore-next-line unused-export
+export { default as ToolCardAskUser } from './ToolCardAskUser.svelte';
+// fallow-ignore-next-line unused-export
 export { default as CodeBlock } from './CodeBlock.svelte';
 // fallow-ignore-next-line unused-export
 export { default as StreamingCaret } from './StreamingCaret.svelte';

--- a/src/lib/components/chat/index.ts
+++ b/src/lib/components/chat/index.ts
@@ -7,6 +7,10 @@ export { default as SystemMessage } from './SystemMessage.svelte';
 // fallow-ignore-next-line unused-export
 export { default as ToolCardCompact } from './ToolCardCompact.svelte';
 // fallow-ignore-next-line unused-export
+export { default as ToolCardExpanded } from './ToolCardExpanded.svelte';
+// fallow-ignore-next-line unused-export
+export { default as ToolCardGroup } from './ToolCardGroup.svelte';
+// fallow-ignore-next-line unused-export
 export { default as CodeBlock } from './CodeBlock.svelte';
 // fallow-ignore-next-line unused-export
 export { default as StreamingCaret } from './StreamingCaret.svelte';

--- a/src/lib/components/chat/tool_card_utils.ts
+++ b/src/lib/components/chat/tool_card_utils.ts
@@ -61,7 +61,7 @@ export function getToolAccentColor(toolName: string): string {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const TOOL_ICON_MAP: Record<string, Component<any>> = {
+const TOOL_ICON_MAP: Record<string, Component<any>> = {
 	Bash: TerminalIcon,
 	Read: EyeIcon,
 	Write: PencilIcon,

--- a/src/lib/components/chat/tool_card_utils.ts
+++ b/src/lib/components/chat/tool_card_utils.ts
@@ -1,0 +1,80 @@
+import type { ChatMessage } from '$lib/modules/chat/index.js';
+import type { Component } from 'svelte';
+import TerminalIcon from '@lucide/svelte/icons/terminal';
+import EyeIcon from '@lucide/svelte/icons/eye';
+import PencilIcon from '@lucide/svelte/icons/pencil';
+import CodeIcon from '@lucide/svelte/icons/code';
+import FolderSearchIcon from '@lucide/svelte/icons/folder-search';
+import SearchIcon from '@lucide/svelte/icons/search';
+import CpuIcon from '@lucide/svelte/icons/cpu';
+import GlobeIcon from '@lucide/svelte/icons/globe';
+import ArrowDownIcon from '@lucide/svelte/icons/arrow-down';
+import ListIcon from '@lucide/svelte/icons/list';
+import SettingsIcon from '@lucide/svelte/icons/settings';
+
+// fallow-ignore-next-line complexity
+export function extractToolDetail(message: ChatMessage): string {
+	if (message.toolInput === undefined || message.toolInput === null) {
+		return '';
+	}
+	if (typeof message.toolInput === 'object' && !Array.isArray(message.toolInput)) {
+		const input = message.toolInput as Record<string, unknown>;
+		if (typeof input.file_path === 'string') {
+			return input.file_path;
+		}
+		if (typeof input.command === 'string') {
+			return `$ ${input.command}`;
+		}
+		if (typeof input.pattern === 'string') {
+			return input.pattern;
+		}
+	}
+	return '';
+}
+
+export function extractToolOutput(message: ChatMessage): string {
+	if (message.toolOutput === undefined || message.toolOutput === null) {
+		return '';
+	}
+	if (typeof message.toolOutput === 'string') {
+		return message.toolOutput;
+	}
+	return JSON.stringify(message.toolOutput, null, 2);
+}
+
+const TOOL_ACCENT_COLORS: Record<string, string> = {
+	Bash: 'oklch(0.700 0.150 145)',
+	Read: 'oklch(0.660 0.105 220)',
+	Write: 'oklch(0.770 0.155 75)',
+	Edit: 'oklch(0.700 0.180 50)',
+	Glob: 'oklch(0.720 0.130 250)',
+	Grep: 'oklch(0.660 0.180 320)',
+	Agent: 'oklch(0.620 0.150 280)',
+	WebSearch: 'oklch(0.720 0.130 165)',
+	WebFetch: 'oklch(0.620 0.150 30)',
+	TodoWrite: 'oklch(0.730 0.165 120)',
+	Task: 'oklch(0.720 0.060 280)',
+};
+
+export function getToolAccentColor(toolName: string): string {
+	return TOOL_ACCENT_COLORS[toolName] ?? 'var(--foreground-muted)';
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const TOOL_ICON_MAP: Record<string, Component<any>> = {
+	Bash: TerminalIcon,
+	Read: EyeIcon,
+	Write: PencilIcon,
+	Edit: CodeIcon,
+	Glob: FolderSearchIcon,
+	Grep: SearchIcon,
+	Agent: CpuIcon,
+	WebSearch: GlobeIcon,
+	WebFetch: ArrowDownIcon,
+	TodoWrite: ListIcon,
+	Task: SettingsIcon,
+};
+
+export function getToolIcon(toolName: string): Component {
+	return TOOL_ICON_MAP[toolName] ?? TerminalIcon;
+}

--- a/src/lib/components/session/AgentTreeNode.svelte
+++ b/src/lib/components/session/AgentTreeNode.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+	import type { SubAgent } from './sub_agent_types.js';
+	import ChevronRightIcon from '@lucide/svelte/icons/chevron-right';
+	import CheckIcon from '@lucide/svelte/icons/check';
+	import XIcon from '@lucide/svelte/icons/x';
+
+	interface Props {
+		agent: SubAgent;
+		depth?: number;
+		activeAgentId?: string | null;
+		onSelect?: (agentId: string) => void;
+	}
+
+	let { agent, depth = 0, activeAgentId = null, onSelect }: Props = $props();
+
+	let expanded = $state(agent.children.length > 0);
+
+	const isActive = $derived(activeAgentId === agent.id);
+	const hasChildren = $derived(agent.children.length > 0);
+</script>
+
+<div>
+	<!-- Node row -->
+	<button
+		class="flex w-full cursor-pointer items-center gap-[5px] rounded-[5px] px-1.5 py-[5px] text-xs"
+		class:bg-primary-soft={isActive}
+		class:bg-surface-2={expanded && !isActive}
+		style="margin-left: {depth * 14}px; border-left: 2px solid {isActive
+			? 'var(--primary)'
+			: 'transparent'}"
+		onclick={() => onSelect?.(agent.id)}
+		type="button"
+	>
+		{#if hasChildren}
+			<ChevronRightIcon
+				size={10}
+				strokeWidth={2}
+				class="shrink-0 text-foreground-subtle transition-transform duration-[120ms]"
+				style="transform: {expanded ? 'none' : 'rotate(-90deg)'}"
+			/>
+		{:else}
+			<span class="w-2.5 shrink-0"></span>
+		{/if}
+
+		<!-- Status indicator -->
+		{#if agent.status === 'running'}
+			<span
+				class="inline-block size-[7px] shrink-0 rounded-full bg-status-success animate-[badge-pulse_1.8s_ease-in-out_infinite]"
+			></span>
+		{:else if agent.status === 'completed'}
+			<CheckIcon size={11} strokeWidth={2.2} class="shrink-0 text-status-success" />
+		{:else}
+			<XIcon size={11} strokeWidth={2.2} class="shrink-0 text-status-danger" />
+		{/if}
+
+		<span
+			class="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-left text-[11.5px] font-medium text-foreground"
+		>
+			{agent.name}
+		</span>
+	</button>
+
+	<!-- Meta row -->
+	<div
+		class="flex items-center gap-2 px-1.5 pb-0.5 font-mono text-[10px] text-foreground-subtle"
+		style="margin-left: {depth * 14 + 28}px"
+	>
+		<span>{agent.model}</span>
+		<span>{agent.toolCount} tools</span>
+		<span>{agent.duration}</span>
+	</div>
+
+	<!-- Children -->
+	{#if expanded && hasChildren}
+		{#each agent.children as child (child.id)}
+			<svelte:self agent={child} depth={depth + 1} {activeAgentId} {onSelect} />
+		{/each}
+	{/if}
+</div>

--- a/src/lib/components/session/AgentTreeNode.svelte
+++ b/src/lib/components/session/AgentTreeNode.svelte
@@ -3,6 +3,7 @@
 	import ChevronRightIcon from '@lucide/svelte/icons/chevron-right';
 	import CheckIcon from '@lucide/svelte/icons/check';
 	import XIcon from '@lucide/svelte/icons/x';
+	import AgentTreeNode from './AgentTreeNode.svelte';
 
 	interface Props {
 		agent: SubAgent;
@@ -13,7 +14,7 @@
 
 	let { agent, depth = 0, activeAgentId = null, onSelect }: Props = $props();
 
-	let expanded = $state(agent.children.length > 0);
+	let expanded = $state(true);
 
 	const isActive = $derived(activeAgentId === agent.id);
 	const hasChildren = $derived(agent.children.length > 0);
@@ -32,12 +33,28 @@
 		type="button"
 	>
 		{#if hasChildren}
-			<ChevronRightIcon
-				size={10}
-				strokeWidth={2}
-				class="shrink-0 text-foreground-subtle transition-transform duration-[120ms]"
-				style="transform: {expanded ? 'none' : 'rotate(-90deg)'}"
-			/>
+			<span
+				class="flex shrink-0 cursor-pointer items-center"
+				role="button"
+				tabindex="-1"
+				onclick={(e) => {
+					e.stopPropagation();
+					expanded = !expanded;
+				}}
+				onkeydown={(e) => {
+					if (e.key === 'Enter') {
+						e.stopPropagation();
+						expanded = !expanded;
+					}
+				}}
+			>
+				<ChevronRightIcon
+					size={10}
+					strokeWidth={2}
+					class="text-foreground-subtle transition-transform duration-[120ms]"
+					style="transform: {expanded ? 'rotate(90deg)' : 'none'}"
+				/>
+			</span>
 		{:else}
 			<span class="w-2.5 shrink-0"></span>
 		{/if}
@@ -73,7 +90,7 @@
 	<!-- Children -->
 	{#if expanded && hasChildren}
 		{#each agent.children as child (child.id)}
-			<svelte:self agent={child} depth={depth + 1} {activeAgentId} {onSelect} />
+			<AgentTreeNode agent={child} depth={depth + 1} {activeAgentId} {onSelect} />
 		{/each}
 	{/if}
 </div>

--- a/src/lib/components/session/FloatingInputPanel.stories.svelte
+++ b/src/lib/components/session/FloatingInputPanel.stories.svelte
@@ -1,0 +1,87 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import FloatingInputPanel from './FloatingInputPanel.svelte';
+	import ThemeDecorator from '$lib/storybook/ThemeDecorator.svelte';
+
+	const { Story } = defineMeta({
+		title: 'Session/FloatingInputPanel',
+		component: FloatingInputPanel,
+		// @ts-expect-error — Storybook decorator typing doesn't match Svelte 5 Component type
+		decorators: [() => ThemeDecorator],
+		tags: ['autodocs'],
+	});
+</script>
+
+<script lang="ts">
+	import SendStopButton from './SendStopButton.svelte';
+	import SkillChipsRow from './SkillChipsRow.svelte';
+	import type { Session } from '$lib/types/generated/Session.js';
+
+	function makeMockSession(overrides: Partial<Session> = {}): Session {
+		return {
+			id: 'mock-session-1',
+			issue_id: null,
+			provider: 'claude-code',
+			state: 'needs-input',
+			pid: 12345,
+			cli_session_id: 'ses_01HXK4mZ',
+			started_at: new Date().toISOString(),
+			ended_at: null,
+			cost_usd: 4.387,
+			token_count: 48200,
+			original_intent: 'Implement the OpenCode provider trait',
+			last_prompt: null,
+			last_response_summary: null,
+			execution_phase: 'none',
+			source: 'spawned',
+			working_directory: '/projects/grovekeeper',
+			...overrides,
+		};
+	}
+
+	const idleSession = makeMockSession({ state: 'needs-input' });
+	const runningSession = makeMockSession({ state: 'running' });
+</script>
+
+<Story name="Idle — Ready for Input">
+	{#snippet template()}
+		<div class="relative h-[300px] w-full bg-background">
+			<FloatingInputPanel session={idleSession} />
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Running — Stop Available">
+	{#snippet template()}
+		<div class="relative h-[300px] w-full bg-background">
+			<FloatingInputPanel session={runningSession} />
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Send / Stop Button States">
+	{#snippet template()}
+		<div class="flex items-center gap-4 p-4">
+			<div class="flex flex-col items-center gap-1">
+				<SendStopButton isRunning={false} disabled={false} />
+				<span class="text-[10px] text-foreground-subtle">Send</span>
+			</div>
+			<div class="flex flex-col items-center gap-1">
+				<SendStopButton isRunning={false} disabled={true} />
+				<span class="text-[10px] text-foreground-subtle">Disabled</span>
+			</div>
+			<div class="flex flex-col items-center gap-1">
+				<SendStopButton isRunning={true} />
+				<span class="text-[10px] text-foreground-subtle">Stop</span>
+			</div>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Skill Chips Row">
+	{#snippet template()}
+		<div class="w-full max-w-[900px] rounded-lg border border-border bg-surface p-0">
+			<SkillChipsRow />
+		</div>
+	{/snippet}
+</Story>

--- a/src/lib/components/session/FloatingInputPanel.stories.svelte
+++ b/src/lib/components/session/FloatingInputPanel.stories.svelte
@@ -5,10 +5,8 @@
 
 	const { Story } = defineMeta({
 		title: 'Session/FloatingInputPanel',
-		component: FloatingInputPanel,
 		// @ts-expect-error — Storybook decorator typing doesn't match Svelte 5 Component type
 		decorators: [() => ThemeDecorator],
-		tags: ['autodocs'],
 	});
 </script>
 

--- a/src/lib/components/session/FloatingInputPanel.svelte
+++ b/src/lib/components/session/FloatingInputPanel.svelte
@@ -58,7 +58,7 @@
 		<!-- Image carousel (expanded) -->
 		{#if showImages && imageCount > 0}
 			<div class="flex items-center gap-1.5 overflow-x-auto border-b border-border px-3 py-2">
-				{#each Array(imageCount) as _, i}
+				{#each Array.from({ length: imageCount }, (_, idx) => idx) as i (i)}
 					<div
 						class="relative flex size-11 w-16 shrink-0 items-center justify-center overflow-hidden rounded-md border border-border bg-surface-3"
 					>

--- a/src/lib/components/session/FloatingInputPanel.svelte
+++ b/src/lib/components/session/FloatingInputPanel.svelte
@@ -1,0 +1,122 @@
+<script lang="ts">
+	import type { Session } from '$lib/types/generated/Session.js';
+	import PlusIcon from '@lucide/svelte/icons/plus';
+	import ChevronDownIcon from '@lucide/svelte/icons/chevron-down';
+	import PaperclipIcon from '@lucide/svelte/icons/paperclip';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Textarea } from '$lib/components/ui/textarea/index.js';
+	import SkillChipsRow from './SkillChipsRow.svelte';
+	import SendStopButton from './SendStopButton.svelte';
+	import { getProviderConfig } from './session_theme_utils.js';
+
+	interface Props {
+		session: Session;
+		value?: string;
+		disabled?: boolean;
+		onSend?: () => void;
+		onStop?: () => void;
+		onKeydown?: (event: KeyboardEvent) => void;
+	}
+
+	let {
+		session,
+		value = $bindable(''),
+		disabled = false,
+		onSend,
+		onStop,
+		onKeydown,
+	}: Props = $props();
+
+	const isRunning = $derived(session.state === 'running');
+	const canSend = $derived(value.trim().length > 0 && !disabled && !isRunning);
+	const providerConfig = $derived(getProviderConfig(session.provider));
+
+	let imageCount = $state(0);
+	let showImages = $state(false);
+
+	function handleChipClick(command: string) {
+		value = command + ' ';
+	}
+</script>
+
+<div
+	class="pointer-events-none absolute bottom-4 left-1/2 z-[15] w-full max-w-[900px] -translate-x-1/2"
+>
+	<div class="pointer-events-auto rounded-[14px] border border-border bg-surface shadow-lg">
+		<!-- Image carousel (collapsed strip) -->
+		{#if !showImages && imageCount > 0}
+			<button
+				class="flex w-full cursor-pointer items-center gap-1 border-b border-border px-3 py-1"
+				onclick={() => (showImages = true)}
+			>
+				<PaperclipIcon size={11} strokeWidth={1.8} class="text-foreground-subtle" />
+				<span class="text-[11px] text-foreground-subtle">{imageCount} images</span>
+				<ChevronDownIcon size={10} strokeWidth={2} class="text-foreground-subtle" />
+			</button>
+		{/if}
+
+		<!-- Image carousel (expanded) -->
+		{#if showImages && imageCount > 0}
+			<div class="flex items-center gap-1.5 overflow-x-auto border-b border-border px-3 py-2">
+				{#each Array(imageCount) as _, i}
+					<div
+						class="relative flex size-11 w-16 shrink-0 items-center justify-center overflow-hidden rounded-md border border-border bg-surface-3"
+					>
+						<span class="font-mono text-[10px] font-semibold text-foreground-muted">
+							#{i + 1}
+						</span>
+						<button
+							class="absolute top-0.5 right-0.5 flex size-3.5 cursor-pointer items-center justify-center rounded-[3px] border-none bg-black/40 p-0 text-[8px] text-white"
+							onclick={() => imageCount--}
+						>
+							×
+						</button>
+					</div>
+				{/each}
+				<Button variant="ghost" size="sm" class="shrink-0 px-2 text-[10px]">
+					<PlusIcon size={10} strokeWidth={2} />
+					Add
+				</Button>
+			</div>
+		{/if}
+
+		<!-- Skill chips -->
+		<SkillChipsRow onChipClick={handleChipClick} />
+
+		<!-- Textarea -->
+		<div class="px-3 py-1">
+			<Textarea
+				bind:value
+				placeholder="Message or /command…"
+				class="min-h-12 max-h-[50vh] resize-none border-none bg-transparent p-0 text-[13px] leading-[1.55] shadow-none focus-visible:ring-0"
+				rows={3}
+				{disabled}
+				onkeydown={onKeydown}
+			/>
+		</div>
+
+		<!-- Bottom controls -->
+		<div class="flex items-center gap-1.5 border-t border-border px-3 py-1.5">
+			<!-- Left group -->
+			<Button variant="ghost" size="sm" class="text-[11px]">
+				<PlusIcon size={11} strokeWidth={2} />
+				Attach
+			</Button>
+			<Button variant="ghost" size="sm" class="text-[11px]">Tools ▾</Button>
+
+			<div class="flex-1"></div>
+
+			<!-- Right group -->
+			<Button variant="ghost" size="sm" class="font-mono text-[10.5px]">Local ▾</Button>
+			<Button
+				variant="secondary"
+				size="sm"
+				class="max-w-[260px] truncate font-mono text-[10.5px]"
+			>
+				{providerConfig.name} · Opus 4.7 (1M) · High ▾
+			</Button>
+			<Button variant="secondary" size="sm" class="text-[10.5px]">Approve each ▾</Button>
+			<SendStopButton {isRunning} disabled={!canSend} {onSend} {onStop} />
+		</div>
+	</div>
+</div>

--- a/src/lib/components/session/ProgressBar.svelte
+++ b/src/lib/components/session/ProgressBar.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	interface Props {
+		percent: number;
+		height?: number;
+		color?: string;
+		class?: string;
+	}
+
+	let {
+		percent,
+		height = 4,
+		color = 'var(--status-success)',
+		class: className = '',
+	}: Props = $props();
+
+	const clampedPercent = $derived(Math.max(0, Math.min(100, percent)));
+</script>
+
+<div class="overflow-hidden rounded-[3px] bg-surface-3 {className}" style="height: {height}px">
+	<div
+		class="h-full rounded-[3px] transition-[width] duration-300"
+		style="width: {clampedPercent}%; background: {color}"
+	></div>
+</div>

--- a/src/lib/components/session/ProviderChip.svelte
+++ b/src/lib/components/session/ProviderChip.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	import ZapIcon from '@lucide/svelte/icons/zap';
+	import { getProviderConfig } from './session_theme_utils.js';
+
+	interface Props {
+		provider: string;
+	}
+
+	let { provider }: Props = $props();
+
+	const config = $derived(getProviderConfig(provider));
+</script>
+
+<div
+	class="inline-flex cursor-pointer items-center gap-[5px] rounded-[6px] border border-border bg-surface-2 px-2 py-[3px] pl-[5px] transition-[border-color] duration-[120ms] hover:border-border-strong"
+>
+	<div
+		class="flex size-3.5 items-center justify-center rounded-[3px]"
+		style="background: {config.color}"
+	>
+		<ZapIcon size={9} strokeWidth={2.4} class="text-background" />
+	</div>
+	<span class="text-[11px] font-medium text-foreground">{config.name}</span>
+</div>

--- a/src/lib/components/session/SendStopButton.svelte
+++ b/src/lib/components/session/SendStopButton.svelte
@@ -2,7 +2,6 @@
 	import SendIcon from '@lucide/svelte/icons/send';
 	import SquareIcon from '@lucide/svelte/icons/square';
 	import { Button } from '$lib/components/ui/button/index.js';
-	import { Kbd } from '$lib/components/ui/kbd/index.js';
 
 	interface Props {
 		isRunning: boolean;

--- a/src/lib/components/session/SendStopButton.svelte
+++ b/src/lib/components/session/SendStopButton.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+	import SendIcon from '@lucide/svelte/icons/send';
+	import SquareIcon from '@lucide/svelte/icons/square';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Kbd } from '$lib/components/ui/kbd/index.js';
+
+	interface Props {
+		isRunning: boolean;
+		disabled?: boolean;
+		onSend?: () => void;
+		onStop?: () => void;
+	}
+
+	let { isRunning, disabled = false, onSend, onStop }: Props = $props();
+</script>
+
+{#if isRunning}
+	<Button variant="danger" size="icon-sm" onclick={onStop} class="rounded-[7px]">
+		<SquareIcon size={11} strokeWidth={2.4} />
+	</Button>
+{:else}
+	<Button variant="primary" size="icon-sm" onclick={onSend} {disabled} class="rounded-[7px]">
+		<SendIcon size={13} strokeWidth={2} />
+	</Button>
+{/if}

--- a/src/lib/components/session/SessionComponents.stories.svelte
+++ b/src/lib/components/session/SessionComponents.stories.svelte
@@ -5,10 +5,8 @@
 
 	const { Story } = defineMeta({
 		title: 'Session/Components',
-		component: SessionStateBadge,
 		// @ts-expect-error — Storybook decorator typing doesn't match Svelte 5 Component type
 		decorators: [() => ThemeDecorator],
-		tags: ['autodocs'],
 	});
 </script>
 
@@ -32,7 +30,7 @@
 <Story name="Session State Badges">
 	{#snippet template()}
 		<div class="flex flex-wrap items-center gap-3 p-4">
-			{#each allStates as state}
+			{#each allStates as state (state)}
 				<SessionStateBadge {state} />
 			{/each}
 		</div>
@@ -65,7 +63,7 @@
 <Story name="Provider Chips">
 	{#snippet template()}
 		<div class="flex flex-wrap items-center gap-3 p-4">
-			{#each providers as provider}
+			{#each providers as provider (provider)}
 				<ProviderChip {provider} />
 			{/each}
 			<ProviderChip provider="unknown-provider" />

--- a/src/lib/components/session/SessionComponents.stories.svelte
+++ b/src/lib/components/session/SessionComponents.stories.svelte
@@ -1,0 +1,74 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import SessionStateBadge from './SessionStateBadge.svelte';
+	import ThemeDecorator from '$lib/storybook/ThemeDecorator.svelte';
+
+	const { Story } = defineMeta({
+		title: 'Session/Components',
+		component: SessionStateBadge,
+		// @ts-expect-error — Storybook decorator typing doesn't match Svelte 5 Component type
+		decorators: [() => ThemeDecorator],
+		tags: ['autodocs'],
+	});
+</script>
+
+<script lang="ts">
+	import ProgressBar from './ProgressBar.svelte';
+	import ProviderChip from './ProviderChip.svelte';
+	import type { SessionState } from '$lib/types/generated/SessionState.js';
+
+	const allStates: SessionState[] = [
+		'running',
+		'needs-input',
+		'needs-review',
+		'paused',
+		'finished',
+		'errored',
+	];
+
+	const providers = ['claude-code', 'open-code', 'codex', 'cursor'];
+</script>
+
+<Story name="Session State Badges">
+	{#snippet template()}
+		<div class="flex flex-wrap items-center gap-3 p-4">
+			{#each allStates as state}
+				<SessionStateBadge {state} />
+			{/each}
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Progress Bars">
+	{#snippet template()}
+		<div class="flex w-64 flex-col gap-4 p-4">
+			<div>
+				<div class="mb-1 text-xs text-foreground-subtle">10% — Green</div>
+				<ProgressBar percent={10} color="var(--status-success)" />
+			</div>
+			<div>
+				<div class="mb-1 text-xs text-foreground-subtle">50% — Orange (context)</div>
+				<ProgressBar percent={50} color="var(--status-warning)" />
+			</div>
+			<div>
+				<div class="mb-1 text-xs text-foreground-subtle">80% — Red (context)</div>
+				<ProgressBar percent={80} color="var(--status-danger)" />
+			</div>
+			<div>
+				<div class="mb-1 text-xs text-foreground-subtle">Custom height (8px)</div>
+				<ProgressBar percent={65} height={8} color="var(--primary)" />
+			</div>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Provider Chips">
+	{#snippet template()}
+		<div class="flex flex-wrap items-center gap-3 p-4">
+			{#each providers as provider}
+				<ProviderChip {provider} />
+			{/each}
+			<ProviderChip provider="unknown-provider" />
+		</div>
+	{/snippet}
+</Story>

--- a/src/lib/components/session/SessionLayout.stories.svelte
+++ b/src/lib/components/session/SessionLayout.stories.svelte
@@ -1,0 +1,156 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import SessionTopBar from './SessionTopBar.svelte';
+	import ThemeDecorator from '$lib/storybook/ThemeDecorator.svelte';
+
+	const { Story } = defineMeta({
+		title: 'Session/Layout',
+		component: SessionTopBar,
+		// @ts-expect-error — Storybook decorator typing doesn't match Svelte 5 Component type
+		decorators: [() => ThemeDecorator],
+		tags: ['autodocs'],
+	});
+</script>
+
+<script lang="ts">
+	import SessionSidebar from './SessionSidebar.svelte';
+	import type { Session } from '$lib/types/generated/Session.js';
+
+	function makeMockSession(overrides: Partial<Session> = {}): Session {
+		return {
+			id: 'mock-session-1',
+			issue_id: null,
+			provider: 'claude-code',
+			state: 'running',
+			pid: 12345,
+			cli_session_id: 'ses_01HXK4mZ',
+			started_at: new Date().toISOString(),
+			ended_at: null,
+			cost_usd: 4.387,
+			token_count: 48200,
+			original_intent: 'Implement the OpenCode provider trait',
+			last_prompt: null,
+			last_response_summary: null,
+			execution_phase: 'none',
+			source: 'spawned',
+			working_directory: '/projects/grovekeeper',
+			...overrides,
+		};
+	}
+
+	const runningSession = makeMockSession();
+	const needsInputSession = makeMockSession({ state: 'needs-input' });
+	const erroredSession = makeMockSession({ state: 'errored', cost_usd: 12.45 });
+</script>
+
+<Story name="Top Bar — Running">
+	{#snippet template()}
+		<div class="w-full">
+			<SessionTopBar
+				session={runningSession}
+				branchName="feat/session-ui"
+				issueNumber={90}
+				prNumber={5}
+			/>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Top Bar — Needs Input">
+	{#snippet template()}
+		<div class="w-full">
+			<SessionTopBar
+				session={needsInputSession}
+				branchName="fix/auth-flow"
+				issueNumber={42}
+			/>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Top Bar — Errored">
+	{#snippet template()}
+		<div class="w-full">
+			<SessionTopBar session={erroredSession} branchName="feat/broken" />
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Sidebar — Expanded">
+	{#snippet template()}
+		<div class="flex h-[600px]">
+			<div class="flex-1 bg-background p-4">
+				<span class="text-sm text-foreground-muted">Chat content area</span>
+			</div>
+			<SessionSidebar
+				session={runningSession}
+				contextPercent={54}
+				quota5hPercent={42}
+				quota7dPercent={18}
+				subAgentCount={5}
+			/>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Sidebar — Quota Warning">
+	{#snippet template()}
+		<div class="flex h-[600px]">
+			<div class="flex-1 bg-background p-4">
+				<span class="text-sm text-foreground-muted">Chat content area</span>
+			</div>
+			<SessionSidebar
+				session={runningSession}
+				contextPercent={72}
+				quota5hPercent={88}
+				quota7dPercent={65}
+				subAgentCount={3}
+			/>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Sidebar — Errored Session">
+	{#snippet template()}
+		<div class="flex h-[600px]">
+			<div class="flex-1 bg-background p-4">
+				<span class="text-sm text-foreground-muted">Chat content area</span>
+			</div>
+			<SessionSidebar
+				session={erroredSession}
+				contextPercent={95}
+				quota5hPercent={50}
+				quota7dPercent={10}
+			/>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Full Layout">
+	{#snippet template()}
+		<div class="flex h-[700px] w-full flex-col">
+			<SessionTopBar
+				session={runningSession}
+				branchName="feat/session-ui"
+				issueNumber={90}
+				prNumber={5}
+			/>
+			<div class="flex flex-1 overflow-hidden">
+				<div class="relative flex-1 overflow-auto bg-background p-6">
+					<div class="mx-auto max-w-[900px]">
+						<p class="text-sm text-foreground-muted">
+							Chat message stream content would appear here...
+						</p>
+					</div>
+				</div>
+				<SessionSidebar
+					session={runningSession}
+					contextPercent={54}
+					quota5hPercent={42}
+					quota7dPercent={18}
+					subAgentCount={5}
+				/>
+			</div>
+		</div>
+	{/snippet}
+</Story>

--- a/src/lib/components/session/SessionLayout.stories.svelte
+++ b/src/lib/components/session/SessionLayout.stories.svelte
@@ -5,10 +5,8 @@
 
 	const { Story } = defineMeta({
 		title: 'Session/Layout',
-		component: SessionTopBar,
 		// @ts-expect-error — Storybook decorator typing doesn't match Svelte 5 Component type
 		decorators: [() => ThemeDecorator],
-		tags: ['autodocs'],
 	});
 </script>
 

--- a/src/lib/components/session/SessionSidebar.svelte
+++ b/src/lib/components/session/SessionSidebar.svelte
@@ -1,0 +1,236 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import type { Session } from '$lib/types/generated/Session.js';
+	import PanelLeftIcon from '@lucide/svelte/icons/panel-left';
+	import CpuIcon from '@lucide/svelte/icons/cpu';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Badge } from '$lib/components/ui/badge/index.js';
+	import ProgressBar from './ProgressBar.svelte';
+	import ProviderChip from './ProviderChip.svelte';
+	import { getContextColor, getQuotaColor, getStatePulseColor } from './session_theme_utils.js';
+
+	interface Props {
+		session: Session;
+		contextPercent?: number;
+		quota5hPercent?: number;
+		quota7dPercent?: number;
+		subAgentCount?: number;
+		subAgentTree?: Snippet;
+	}
+
+	let {
+		session,
+		contextPercent = 0,
+		quota5hPercent = 0,
+		quota7dPercent = 0,
+		subAgentCount = 0,
+		subAgentTree,
+	}: Props = $props();
+
+	let collapsed = $state(false);
+
+	const costDisplay = $derived(
+		session.cost_usd !== null ? `$${session.cost_usd.toFixed(3)}` : '$0.000',
+	);
+
+	const tokenDisplay = $derived.by(() => {
+		const total = session.token_count ?? 0;
+		if (total >= 1000) {
+			return `${(total / 1000).toFixed(1)}K`;
+		}
+		return String(total);
+	});
+
+	const contextLabel = $derived(`${contextPercent}% · ${Math.round(contextPercent * 2)}K`);
+
+	const quota5hRemaining = $derived.by(() => {
+		const minutesLeft = Math.round((1 - quota5hPercent / 100) * 300);
+		if (minutesLeft >= 60) {
+			return `${Math.floor(minutesLeft / 60)}h ${minutesLeft % 60}m`;
+		}
+		return `${minutesLeft}m left`;
+	});
+
+	const quota7dRemaining = $derived.by(() => {
+		const hoursLeft = Math.round((1 - quota7dPercent / 100) * 168);
+		if (hoursLeft >= 24) {
+			return `${Math.floor(hoursLeft / 24)}d ${hoursLeft % 24}h`;
+		}
+		return `${hoursLeft}h left`;
+	});
+
+	const pulseColor = $derived(getStatePulseColor(session.state));
+</script>
+
+{#if collapsed}
+	<!-- Collapsed sidebar (44px) -->
+	<div
+		class="flex w-11 shrink-0 flex-col items-center gap-2.5 border-l border-border bg-[var(--sidebar-bg,var(--surface))] pt-2"
+	>
+		<Button variant="ghost" size="icon-sm" onclick={() => (collapsed = false)}>
+			<PanelLeftIcon size={14} strokeWidth={1.8} class="-scale-x-100" />
+		</Button>
+
+		<!-- State pulse dot -->
+		<div
+			class="size-2 rounded-full animate-[badge-pulse_1.8s_ease-in-out_infinite]"
+			style="background: {pulseColor}"
+		></div>
+
+		<!-- Vertical context bar -->
+		<div class="relative h-10 w-[5px] overflow-hidden rounded-[3px] bg-surface-3">
+			<div
+				class="absolute bottom-0 w-full rounded-[3px]"
+				style="height: {contextPercent}%; background: {getContextColor(contextPercent)}"
+			></div>
+		</div>
+		<span
+			class="font-mono text-[9px] tracking-[0.04em] text-foreground-subtle"
+			style="writing-mode: vertical-lr; transform: rotate(180deg)"
+		>
+			{contextPercent}%
+		</span>
+
+		<div class="flex-1"></div>
+
+		{#if subAgentCount > 0}
+			<span
+				class="mb-2.5 font-mono text-[9px] text-foreground-subtle"
+				style="writing-mode: vertical-lr; transform: rotate(180deg)"
+			>
+				{subAgentCount} agents
+			</span>
+		{/if}
+	</div>
+{:else}
+	<!-- Expanded sidebar (272px) -->
+	<div
+		class="flex w-[272px] shrink-0 flex-col overflow-hidden border-l border-border bg-[var(--sidebar-bg,var(--surface))]"
+	>
+		<!-- Header with collapse toggle -->
+		<div class="flex items-center border-b border-border px-2.5 py-2">
+			<Button variant="ghost" size="icon-sm" onclick={() => (collapsed = true)}>
+				<PanelLeftIcon size={13} strokeWidth={1.8} class="-scale-x-100" />
+			</Button>
+		</div>
+
+		<!-- Provider -->
+		<div class="border-b border-border px-3 py-2.5">
+			<div
+				class="mb-1.5 text-[10px] font-semibold uppercase tracking-wider text-foreground-subtle"
+			>
+				Provider
+			</div>
+			<ProviderChip provider={session.provider} />
+		</div>
+
+		<!-- Global usage -->
+		<div class="border-b border-border px-3 py-2.5">
+			<div
+				class="mb-2 text-[10px] font-semibold uppercase tracking-wider text-foreground-subtle"
+			>
+				Global Usage
+			</div>
+			<div class="flex flex-col gap-1.5">
+				<!-- 5h quota -->
+				<div class="flex items-center gap-0">
+					<span class="w-[52px] shrink-0 text-[10.5px] text-foreground-subtle"
+						>5h quota</span
+					>
+					<div class="flex-1 px-2">
+						<ProgressBar
+							percent={quota5hPercent}
+							color={getQuotaColor(quota5hPercent)}
+						/>
+					</div>
+					<span
+						class="min-w-[48px] text-right font-mono text-[10px] text-foreground-subtle"
+					>
+						{quota5hRemaining}
+					</span>
+				</div>
+				<!-- 7d quota -->
+				<div class="flex items-center gap-0">
+					<span class="w-[52px] shrink-0 text-[10.5px] text-foreground-subtle"
+						>7d quota</span
+					>
+					<div class="flex-1 px-2">
+						<ProgressBar
+							percent={quota7dPercent}
+							color={getQuotaColor(quota7dPercent)}
+						/>
+					</div>
+					<span
+						class="min-w-[48px] text-right font-mono text-[10px] text-foreground-subtle"
+					>
+						{quota7dRemaining}
+					</span>
+				</div>
+			</div>
+		</div>
+
+		<!-- Session metrics -->
+		<div class="border-b border-border px-3 py-2.5">
+			<div
+				class="mb-2 text-[10px] font-semibold uppercase tracking-wider text-foreground-subtle"
+			>
+				Session
+			</div>
+			<div class="flex flex-col gap-1.5">
+				<!-- Context -->
+				<div class="flex items-center gap-0">
+					<span class="w-[52px] shrink-0 text-[10.5px] text-foreground-subtle"
+						>Context</span
+					>
+					<div class="flex-1 px-2">
+						<ProgressBar
+							percent={contextPercent}
+							color={getContextColor(contextPercent)}
+						/>
+					</div>
+					<span
+						class="min-w-[48px] text-right font-mono text-[10px] text-foreground-subtle"
+					>
+						{contextLabel}
+					</span>
+				</div>
+				<!-- Cost -->
+				<div class="flex items-center gap-0">
+					<span class="w-[52px] shrink-0 text-[10.5px] text-foreground-subtle">Cost</span>
+					<span
+						class="flex-1 text-right font-mono text-[11.5px] font-semibold text-foreground"
+					>
+						{costDisplay}
+					</span>
+				</div>
+				<!-- Tokens -->
+				<div class="flex items-center gap-0">
+					<span class="w-[52px] shrink-0 text-[10.5px] text-foreground-subtle"
+						>Tokens</span
+					>
+					<span class="flex-1 text-right font-mono text-[10.5px] text-foreground-subtle">
+						{tokenDisplay} in · 0 out
+					</span>
+				</div>
+			</div>
+		</div>
+
+		<!-- Sub-agents -->
+		<div class="flex flex-1 flex-col overflow-hidden">
+			<div class="flex items-center gap-1.5 border-b border-border px-3 py-2">
+				<CpuIcon size={12} strokeWidth={1.8} class="text-foreground-subtle" />
+				<span class="flex-1 text-[11px] font-semibold">Sub-Agents</span>
+				<Badge>{subAgentCount}</Badge>
+			</div>
+			<div class="flex-1 overflow-auto px-1 py-1.5">
+				{#if subAgentTree}
+					{@render subAgentTree()}
+				{:else}
+					<div class="py-5 text-center text-[11px] text-foreground-subtle">
+						No sub-agents spawned yet
+					</div>
+				{/if}
+			</div>
+		</div>
+	</div>
+{/if}

--- a/src/lib/components/session/SessionStateBadge.svelte
+++ b/src/lib/components/session/SessionStateBadge.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import type { SessionState } from '$lib/types/generated/SessionState.js';
+	import { Badge } from '$lib/components/ui/badge/index.js';
+	import { SESSION_BADGE_CONFIG } from './session_theme_utils.js';
+
+	interface Props {
+		state: SessionState;
+	}
+
+	let { state }: Props = $props();
+
+	const config = $derived(SESSION_BADGE_CONFIG[state] ?? SESSION_BADGE_CONFIG.running);
+</script>
+
+<Badge variant={config.variant} dot={config.pulse ? 'pulsing' : 'static'}>
+	{config.label}
+</Badge>

--- a/src/lib/components/session/SessionTopBar.svelte
+++ b/src/lib/components/session/SessionTopBar.svelte
@@ -1,0 +1,93 @@
+<script lang="ts">
+	import type { Session } from '$lib/types/generated/Session.js';
+	import GitBranchIcon from '@lucide/svelte/icons/git-branch';
+	import ExternalLinkIcon from '@lucide/svelte/icons/external-link';
+	import EllipsisVerticalIcon from '@lucide/svelte/icons/ellipsis-vertical';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Badge } from '$lib/components/ui/badge/index.js';
+	import * as Tabs from '$lib/components/ui/tabs/index.js';
+	import { SimpleTooltip } from '$lib/components/ui/tooltip/index.js';
+	import SessionStateBadge from './SessionStateBadge.svelte';
+
+	interface Props {
+		session: Session;
+		branchName?: string;
+		issueNumber?: number | null;
+		prNumber?: number | null;
+		activeTab?: 'chat' | 'files' | 'stats';
+		onTabChange?: (tab: 'chat' | 'files' | 'stats') => void;
+		onOpenInCli?: () => void;
+	}
+
+	let {
+		session,
+		branchName = '',
+		issueNumber = null,
+		prNumber = null,
+		activeTab = 'chat',
+		onTabChange,
+		onOpenInCli,
+	}: Props = $props();
+
+	const sessionTitle = $derived(
+		session.original_intent ?? session.last_prompt ?? `Session ${session.id.slice(0, 8)}`,
+	);
+
+	const truncatedTitle = $derived(
+		sessionTitle.length > 60 ? sessionTitle.slice(0, 60) + '…' : sessionTitle,
+	);
+</script>
+
+<div class="flex h-10 shrink-0 items-center gap-2.5 border-b border-border bg-surface px-3.5">
+	<!-- Left: title + state badge -->
+	<span
+		class="max-w-[280px] shrink-0 overflow-hidden text-ellipsis whitespace-nowrap text-[13px] font-semibold tracking-[-0.01em]"
+	>
+		{truncatedTitle}
+	</span>
+	<SessionStateBadge state={session.state} />
+
+	<!-- Center: git context -->
+	<div class="flex flex-1 items-center justify-center gap-2">
+		{#if branchName}
+			<GitBranchIcon size={12} strokeWidth={1.6} class="text-foreground-subtle" />
+			<span class="font-mono text-[11px] text-foreground-muted">{branchName}</span>
+		{/if}
+		{#if issueNumber !== null}
+			<Badge variant="info">#{issueNumber} open</Badge>
+		{/if}
+		{#if prNumber !== null}
+			<Badge variant="moss">PR #{prNumber} draft</Badge>
+		{/if}
+	</div>
+
+	<!-- Right: actions + tabs -->
+	<div class="flex shrink-0 items-center gap-1.5">
+		{#if onOpenInCli}
+			<SimpleTooltip text="Open session in CLI">
+				<Button variant="secondary" size="sm" onclick={onOpenInCli}>
+					<ExternalLinkIcon size={11} strokeWidth={1.8} />
+					<span class="text-[11px]">Open in CLI</span>
+				</Button>
+			</SimpleTooltip>
+		{/if}
+
+		<Button variant="ghost" size="icon-sm">
+			<EllipsisVerticalIcon size={14} strokeWidth={2} />
+		</Button>
+
+		<div class="mx-1 h-[18px] w-px bg-border"></div>
+
+		<Tabs.Root>
+			<Tabs.Tab active={activeTab === 'chat'} onclick={() => onTabChange?.('chat')}>
+				Chat
+			</Tabs.Tab>
+			<Tabs.Tab active={activeTab === 'files'} onclick={() => onTabChange?.('files')}>
+				Files
+			</Tabs.Tab>
+			<Tabs.Tab active={activeTab === 'stats'} onclick={() => onTabChange?.('stats')}>
+				Stats
+			</Tabs.Tab>
+		</Tabs.Root>
+	</div>
+</div>

--- a/src/lib/components/session/SessionTopBar.svelte
+++ b/src/lib/components/session/SessionTopBar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { Session } from '$lib/types/generated/Session.js';
+	import ArrowLeftIcon from '@lucide/svelte/icons/arrow-left';
 	import GitBranchIcon from '@lucide/svelte/icons/git-branch';
 	import ExternalLinkIcon from '@lucide/svelte/icons/external-link';
 	import EllipsisVerticalIcon from '@lucide/svelte/icons/ellipsis-vertical';
@@ -17,6 +18,7 @@
 		activeTab?: 'chat' | 'files' | 'stats';
 		onTabChange?: (tab: 'chat' | 'files' | 'stats') => void;
 		onOpenInCli?: () => void;
+		onBack?: () => void;
 	}
 
 	let {
@@ -27,6 +29,7 @@
 		activeTab = 'chat',
 		onTabChange,
 		onOpenInCli,
+		onBack,
 	}: Props = $props();
 
 	const sessionTitle = $derived(
@@ -39,7 +42,12 @@
 </script>
 
 <div class="flex h-10 shrink-0 items-center gap-2.5 border-b border-border bg-surface px-3.5">
-	<!-- Left: title + state badge -->
+	<!-- Left: back button + title + state badge -->
+	{#if onBack}
+		<Button variant="ghost" size="icon-sm" onclick={onBack}>
+			<ArrowLeftIcon size={14} strokeWidth={2} />
+		</Button>
+	{/if}
 	<span
 		class="max-w-[280px] shrink-0 overflow-hidden text-ellipsis whitespace-nowrap text-[13px] font-semibold tracking-[-0.01em]"
 	>

--- a/src/lib/components/session/SkillChipsRow.svelte
+++ b/src/lib/components/session/SkillChipsRow.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import { Button } from '$lib/components/ui/button/index.js';
+
+	interface SkillChip {
+		label: string;
+		command: string;
+		visible?: boolean;
+	}
+
+	interface Props {
+		onChipClick?: (command: string) => void;
+	}
+
+	let { onChipClick }: Props = $props();
+
+	const defaultChips: SkillChip[] = [
+		{ label: 'Execute', command: '/execute' },
+		{ label: 'Review', command: '/review' },
+		{ label: 'Check & Fix', command: '/check-and-fix' },
+		{ label: 'Commit', command: '/commit' },
+		{ label: 'Ship', command: '/ship' },
+	];
+</script>
+
+<div class="flex flex-wrap gap-1 px-3 pb-1 pt-2">
+	{#each defaultChips as chip (chip.command)}
+		<Button
+			variant="secondary"
+			size="sm"
+			class="rounded-full px-2 text-[10.5px]"
+			onclick={() => onChipClick?.(chip.command)}
+		>
+			{chip.label}
+		</Button>
+	{/each}
+	<Button variant="ghost" size="sm" class="px-1.5 text-[10.5px]">More ▾</Button>
+</div>

--- a/src/lib/components/session/SubAgentExpansion.svelte
+++ b/src/lib/components/session/SubAgentExpansion.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import CpuIcon from '@lucide/svelte/icons/cpu';
+	import { Button } from '$lib/components/ui/button/index.js';
+
+	interface Props {
+		name: string;
+		model: string;
+		toolCount: number;
+		duration: string;
+		onCollapse?: () => void;
+		children?: Snippet;
+	}
+
+	let { name, model, toolCount, duration, onCollapse, children }: Props = $props();
+</script>
+
+<div
+	class="my-2.5 rounded-r-md border-l-[3px] border-l-azure-400 px-3.5 py-2.5"
+	style="background: color-mix(in oklch, var(--azure-400) 4%, transparent)"
+>
+	<!-- Header -->
+	<div class="mb-2 flex items-center gap-1.5">
+		<CpuIcon size={12} strokeWidth={1.8} class="text-azure-400" />
+		<span class="text-xs font-semibold">Sub-agent: {name}</span>
+		<span class="font-mono text-[10px] text-foreground-subtle">
+			{model} · {toolCount} tools · {duration}
+		</span>
+		<div class="flex-1"></div>
+		<Button variant="ghost" size="sm" class="px-1.5 text-[10px]" onclick={onCollapse}>
+			Collapse
+		</Button>
+	</div>
+
+	<!-- Sub-agent content -->
+	<div class="flex flex-col gap-1.5 opacity-85">
+		{#if children}
+			{@render children()}
+		{:else}
+			<div class="text-[13px] leading-[1.5] text-foreground-muted">
+				Sub-agent messages would appear here when data is available.
+			</div>
+		{/if}
+	</div>
+</div>

--- a/src/lib/components/session/SubAgentTree.stories.svelte
+++ b/src/lib/components/session/SubAgentTree.stories.svelte
@@ -1,0 +1,254 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import SubAgentTree from './SubAgentTree.svelte';
+	import ThemeDecorator from '$lib/storybook/ThemeDecorator.svelte';
+
+	const { Story } = defineMeta({
+		title: 'Session/SubAgentTree',
+		component: SubAgentTree,
+		// @ts-expect-error — Storybook decorator typing doesn't match Svelte 5 Component type
+		decorators: [() => ThemeDecorator],
+		tags: ['autodocs'],
+	});
+</script>
+
+<script lang="ts">
+	import type { SubAgent } from './sub_agent_types.js';
+	import SubAgentExpansion from './SubAgentExpansion.svelte';
+	import { ToolCardCompact } from '$lib/components/chat/index.js';
+
+	const canonicalTree: SubAgent[] = [
+		{
+			id: 'main',
+			name: 'Main session',
+			model: 'Opus 4.7',
+			status: 'running',
+			toolCount: 45,
+			duration: '4m 12s',
+			children: [
+				{
+					id: 'explore',
+					name: 'Explore codebase structure',
+					model: 'Sonnet',
+					status: 'completed',
+					toolCount: 12,
+					duration: '23s',
+					children: [],
+				},
+				{
+					id: 'review',
+					name: 'Review error handling',
+					model: 'Sonnet',
+					status: 'completed',
+					toolCount: 8,
+					duration: '15s',
+					children: [
+						{
+							id: 'fetch-docs',
+							name: 'Fetch library docs',
+							model: 'Haiku',
+							status: 'completed',
+							toolCount: 3,
+							duration: '4s',
+							children: [],
+						},
+					],
+				},
+				{
+					id: 'implement',
+					name: 'Implement provider trait',
+					model: 'Sonnet',
+					status: 'running',
+					toolCount: 5,
+					duration: '…',
+					children: [],
+				},
+				{
+					id: 'test',
+					name: 'Run test suite',
+					model: 'Haiku',
+					status: 'failed',
+					toolCount: 2,
+					duration: '8s',
+					children: [],
+				},
+			],
+		},
+	];
+
+	const emptyTree: SubAgent[] = [];
+
+	const singleAgent: SubAgent[] = [
+		{
+			id: 'main',
+			name: 'Main session',
+			model: 'Opus 4.7',
+			status: 'running',
+			toolCount: 12,
+			duration: '1m 30s',
+			children: [
+				{
+					id: 'review-auth',
+					name: 'Review auth module',
+					model: 'Sonnet',
+					status: 'running',
+					toolCount: 4,
+					duration: '…',
+					children: [],
+				},
+			],
+		},
+	];
+
+	const deepTree: SubAgent[] = [
+		{
+			id: 'main',
+			name: 'Main session',
+			model: 'Opus 4.7',
+			status: 'running',
+			toolCount: 82,
+			duration: '8m 45s',
+			children: [
+				{
+					id: 'auth',
+					name: 'Implement auth system',
+					model: 'Sonnet',
+					status: 'running',
+					toolCount: 34,
+					duration: '5m 12s',
+					children: [
+						{
+							id: 'research',
+							name: 'Research OAuth2 crates',
+							model: 'Haiku',
+							status: 'completed',
+							toolCount: 6,
+							duration: '12s',
+							children: [],
+						},
+						{
+							id: 'pkce',
+							name: 'Write PKCE module',
+							model: 'Sonnet',
+							status: 'completed',
+							toolCount: 14,
+							duration: '2m 8s',
+							children: [
+								{
+									id: 'fixtures',
+									name: 'Generate test fixtures',
+									model: 'Haiku',
+									status: 'completed',
+									toolCount: 3,
+									duration: '5s',
+									children: [
+										{
+											id: 'rfc',
+											name: 'Fetch RFC examples',
+											model: 'Haiku',
+											status: 'completed',
+											toolCount: 2,
+											duration: '3s',
+											children: [],
+										},
+									],
+								},
+							],
+						},
+					],
+				},
+			],
+		},
+	];
+</script>
+
+<Story name="Canonical Tree">
+	{#snippet template()}
+		<div
+			class="w-[260px] rounded-lg border border-border bg-[var(--sidebar-bg,var(--surface))] p-2"
+		>
+			<SubAgentTree agents={canonicalTree} activeAgentId="explore" />
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Empty">
+	{#snippet template()}
+		<div
+			class="w-[260px] rounded-lg border border-border bg-[var(--sidebar-bg,var(--surface))] p-2"
+		>
+			<SubAgentTree agents={emptyTree} />
+			<div class="py-5 text-center text-[11px] text-foreground-subtle">
+				No sub-agents spawned yet
+			</div>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Single Agent">
+	{#snippet template()}
+		<div
+			class="w-[260px] rounded-lg border border-border bg-[var(--sidebar-bg,var(--surface))] p-2"
+		>
+			<SubAgentTree agents={singleAgent} />
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Deep Nesting (4+ levels)">
+	{#snippet template()}
+		<div
+			class="w-[260px] rounded-lg border border-border bg-[var(--sidebar-bg,var(--surface))] p-2"
+		>
+			<SubAgentTree agents={deepTree} />
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Inline Expansion">
+	{#snippet template()}
+		<div class="mx-auto max-w-[900px] space-y-2 p-4">
+			<div class="text-[13px] text-foreground">Assistant message before sub-agent...</div>
+			<SubAgentExpansion
+				name="Explore codebase structure"
+				model="Sonnet"
+				toolCount={12}
+				duration="23s"
+			>
+				{#snippet children()}
+					<div class="text-[13px] leading-[1.5] text-foreground-muted">
+						Exploring the project structure to understand codebase layout.
+					</div>
+					<ToolCardCompact
+						message={{
+							id: 'sub-1',
+							role: 'tool',
+							content: '',
+							timestamp: Date.now(),
+							toolName: 'Glob',
+							toolUseId: 'tu_sub1',
+							toolStatus: 'success',
+							toolInput: { pattern: '**/*.rs' },
+						}}
+					/>
+					<ToolCardCompact
+						message={{
+							id: 'sub-2',
+							role: 'tool',
+							content: '',
+							timestamp: Date.now(),
+							toolName: 'Read',
+							toolUseId: 'tu_sub2',
+							toolStatus: 'success',
+							toolInput: { file_path: 'src/main.rs' },
+						}}
+					/>
+					<div class="text-[13px] leading-[1.5] text-foreground-muted">
+						Found 23 Rust source files in 4 modules.
+					</div>
+				{/snippet}
+			</SubAgentExpansion>
+			<div class="text-[13px] text-foreground">Assistant message after sub-agent...</div>
+		</div>
+	{/snippet}
+</Story>

--- a/src/lib/components/session/SubAgentTree.stories.svelte
+++ b/src/lib/components/session/SubAgentTree.stories.svelte
@@ -5,10 +5,8 @@
 
 	const { Story } = defineMeta({
 		title: 'Session/SubAgentTree',
-		component: SubAgentTree,
 		// @ts-expect-error — Storybook decorator typing doesn't match Svelte 5 Component type
 		decorators: [() => ThemeDecorator],
-		tags: ['autodocs'],
 	});
 </script>
 
@@ -215,38 +213,36 @@
 				toolCount={12}
 				duration="23s"
 			>
-				{#snippet children()}
-					<div class="text-[13px] leading-[1.5] text-foreground-muted">
-						Exploring the project structure to understand codebase layout.
-					</div>
-					<ToolCardCompact
-						message={{
-							id: 'sub-1',
-							role: 'tool',
-							content: '',
-							timestamp: Date.now(),
-							toolName: 'Glob',
-							toolUseId: 'tu_sub1',
-							toolStatus: 'success',
-							toolInput: { pattern: '**/*.rs' },
-						}}
-					/>
-					<ToolCardCompact
-						message={{
-							id: 'sub-2',
-							role: 'tool',
-							content: '',
-							timestamp: Date.now(),
-							toolName: 'Read',
-							toolUseId: 'tu_sub2',
-							toolStatus: 'success',
-							toolInput: { file_path: 'src/main.rs' },
-						}}
-					/>
-					<div class="text-[13px] leading-[1.5] text-foreground-muted">
-						Found 23 Rust source files in 4 modules.
-					</div>
-				{/snippet}
+				<div class="text-[13px] leading-[1.5] text-foreground-muted">
+					Exploring the project structure to understand codebase layout.
+				</div>
+				<ToolCardCompact
+					message={{
+						id: 'sub-1',
+						role: 'tool',
+						content: '',
+						timestamp: Date.now(),
+						toolName: 'Glob',
+						toolUseId: 'tu_sub1',
+						toolStatus: 'success',
+						toolInput: { pattern: '**/*.rs' },
+					}}
+				/>
+				<ToolCardCompact
+					message={{
+						id: 'sub-2',
+						role: 'tool',
+						content: '',
+						timestamp: Date.now(),
+						toolName: 'Read',
+						toolUseId: 'tu_sub2',
+						toolStatus: 'success',
+						toolInput: { file_path: 'src/main.rs' },
+					}}
+				/>
+				<div class="text-[13px] leading-[1.5] text-foreground-muted">
+					Found 23 Rust source files in 4 modules.
+				</div>
 			</SubAgentExpansion>
 			<div class="text-[13px] text-foreground">Assistant message after sub-agent...</div>
 		</div>

--- a/src/lib/components/session/SubAgentTree.svelte
+++ b/src/lib/components/session/SubAgentTree.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	import type { SubAgent } from './sub_agent_types.js';
+	import AgentTreeNode from './AgentTreeNode.svelte';
+
+	interface Props {
+		agents: SubAgent[];
+		activeAgentId?: string | null;
+		onSelect?: (agentId: string) => void;
+	}
+
+	let { agents, activeAgentId = null, onSelect }: Props = $props();
+</script>
+
+<div class="flex flex-col gap-px">
+	{#each agents as agent (agent.id)}
+		<AgentTreeNode {agent} {activeAgentId} {onSelect} />
+	{/each}
+</div>

--- a/src/lib/components/session/session_theme_utils.ts
+++ b/src/lib/components/session/session_theme_utils.ts
@@ -1,0 +1,62 @@
+import type { SessionState } from '$lib/types/generated/SessionState.js';
+
+interface SessionBadgeConfig {
+	variant: 'success' | 'warning' | 'info' | 'moss' | 'danger' | 'default';
+	label: string;
+	pulse: boolean;
+}
+
+export const SESSION_BADGE_CONFIG: Record<SessionState, SessionBadgeConfig> = {
+	running: { variant: 'success', label: 'Running', pulse: true },
+	'needs-input': { variant: 'warning', label: 'Needs Input', pulse: true },
+	'needs-review': { variant: 'info', label: 'Needs Review', pulse: false },
+	paused: { variant: 'warning', label: 'Stopped', pulse: false },
+	finished: { variant: 'moss', label: 'Finished', pulse: false },
+	errored: { variant: 'danger', label: 'Errored', pulse: false },
+};
+
+export function getContextColor(percent: number): string {
+	if (percent > 60) {
+		return 'var(--status-danger)';
+	}
+	if (percent > 40) {
+		return 'var(--status-warning)';
+	}
+	return 'var(--status-success)';
+}
+
+export function getQuotaColor(percent: number): string {
+	if (percent > 85) {
+		return 'var(--status-danger)';
+	}
+	if (percent > 60) {
+		return 'var(--status-warning)';
+	}
+	return 'var(--status-success)';
+}
+
+interface ProviderConfig {
+	name: string;
+	color: string;
+}
+
+const PROVIDER_CONFIGS: Record<string, ProviderConfig> = {
+	'claude-code': { name: 'Claude Code', color: 'var(--amber-400)' },
+	'open-code': { name: 'OpenCode', color: 'var(--azure-400)' },
+	codex: { name: 'Codex', color: 'var(--status-success)' },
+	cursor: { name: 'Cursor', color: 'var(--foreground-muted)' },
+};
+
+export function getProviderConfig(provider: string): ProviderConfig {
+	return PROVIDER_CONFIGS[provider] ?? { name: provider, color: 'var(--foreground-subtle)' };
+}
+
+export function getStatePulseColor(state: SessionState): string {
+	if (state === 'running') {
+		return 'var(--status-success)';
+	}
+	if (state === 'errored') {
+		return 'var(--status-danger)';
+	}
+	return 'var(--status-warning)';
+}

--- a/src/lib/components/session/sub_agent_types.ts
+++ b/src/lib/components/session/sub_agent_types.ts
@@ -1,0 +1,9 @@
+export interface SubAgent {
+	id: string;
+	name: string;
+	model: string;
+	status: 'running' | 'completed' | 'failed';
+	toolCount: number;
+	duration: string;
+	children: SubAgent[];
+}

--- a/src/lib/modules/chat/chat_message_builder.test.ts
+++ b/src/lib/modules/chat/chat_message_builder.test.ts
@@ -113,7 +113,7 @@ describe('buildChatMessage', () => {
 		expect(buildChatMessage(event)).toBeNull();
 	});
 
-	it('creates system message from permission_prompt', () => {
+	it('creates tool message with permission interactionType from permission_prompt', () => {
 		// fallow-ignore-next-line code-duplication
 		const event: SessionEvent = {
 			type: 'permission_prompt',
@@ -123,8 +123,10 @@ describe('buildChatMessage', () => {
 		};
 		const message = buildChatMessage(event);
 		expect(message).not.toBeNull();
-		expect(message!.role).toBe('system');
-		expect(message!.content).toBeTruthy();
+		expect(message!.role).toBe('tool');
+		expect(message!.interactionType).toBe('permission');
+		expect(message!.toolName).toBe('Bash');
+		expect(message!.requestId).toBe('req_1');
 	});
 
 	it('creates system message from system_status', () => {

--- a/src/lib/modules/chat/chat_message_builder.ts
+++ b/src/lib/modules/chat/chat_message_builder.ts
@@ -3,6 +3,7 @@ import * as m from '$lib/paraglide/messages.js';
 import {
 	MESSAGE_ROLE,
 	TOOL_STATUS,
+	INTERACTION_TYPE,
 	type ChatMessage,
 	type ChatTurn,
 } from './chat_message_types.js';
@@ -75,9 +76,25 @@ export function buildChatMessage(event: SessionEvent): ChatMessage | null {
 		case 'permission_prompt':
 			return {
 				id: generateId(),
-				role: MESSAGE_ROLE.system,
+				role: MESSAGE_ROLE.tool,
 				content: m.chat_permission_needed({ toolName: event.tool_name }),
 				timestamp,
+				toolName: event.tool_name,
+				toolInput: event.tool_input,
+				toolStatus: TOOL_STATUS.running,
+				interactionType: INTERACTION_TYPE.permission,
+				requestId: event.request_id,
+			};
+
+		case 'elicitation_prompt':
+			return {
+				id: generateId(),
+				role: MESSAGE_ROLE.tool,
+				content: event.message,
+				timestamp,
+				toolStatus: TOOL_STATUS.running,
+				interactionType: INTERACTION_TYPE.elicitation,
+				requestId: event.request_id,
 			};
 
 		case 'system_status':
@@ -93,7 +110,6 @@ export function buildChatMessage(event: SessionEvent): ChatMessage | null {
 		case 'usage_update':
 		case 'tool_progress':
 		case 'tool_use_summary':
-		case 'elicitation_prompt':
 		case 'compact_boundary':
 		case 'control_cancelled':
 		case 'raw':

--- a/src/lib/modules/chat/chat_message_types.ts
+++ b/src/lib/modules/chat/chat_message_types.ts
@@ -17,6 +17,14 @@ export const TOOL_STATUS = {
 
 export type ToolStatus = (typeof TOOL_STATUS)[keyof typeof TOOL_STATUS];
 
+export const INTERACTION_TYPE = {
+	permission: 'permission',
+	elicitation: 'elicitation',
+	askUser: 'ask-user',
+} as const;
+
+export type InteractionType = (typeof INTERACTION_TYPE)[keyof typeof INTERACTION_TYPE];
+
 export interface ChatMessage {
 	id: string;
 	role: MessageRole;
@@ -29,6 +37,8 @@ export interface ChatMessage {
 	toolOutput?: JsonValue;
 	isError?: boolean;
 	messageId?: string;
+	interactionType?: InteractionType;
+	requestId?: string;
 }
 
 export interface ChatTurn {

--- a/src/lib/modules/chat/index.ts
+++ b/src/lib/modules/chat/index.ts
@@ -10,8 +10,10 @@ export {
 export {
 	MESSAGE_ROLE,
 	TOOL_STATUS,
+	INTERACTION_TYPE,
 	type ChatMessage,
 	type ChatTurn,
 	type MessageRole,
 	type ToolStatus,
+	type InteractionType,
 } from './chat_message_types.js';

--- a/src/routes/sessions/+page.svelte
+++ b/src/routes/sessions/+page.svelte
@@ -84,18 +84,8 @@
 
 {#if selectedSession}
 	<!-- Chat view for selected session -->
-	<div class="flex h-full flex-col">
-		<div class="flex items-center gap-3 border-b border-border px-4 py-3">
-			<Button variant="ghost" size="sm" onclick={handleBack}>
-				{m.session_back()}
-			</Button>
-			<h2 class="truncate text-sm font-medium text-foreground">
-				{selectedSession.original_intent ?? m.session_fallback_title()}
-			</h2>
-		</div>
-		<div class="flex-1">
-			<SessionChatView session={selectedSession} />
-		</div>
+	<div class="h-full">
+		<SessionChatView session={selectedSession} onBack={handleBack} />
 	</div>
 {:else}
 	<!-- Session list -->


### PR DESCRIPTION
## Summary

- **#155**: Add session top bar (title, state badge, git context, tab switcher) and right sidebar (expanded 272px / collapsed 44px with provider chip, quota progress bars, session metrics, sub-agent slot)
- **#159**: Replace basic input bar with floating input panel containing skill chips row, auto-grow textarea, bottom controls (attach, tools, model/provider selector, permission mode, send/stop morph button)
- **#153**: Add tool card L2 expansion with accent border and content panel, collapsible tool groups for 5+ consecutive calls, click-to-expand on L1 cards
- **#154**: Add L3 interaction cards — permission prompt (amber, allow/deny buttons), elicitation prompt (blue, text input + submit), ask-user question (radio options + confirm). Update chat message builder to produce tool-role messages for permission/elicitation events
- **#157**: Add sub-agent tree sidebar panel with recursive AgentTreeNode (status indicators, depth indentation, active state), inline expansion block with azure accent border

### Components created (with Storybook stories)

| Component | Location | Purpose |
|-----------|----------|---------|
| SessionTopBar | session/ | Page chrome — title, state badge, tabs, back button |
| SessionSidebar | session/ | Right sidebar — provider, quotas, metrics, sub-agents |
| SessionStateBadge | session/ | State-mapped badge using Badge component |
| ProviderChip | session/ | Clickable provider icon + name |
| ProgressBar | session/ | Reusable progress bar with color thresholds |
| FloatingInputPanel | session/ | Composer — skill chips, textarea, controls |
| SendStopButton | session/ | Morphing send/stop button |
| SkillChipsRow | session/ | Context-aware skill shortcut buttons |
| AgentTreeNode | session/ | Recursive tree node with status indicators |
| SubAgentTree | session/ | Tree container for sub-agents |
| SubAgentExpansion | session/ | Inline expansion block in chat stream |
| ToolCardExpanded | chat/ | L2 expanded tool card with content panel |
| ToolCardGroup | chat/ | Collapsible group for 5+ tool calls |
| ToolCardPermission | chat/ | L3 permission prompt card |
| ToolCardElicitation | chat/ | L3 MCP elicitation card |
| ToolCardAskUser | chat/ | L3 question with radio options |

## Test plan

- [x] All 916 unit/storybook tests pass
- [x] `pnpm check:all` passes (format + lint + fallow + typecheck + eslint)
- [x] Visual verification via Chrome DevTools MCP:
  - Session top bar renders with title, state badge, tabs
  - Right sidebar shows provider, quotas, metrics correctly
  - Sidebar collapses to 44px strip with vertical context bar
  - Floating input panel with skill chips and send/stop morph
  - Send button shows for needs-input, stop for running sessions
  - Back button navigates to session list
  - Zero console errors

Refs #153, #154, #155, #157, #159