### PR TITLE
#226 refactor: replace manual UI patterns with library components

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -42,6 +42,7 @@
 	--color-status-warning: var(--status-warning);
 	--color-status-danger: var(--status-danger);
 	--color-status-info: var(--status-info);
+	--color-status-merged: var(--status-merged);
 	--color-code-bg: var(--code-bg);
 	--color-priority-top: var(--priority-top);
 	--color-priority-high: var(--priority-high);
@@ -237,6 +238,7 @@
 	--status-warning: oklch(0.77 0.155 75);
 	--status-danger: oklch(0.62 0.205 25);
 	--status-info: oklch(0.66 0.105 220);
+	--status-merged: var(--gh-merged);
 	--priority-top: oklch(0.62 0.205 25);
 	--priority-high: oklch(0.72 0.16 55);
 	--priority-medium: oklch(0.82 0.16 85);

--- a/src/lib/components/AssignedIssuesPanel.svelte
+++ b/src/lib/components/AssignedIssuesPanel.svelte
@@ -11,6 +11,7 @@
 	import GitBranch from '@lucide/svelte/icons/git-branch';
 	import { openUrl } from '@tauri-apps/plugin-opener';
 	import { Persisted, jsonSerde } from '$lib/reactivity/persisted.svelte.js';
+	import { Badge } from '$lib/components/ui/badge/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { SimpleTooltip } from '$lib/components/ui/tooltip/index.js';
 	import { cn } from '$lib/utils.js';
@@ -84,12 +85,13 @@
 			{#if issue.labels.length > 0}
 				<span class="flex shrink-0 items-center gap-1">
 					{#each issue.labels as label (label.name)}
-						<span
-							class="inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-medium leading-none"
-							style="background-color: {label.color}20; color: {label.color}; border: 1px solid {label.color}40;"
+						<Badge
+							size="compact"
+							class="rounded-full"
+							style="background-color: {label.color}20; color: {label.color}; border-color: {label.color}40;"
 						>
 							{label.name}
-						</span>
+						</Badge>
 					{/each}
 				</span>
 			{/if}

--- a/src/lib/components/CommandPalette.svelte
+++ b/src/lib/components/CommandPalette.svelte
@@ -2,6 +2,7 @@
 	import * as m from '$lib/paraglide/messages.js';
 	import SearchIcon from '@lucide/svelte/icons/search';
 	import * as Dialog from '$lib/components/ui/dialog/index.js';
+	import * as Popover from '$lib/components/ui/popover/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import { Kbd } from '$lib/components/ui/kbd/index.js';
 	import { Badge } from '$lib/components/ui/badge/index.js';
@@ -70,26 +71,20 @@
 		<div class="max-h-[320px] overflow-y-auto p-1.5">
 			{#each [...paletteCtx.groupedResults] as [category, items], groupIndex (category)}
 				{#if groupIndex > 0}
-					<hr data-slot="popover-divider" class="my-1 border-t border-border" />
+					<Popover.Divider />
 				{/if}
 
-				<div
-					data-slot="popover-label"
-					class="px-2 pb-1 pt-1.5 text-[length:var(--text-2xs)] font-medium uppercase tracking-wider text-foreground-subtle"
-				>
-					{CATEGORY_LABELS[category]()}
-				</div>
+				<Popover.Label>{CATEGORY_LABELS[category]()}</Popover.Label>
 
 				{#each items as item (item.id)}
 					{@const flatIdx = paletteCtx.flatIndexByItemId.get(item.id) ?? -1}
 					{@const isSelected = flatIdx === paletteCtx.selectedIndex}
-					<div
-						data-slot="popover-item"
-						data-state={isSelected ? 'active' : undefined}
+					<Popover.Item
+						active={isSelected}
 						role="option"
 						aria-selected={isSelected}
 						tabindex={-1}
-						class="flex min-h-[28px] w-full cursor-pointer select-none items-center gap-2 rounded-md px-2 py-1 text-[length:var(--text-sm)] text-foreground outline-none hover:bg-surface-2 focus-visible:bg-surface-2 data-[state=active]:bg-surface-2 data-[state=active]:text-primary"
+						class="data-[state=active]:bg-surface-2"
 						onclick={() => paletteCtx.executeItem(item)}
 						onkeydown={(event) => {
 							if (event.key === 'Enter') {
@@ -124,7 +119,7 @@
 								{/if}
 							{/if}
 						</span>
-					</div>
+					</Popover.Item>
 				{/each}
 			{/each}
 

--- a/src/lib/components/IssueCard.svelte
+++ b/src/lib/components/IssueCard.svelte
@@ -396,12 +396,13 @@
 				<div class="flex flex-wrap items-center gap-1">
 					{#each issue.labels as label (label.name)}
 						<SimpleTooltip text={label.name}>
-							<span
-								class="inline-block rounded-full px-1.5 py-px text-[10px] font-medium leading-3"
-								style="background-color: {label.color}33; color: {label.color}; border: 1px solid {label.color}44;"
+							<Badge
+								size="compact"
+								class="rounded-full py-px leading-3"
+								style="background-color: {label.color}33; color: {label.color}; border-color: {label.color}44;"
 							>
 								{label.name}
-							</span>
+							</Badge>
 						</SimpleTooltip>
 					{/each}
 				</div>

--- a/src/lib/components/IssueDetail.svelte
+++ b/src/lib/components/IssueDetail.svelte
@@ -6,6 +6,7 @@
 	import ColorPicker from './color-picker/ColorPicker.svelte';
 	import GitHubBadge from './GitHubBadge.svelte';
 	import WorktreeStateIcon from './WorktreeStateIcon.svelte';
+	import { Badge } from '$lib/components/ui/badge/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { SimpleTooltip } from '$lib/components/ui/tooltip/index.js';
 	import Pencil from '@lucide/svelte/icons/pencil';
@@ -85,12 +86,13 @@
 				</span>
 				{#if issue.labels.length > 0}
 					{#each issue.labels as label (label.name)}
-						<span
-							class="inline-flex rounded-full px-1.5 py-0.5 text-[10px] font-medium leading-none"
-							style="background-color: {label.color}20; color: {label.color}; border: 1px solid {label.color}40;"
+						<Badge
+							size="compact"
+							class="rounded-full"
+							style="background-color: {label.color}20; color: {label.color}; border-color: {label.color}40;"
 						>
 							{label.name}
-						</span>
+						</Badge>
 					{/each}
 				{/if}
 			</div>

--- a/src/lib/components/PruneWorktreesDialog.svelte
+++ b/src/lib/components/PruneWorktreesDialog.svelte
@@ -5,6 +5,7 @@
 	import * as Dialog from '$lib/components/ui/dialog/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Checkbox } from '$lib/components/ui/checkbox/index.js';
+	import { Badge } from '$lib/components/ui/badge/index.js';
 
 	interface Props {
 		open: boolean;
@@ -78,16 +79,12 @@
 								</div>
 							</div>
 							<div class="flex items-center gap-1">
-								<span
-									class="rounded bg-purple-900/40 px-1.5 py-0.5 text-[10px] text-purple-400"
+								<Badge variant="merged" size="compact"
+									>{m.prune_badge_merged()}</Badge
 								>
-									{m.prune_badge_merged()}
-								</span>
-								<span
-									class="rounded bg-red-900/40 px-1.5 py-0.5 text-[10px] text-red-400"
+								<Badge variant="danger" size="compact"
+									>{m.prune_badge_closed()}</Badge
 								>
-									{m.prune_badge_closed()}
-								</span>
 							</div>
 						</label>
 					{/each}

--- a/src/lib/components/chat/ToolCardAskUser.svelte
+++ b/src/lib/components/chat/ToolCardAskUser.svelte
@@ -3,6 +3,8 @@
 	import CompassIcon from '@lucide/svelte/icons/compass';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Kbd } from '$lib/components/ui/kbd/index.js';
+	import * as Card from '$lib/components/ui/card/index.js';
+	import * as RadioGroup from '$lib/components/ui/radio-group/index.js';
 
 	interface Props {
 		message: ChatMessage;
@@ -11,7 +13,9 @@
 
 	let { message, onConfirm }: Props = $props();
 
-	let selectedIndex = $state(0);
+	let selectedValue = $state('0');
+
+	const selectedIndex = $derived(parseInt(selectedValue, 10));
 
 	const options = $derived.by(() => {
 		if (
@@ -42,7 +46,7 @@
 	});
 </script>
 
-<div class="overflow-hidden rounded-lg border border-border bg-surface">
+<Card.Card padding="none" class="overflow-hidden">
 	<!-- Header -->
 	<div class="flex h-9 items-center gap-2 border-b border-border bg-surface-2 px-3">
 		<CompassIcon size={13} strokeWidth={1.8} class="text-foreground-muted" />
@@ -55,7 +59,7 @@
 			{question}
 		</div>
 		{#if options.length > 0}
-			<div class="mb-2.5 flex flex-col gap-1">
+			<RadioGroup.Root bind:value={selectedValue} class="mb-2.5 gap-1">
 				{#each options as option, i (i)}
 					<label
 						class="flex cursor-pointer items-center gap-2 rounded-md px-2 py-[5px] text-[12.5px]"
@@ -64,20 +68,14 @@
 							? 'border: 1px solid color-mix(in oklch, var(--primary) 30%, var(--border))'
 							: 'border: 1px solid transparent'}
 					>
-						<input
-							type="radio"
-							name="ask-option"
-							class="accent-primary"
-							checked={selectedIndex === i}
-							onchange={() => (selectedIndex = i)}
-						/>
+						<RadioGroup.Item value={String(i)} />
 						<span>{option}</span>
 					</label>
 				{/each}
-			</div>
+			</RadioGroup.Root>
 		{/if}
 		<Button variant="primary" size="sm" onclick={() => onConfirm?.(selectedIndex)}>
 			Confirm <Kbd class="ml-1">↵</Kbd>
 		</Button>
 	</div>
-</div>
+</Card.Card>

--- a/src/lib/components/chat/ToolCardExpanded.svelte
+++ b/src/lib/components/chat/ToolCardExpanded.svelte
@@ -3,6 +3,7 @@
 	import { TOOL_STATUS } from '$lib/modules/chat/index.js';
 	import CheckIcon from '@lucide/svelte/icons/check';
 	import XIcon from '@lucide/svelte/icons/x';
+	import * as Card from '$lib/components/ui/card/index.js';
 	import {
 		extractToolDetail,
 		extractToolOutput,
@@ -23,8 +24,9 @@
 	const accentColor = $derived(getToolAccentColor(message.toolName ?? ''));
 </script>
 
-<div
-	class="overflow-hidden rounded-lg border border-border bg-surface"
+<Card.Card
+	padding="none"
+	class="overflow-hidden"
 	role="region"
 	aria-label="Tool card: {message.toolName}"
 >
@@ -61,4 +63,4 @@
 			class="m-0 max-h-[260px] flex-1 overflow-auto break-all whitespace-pre-wrap px-3 py-2.5 font-mono text-[11.5px] leading-[1.55] text-foreground-muted">{output ||
 				detail}</pre>
 	</div>
-</div>
+</Card.Card>

--- a/src/lib/components/color-picker/ColorPickerContent.svelte
+++ b/src/lib/components/color-picker/ColorPickerContent.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { tick, untrack } from 'svelte';
 	import { Input } from '$lib/components/ui/input/index.js';
+	import { Separator } from '$lib/components/ui/separator/index.js';
 	import type { ColorPickerContentProps } from './color_picker_types.js';
 	import { DEFAULT_COLOR_PALETTE, getContrastTextColor, isValidHexColor } from './color_utils.js';
 
@@ -164,7 +165,7 @@
 	{/each}
 </div>
 
-<div class="my-2 border-t border-border"></div>
+<Separator class="my-2" />
 
 <div class="flex flex-1 items-center justify-center gap-2">
 	<label

--- a/src/lib/components/creation-wizard/StepGithubSearch.svelte
+++ b/src/lib/components/creation-wizard/StepGithubSearch.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
-	import { Input } from '$lib/components/ui/input/index.js';
+	import { SearchField } from '$lib/components/ui/search-field/index.js';
 	import { onMount, untrack } from 'svelte';
 	import { useCreationWizard } from '$lib/modules/creation-wizard';
 	import type { AssignedIssue, SearchedGithubIssue } from '$lib/types/generated';
-	import SearchIcon from '@lucide/svelte/icons/search';
 	import CircleDot from '@lucide/svelte/icons/circle-dot';
 	import CircleCheck from '@lucide/svelte/icons/circle-check';
 	import Loader2 from '@lucide/svelte/icons/loader-2';
@@ -120,25 +119,19 @@
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div class="flex flex-col gap-3" onkeydown={handleKeydown}>
-	<div class="relative">
-		<SearchIcon
-			size={14}
-			class="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
-		/>
-		<Input
-			bind:ref={inputElement}
-			value={inputDisplayValue}
-			oninput={handleInput}
-			placeholder={m.wizard_search_placeholder()}
-			class="pl-9"
-		/>
+	<SearchField
+		bind:ref={inputElement}
+		value={inputDisplayValue}
+		oninput={handleInput}
+		placeholder={m.wizard_search_placeholder()}
+	>
 		{#if wizard.searching}
 			<Loader2
 				size={14}
 				class="absolute right-3 top-1/2 -translate-y-1/2 animate-spin text-muted-foreground"
 			/>
 		{/if}
-	</div>
+	</SearchField>
 
 	{#if wizard.skipNotice}
 		<p class="text-center text-xs text-muted-foreground">{m.wizard_search_skipping()}</p>

--- a/src/lib/components/creation-wizard/StepIssueName.svelte
+++ b/src/lib/components/creation-wizard/StepIssueName.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
 	import { Input } from '$lib/components/ui/input/index.js';
+	import { HelpText } from '$lib/components/ui/help-text/index.js';
 	import { onMount } from 'svelte';
 	import { useCreationWizard } from '$lib/modules/creation-wizard';
 	import { generateBranchName } from '$lib/modules/creation-wizard';
@@ -55,11 +56,9 @@
 		oninput={() => (showError = false)}
 	/>
 	{#if showError}
-		<p class="text-xs text-destructive">{m.wizard_name_required()}</p>
+		<HelpText status="error" class="mt-0">{m.wizard_name_required()}</HelpText>
 	{/if}
 	{#if branchPreview}
-		<p class="text-xs text-muted-foreground">
-			{m.wizard_branch_preview({ branch: branchPreview })}
-		</p>
+		<HelpText class="mt-0">{m.wizard_branch_preview({ branch: branchPreview })}</HelpText>
 	{/if}
 </div>

--- a/src/lib/components/github_badge_variants.ts
+++ b/src/lib/components/github_badge_variants.ts
@@ -24,7 +24,7 @@ export const VARIANT_CLASSES: Record<GitHubBadgeVariant, string> = {
 	info: 'bg-cyan-50 text-cyan-700 border-cyan-200 dark:bg-cyan-900/40 dark:text-cyan-300 dark:border-cyan-700/50',
 	emerald:
 		'bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-900/40 dark:text-emerald-300 dark:border-emerald-700/50',
-	purple: 'bg-purple-50 text-purple-700 border-purple-200 dark:bg-purple-900/40 dark:text-purple-300 dark:border-purple-700/50',
+	purple: 'bg-[color-mix(in_oklch,var(--status-merged)_14%,transparent)] text-status-merged border-[color-mix(in_oklch,var(--status-merged)_30%,transparent)]',
 	neutral:
 		'bg-neutral-50 text-neutral-600 border-neutral-200 dark:bg-neutral-800/40 dark:text-neutral-400 dark:border-neutral-600/50',
 };

--- a/src/lib/components/session/SessionTopBar.svelte
+++ b/src/lib/components/session/SessionTopBar.svelte
@@ -8,6 +8,7 @@
 	import { Badge } from '$lib/components/ui/badge/index.js';
 	import * as Tabs from '$lib/components/ui/tabs/index.js';
 	import { SimpleTooltip } from '$lib/components/ui/tooltip/index.js';
+	import { Separator } from '$lib/components/ui/separator/index.js';
 	import SessionStateBadge from './SessionStateBadge.svelte';
 
 	interface Props {
@@ -84,7 +85,7 @@
 			<EllipsisVerticalIcon size={14} strokeWidth={2} />
 		</Button>
 
-		<div class="mx-1 h-[18px] w-px bg-border"></div>
+		<Separator orientation="vertical" class="mx-1 h-[18px]" />
 
 		<Tabs.Root>
 			<Tabs.Tab active={activeTab === 'chat'} onclick={() => onTabChange?.('chat')}>

--- a/src/lib/components/ui/badge/badge-variants.ts
+++ b/src/lib/components/ui/badge/badge-variants.ts
@@ -12,6 +12,7 @@ export const BADGE_VARIANT_OPTIONS = [
 	'moss',
 	'amber',
 	'mono',
+	'merged',
 ] as const;
 
 export const BADGE_DOT_OPTIONS = ['static', 'pulsing'] as const;
@@ -32,6 +33,7 @@ export const badgeVariants = tv({
 			moss: 'bg-[color-mix(in_oklch,var(--primary)_14%,transparent)] text-primary border-[color-mix(in_oklch,var(--primary)_30%,transparent)]',
 			amber: 'bg-[color-mix(in_oklch,var(--accent)_16%,transparent)] text-[color-mix(in_oklch,var(--accent)_70%,var(--foreground))] border-[color-mix(in_oklch,var(--accent)_32%,transparent)]',
 			mono: 'bg-surface-2 text-foreground-muted border-border font-mono text-[10.5px]',
+			merged: 'bg-[color-mix(in_oklch,var(--status-merged)_14%,transparent)] text-status-merged border-[color-mix(in_oklch,var(--status-merged)_30%,transparent)]',
 		},
 		size: {
 			default: 'h-5 px-[7px] text-[11px] rounded-full',

--- a/src/lib/components/ui/search-field/SearchField.svelte
+++ b/src/lib/components/ui/search-field/SearchField.svelte
@@ -15,13 +15,13 @@
 
 <div class="relative" data-slot="search-field">
 	<SearchIcon
-		class="pointer-events-none absolute left-2.5 top-[9px] size-[13px] text-foreground-subtle"
+		class="pointer-events-none absolute left-3 top-1/2 size-3.5 -translate-y-1/2 text-foreground-subtle"
 	/>
 	<input
 		bind:this={ref}
 		bind:value
 		data-slot="search-field-input"
-		class={cn(inputVariants(), 'pl-[30px]', className)}
+		class={cn(inputVariants(), 'pl-9', className)}
 		type="search"
 		{...restProps}
 	/>

--- a/src/lib/components/ui/toast/Toast.svelte
+++ b/src/lib/components/ui/toast/Toast.svelte
@@ -2,6 +2,7 @@
 	import { cn } from '$lib/utils.js';
 	import { toastVariants, toastIconColors, type ToastProps } from './toast-variants.js';
 	import XIcon from '@lucide/svelte/icons/x';
+	import { Button } from '$lib/components/ui/button/index.js';
 
 	let {
 		ref = $bindable<HTMLDivElement | null>(null),
@@ -43,13 +44,14 @@
 	{/if}
 
 	{#if onDismiss}
-		<button
-			type="button"
+		<Button
+			variant="ghost"
+			size="icon-sm"
+			class="size-6 text-foreground-subtle"
 			onclick={onDismiss}
 			aria-label="Dismiss"
-			class="shrink-0 inline-flex size-6 items-center justify-center rounded-md text-foreground-subtle transition-colors hover:bg-surface-2 hover:text-foreground"
 		>
 			<XIcon class="size-3" />
-		</button>
+		</Button>
 	{/if}
 </div>


### PR DESCRIPTION
## Description
- Added `--status-merged` design token (aliased from `--gh-merged`) and Badge `merged` variant
- Replaced manual card shells with `<Card>` component in ToolCardAskUser and ToolCardExpanded
- Replaced native `<input type="radio">` with `<RadioGroup>` in ToolCardAskUser
- Replaced manual divider `<div>`s with `<Separator>` in ColorPickerContent and SessionTopBar
- Replaced native `<button>` dismiss in Toast with `<Button>` component
- Replaced GitHub label chip `<span>`s with `<Badge>` in AssignedIssuesPanel, IssueCard, IssueDetail
- Replaced raw Tailwind pills in PruneWorktreesDialog with `<Badge variant="merged|danger">`
- Aligned SearchField icon/padding, then swapped StepGithubSearch manual search pattern to `<SearchField>`
- Adopted `<HelpText>` in StepIssueName for error and branch preview text
- Refactored CommandPalette to use `Popover.Divider`, `Popover.Label`, `Popover.Item` instead of manual `data-slot` attributes
- Aligned GitHubBadge purple variant to `--status-merged` token (replacing raw Tailwind `purple-*` classes)

## Resolves
Closes #226