### PR TITLE
#230 feat: improve tree thumbnail visibility in issue cards

### DIFF
--- a/src/lib/components/IssueCard.svelte
+++ b/src/lib/components/IssueCard.svelte
@@ -315,10 +315,10 @@
 	</div>
 
 	<!-- Body: tree thumbnail | info -->
-	<div class="grid items-start gap-2.5 p-2.5 pr-3" style="grid-template-columns: 72px 1fr;">
+	<div class="grid items-start gap-2.5 p-2.5 pr-3" style="grid-template-columns: 100px 1fr;">
 		<!-- Tree thumbnail -->
 		<div
-			class="relative flex size-[72px] shrink-0 items-end justify-center overflow-hidden rounded-[7px] border"
+			class="relative flex size-[100px] shrink-0 items-end justify-center overflow-hidden rounded-[7px] border"
 			style="background: linear-gradient(180deg, color-mix(in oklch, {color} var(--tree-bg-mix), var(--surface-2, hsl(0 0% 12%))) 0%, color-mix(in oklch, {color} 5%, var(--surface-3, hsl(0 0% 10%))) 100%); border-color: color-mix(in oklch, {color} 20%, var(--border));"
 		>
 			{#if notificationDotColor !== null && sessionState === null}
@@ -329,7 +329,7 @@
 				</SimpleTooltip>
 			{/if}
 			{#if visualization}
-				<div class="absolute inset-0">
+				<div class="absolute inset-0" style="transform: scale(1.4) translateY(10%);">
 					<TreeThumbnailImage {visualization} />
 				</div>
 			{:else}


### PR DESCRIPTION
## Summary

- Increase thumbnail container from 72px to 100px with updated grid layout
- Add CSS zoom-crop transform (`scale(1.4) translateY(10%)`) on tree wrapper to focus on canopy
- Enlarge seed (1→2.5) and sprouting (1→1.8) stage scales in `low-poly-2d-trees` library

## Test plan

- [x] Unit tests: seed scale=2.5, sprouting scale=1.8, stump remains 1.0
- [x] Static checks pass (check:all)
- [x] All 887 unit tests pass
- [ ] Visual: seed stage recognizable at 100px thumbnail
- [ ] Visual: sprouting stage shows stem + leaves
- [ ] Visual: larger trees show crown/canopy, not empty sky
- [ ] Visual: ForestView/DependencyGraphView no regression from scale changes
- [ ] Visual: all three viz kinds (tree, potted-plant, oak) render correctly

closes #230