### PR TITLE
feat(metrics): wire pricing engine, achievements, events, currency, workspace scoping

### DIFF
--- a/src-tauri/src/commands/issue_commands.rs
+++ b/src-tauri/src/commands/issue_commands.rs
@@ -1,8 +1,9 @@
 use rusqlite::Row;
-use tauri::State;
+use tauri::{AppHandle, Emitter, State};
 use uuid::Uuid;
 
 use crate::database::connection::DatabaseState;
+use crate::metrics::achievement_tracker;
 use crate::models::issue::{CreateIssueRequest, Issue, UpdateIssueRequest};
 
 use super::shared::resolve_nullable_field;
@@ -52,6 +53,7 @@ fn row_to_issue(row: &Row) -> Result<Issue, rusqlite::Error> {
 
 #[tauri::command]
 pub fn create_issue(
+    app_handle: AppHandle,
     state: State<DatabaseState>,
     request: CreateIssueRequest,
 ) -> Result<Issue, String> {
@@ -75,6 +77,11 @@ pub fn create_issue(
             ],
         )
         .map_err(|error| format!("Failed to create issue: {error}"))?;
+
+    let newly_unlocked = achievement_tracker::check_issue_achievements(&connection);
+    for kind in &newly_unlocked {
+        let _ = app_handle.emit("achievement-unlocked", kind.as_str());
+    }
 
     let query = format!("SELECT {ISSUE_SELECT_COLUMNS} FROM issues WHERE id = ?1");
     connection

--- a/src-tauri/src/commands/metrics_commands.rs
+++ b/src-tauri/src/commands/metrics_commands.rs
@@ -1,9 +1,11 @@
+use std::collections::HashMap;
+
 use serde::Serialize;
-use tauri::State;
+use tauri::{Manager, State};
 use ts_rs::TS;
 
 use crate::database::connection::DatabaseState;
-use crate::metrics::{achievement_tracker, historical_import, queries};
+use crate::metrics::{achievement_tracker, currency, historical_import, queries};
 use crate::models::achievement::Achievement;
 use crate::models::metrics::{MetricsPeriod, UsageDashboardData};
 
@@ -31,9 +33,10 @@ pub struct ProviderImportSummary {
 pub fn get_usage_dashboard(
     state: State<DatabaseState>,
     period: MetricsPeriod,
+    dashboard_id: Option<String>,
 ) -> Result<UsageDashboardData, String> {
     let connection = state.read()?;
-    queries::query_usage_dashboard(&connection, period)
+    queries::query_usage_dashboard(&connection, &period, dashboard_id.as_deref())
         .map_err(|error| format!("Failed to query usage dashboard: {error}"))
 }
 
@@ -68,4 +71,19 @@ pub fn import_historical_sessions(state: State<DatabaseState>) -> Result<ImportS
         total_sessions,
         total_skipped,
     })
+}
+
+#[tauri::command]
+pub async fn get_exchange_rates(
+    app_handle: tauri::AppHandle,
+) -> Result<HashMap<String, f64>, String> {
+    let app_data_dir = app_handle
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to resolve app data dir: {e}"))?;
+    let service = currency::CurrencyService::new(&app_data_dir);
+    service
+        .get_exchange_rates()
+        .await
+        .map_err(|e| format!("Failed to fetch exchange rates: {e}"))
 }

--- a/src-tauri/src/database/defaults.rs
+++ b/src-tauri/src/database/defaults.rs
@@ -62,7 +62,20 @@ pub fn seed_defaults(connection: &Connection) -> Result<(), rusqlite::Error> {
     )?;
 
     seed_grovekeeper_workspace(connection)?;
+    seed_fast_mode_multipliers(connection)?;
 
+    Ok(())
+}
+
+fn seed_fast_mode_multipliers(connection: &Connection) -> Result<(), rusqlite::Error> {
+    for (model_id, multiplier) in &[("claude-opus-4-7", 6.0), ("claude-opus-4-6", 6.0)] {
+        connection.execute(
+            "INSERT OR IGNORE INTO model_pricing_cache \
+             (model_id, input_cost_per_token, output_cost_per_token, fast_mode_multiplier, source) \
+             VALUES (?1, 0.0, 0.0, ?2, 'litellm')",
+            rusqlite::params![model_id, multiplier],
+        )?;
+    }
     Ok(())
 }
 

--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -233,6 +233,9 @@ pub fn create_tables(connection: &Connection) -> Result<(), rusqlite::Error> {
             output_cost_per_token REAL NOT NULL,
             cache_read_cost_per_token REAL,
             cache_write_cost_per_token REAL,
+            fast_mode_multiplier REAL,
+            source TEXT NOT NULL DEFAULT 'litellm'
+                CHECK (source IN ('user', 'litellm', 'openrouter')),
             updated_at TEXT NOT NULL DEFAULT (datetime('now'))
         );
 
@@ -247,6 +250,9 @@ pub fn create_tables(connection: &Connection) -> Result<(), rusqlite::Error> {
         CREATE INDEX IF NOT EXISTS idx_turn_metrics_category ON turn_metrics(category);
         CREATE INDEX IF NOT EXISTS idx_tool_usage_session_id ON tool_usage(session_id);
         CREATE INDEX IF NOT EXISTS idx_tool_usage_tool_name ON tool_usage(tool_name);
+        CREATE INDEX IF NOT EXISTS idx_turn_metrics_timestamp ON turn_metrics(timestamp);
+        CREATE INDEX IF NOT EXISTS idx_tool_usage_timestamp ON tool_usage(timestamp);
+        CREATE INDEX IF NOT EXISTS idx_session_metrics_cost_usd ON session_metrics(cost_usd DESC);
 
         COMMIT;
         ",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,8 +16,11 @@ use commands::{
     notification_commands, portfolio_commands, raw_requirements_commands, seed_commands,
     session_commands, terminal_commands, window_commands, worktree_commands,
 };
+use std::sync::Arc;
+
 use database::connection::DatabaseState;
 use git::fetch_coordinator::FetchCoordinator;
+use metrics::pricing::PricingEngine;
 use models::app_setting::{STARTUP_BEHAVIOR_KEY, STARTUP_BEHAVIOR_LAST_WORKSPACE, STARTUP_BEHAVIOR_OVERVIEW};
 use notification::playback_queue;
 use notification::service::NotificationService;
@@ -25,6 +28,8 @@ use session::discovery_polling::DiscoveryPoller;
 use session::manager::SessionManager;
 use tauri::Manager;
 use window_manager::{APP_NAME, DEFAULT_WINDOW_HEIGHT, DEFAULT_WINDOW_WIDTH};
+
+pub type SharedPricingEngine = Arc<tokio::sync::Mutex<PricingEngine>>;
 
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -94,7 +99,14 @@ pub fn run() {
                     .unwrap_or_else(|_| STARTUP_BEHAVIOR_OVERVIEW.to_string())
             };
 
+            let mut pricing_engine = PricingEngine::new(&app_data_directory);
+            {
+                let conn = database_state.read().unwrap_or_else(|e| panic!("{e}"));
+                pricing_engine.load_overrides_from_database(&conn);
+            }
+
             app.manage(database_state);
+            app.manage(Arc::new(tokio::sync::Mutex::new(pricing_engine)) as SharedPricingEngine);
             app.manage(SessionManager::new());
             app.manage(FetchCoordinator::new());
             app.manage(DiscoveryPoller::new());
@@ -216,6 +228,7 @@ pub fn run() {
             metrics_commands::get_usage_dashboard,
             metrics_commands::get_achievements,
             metrics_commands::import_historical_sessions,
+            metrics_commands::get_exchange_rates,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/src-tauri/src/metrics/currency.rs
+++ b/src-tauri/src/metrics/currency.rs
@@ -1,0 +1,124 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+const FRANKFURTER_URL: &str = "https://api.frankfurter.dev/v1/latest?from=USD";
+
+const CACHE_TTL_SECONDS: u64 = 86_400;
+
+#[derive(Serialize, Deserialize)]
+struct CurrencyCacheFile {
+    timestamp: u64,
+    rates: HashMap<String, f64>,
+}
+
+pub struct CurrencyService {
+    cache_path: PathBuf,
+}
+
+impl CurrencyService {
+    pub fn new(app_data_dir: &Path) -> Self {
+        Self {
+            cache_path: app_data_dir.join("currency-cache.json"),
+        }
+    }
+
+    pub async fn get_exchange_rates(&self) -> Result<HashMap<String, f64>, Box<dyn std::error::Error>> {
+        if let Some(cached) = self.load_cache() {
+            return Ok(cached);
+        }
+
+        let rates = fetch_rates().await?;
+        self.save_cache(&rates);
+        Ok(rates)
+    }
+
+    fn load_cache(&self) -> Option<HashMap<String, f64>> {
+        let content = std::fs::read_to_string(&self.cache_path).ok()?;
+        let cache: CurrencyCacheFile = serde_json::from_str(&content).ok()?;
+
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or(Duration::ZERO)
+            .as_secs();
+
+        if now.saturating_sub(cache.timestamp) >= CACHE_TTL_SECONDS {
+            return None;
+        }
+
+        Some(cache.rates)
+    }
+
+    fn save_cache(&self, rates: &HashMap<String, f64>) {
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or(Duration::ZERO)
+            .as_secs();
+
+        let cache = CurrencyCacheFile {
+            timestamp,
+            rates: rates.clone(),
+        };
+
+        if let Ok(json) = serde_json::to_string(&cache) {
+            let _ = std::fs::write(&self.cache_path, json);
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct FrankfurterResponse {
+    rates: HashMap<String, f64>,
+}
+
+async fn fetch_rates() -> Result<HashMap<String, f64>, Box<dyn std::error::Error>> {
+    let response = reqwest::get(FRANKFURTER_URL).await?;
+    let data: FrankfurterResponse = response.json().await?;
+    Ok(data.rates)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn cache_roundtrip() {
+        let tmp = TempDir::new().unwrap();
+        let service = CurrencyService::new(tmp.path());
+
+        let mut rates = HashMap::new();
+        rates.insert("EUR".to_string(), 0.92);
+        rates.insert("CZK".to_string(), 22.5);
+
+        service.save_cache(&rates);
+        let loaded = service.load_cache().expect("cache should load");
+
+        assert!((loaded["EUR"] - 0.92).abs() < 1e-6);
+        assert!((loaded["CZK"] - 22.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn stale_cache_returns_none() {
+        let tmp = TempDir::new().unwrap();
+        let service = CurrencyService::new(tmp.path());
+
+        let stale = CurrencyCacheFile {
+            timestamp: 0,
+            rates: HashMap::new(),
+        };
+        let json = serde_json::to_string(&stale).unwrap();
+        std::fs::write(&service.cache_path, json).unwrap();
+
+        assert!(service.load_cache().is_none());
+    }
+
+    #[test]
+    fn missing_cache_returns_none() {
+        let tmp = TempDir::new().unwrap();
+        let service = CurrencyService::new(tmp.path());
+        assert!(service.load_cache().is_none());
+    }
+}

--- a/src-tauri/src/metrics/mod.rs
+++ b/src-tauri/src/metrics/mod.rs
@@ -1,8 +1,6 @@
-#[allow(dead_code)]
 pub mod achievement_tracker;
 pub mod classifier;
-#[allow(dead_code)]
+pub mod currency;
 pub mod historical_import;
-#[allow(dead_code)]
 pub mod pricing;
 pub mod queries;

--- a/src-tauri/src/metrics/pricing.rs
+++ b/src-tauri/src/metrics/pricing.rs
@@ -2,23 +2,32 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
 
 const LITELLM_URL: &str =
     "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
+
+const OPENROUTER_URL: &str = "https://openrouter.ai/api/v1/models";
 
 const CACHE_TTL_SECONDS: u64 = 86_400;
 
 const BUNDLED_SNAPSHOT: &str =
     include_str!("../../data/litellm-snapshot.json");
 
-const FAST_MODE_MULTIPLIER_MODELS: &[&str] = &["claude-opus-4-7", "claude-opus-4-6"];
+const DEFAULT_FAST_MODE_MULTIPLIER: f64 = 6.0;
 
-struct ModelPricing {
-    input_cost_per_token: f64,
-    output_cost_per_token: f64,
-    cache_read_cost_per_token: f64,
-    cache_write_cost_per_token: f64,
+#[derive(Debug, Clone, Serialize)]
+pub struct PricingResult {
+    pub cost_usd: f64,
+    pub pricing_available: bool,
+}
+
+pub struct ModelPricing {
+    pub input_cost_per_token: f64,
+    pub output_cost_per_token: f64,
+    pub cache_read_cost_per_token: f64,
+    pub cache_write_cost_per_token: f64,
 }
 
 #[derive(Deserialize)]
@@ -43,8 +52,30 @@ struct CachedModelPricing {
     cache_write_cost_per_token: f64,
 }
 
+#[derive(Deserialize)]
+struct OpenRouterResponse {
+    data: Vec<OpenRouterModel>,
+}
+
+#[derive(Deserialize)]
+struct OpenRouterModel {
+    id: String,
+    pricing: Option<OpenRouterPricing>,
+}
+
+#[derive(Deserialize)]
+struct OpenRouterPricing {
+    prompt: Option<String>,
+    completion: Option<String>,
+    #[serde(rename = "input_cache_read")]
+    cache_read: Option<String>,
+    #[serde(rename = "input_cache_write")]
+    cache_write: Option<String>,
+}
+
 pub struct PricingEngine {
     prices: HashMap<String, ModelPricing>,
+    fast_mode_multipliers: HashMap<String, f64>,
     cache_path: PathBuf,
 }
 
@@ -52,7 +83,67 @@ impl PricingEngine {
     pub fn new(app_data_dir: &Path) -> Self {
         let cache_path = app_data_dir.join("pricing-cache.json");
         let prices = load_initial_prices(&cache_path);
-        Self { prices, cache_path }
+        Self {
+            prices,
+            fast_mode_multipliers: HashMap::new(),
+            cache_path,
+        }
+    }
+
+    pub fn load_overrides_from_database(&mut self, conn: &Connection) {
+        let mut stmt = match conn.prepare(
+            "SELECT model_id, input_cost_per_token, output_cost_per_token, \
+             cache_read_cost_per_token, cache_write_cost_per_token, \
+             fast_mode_multiplier, source FROM model_pricing_cache"
+        ) {
+            Ok(s) => s,
+            Err(e) => {
+                log::warn!("Failed to load pricing overrides: {e}");
+                return;
+            }
+        };
+
+        let rows = stmt.query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, f64>(1)?,
+                row.get::<_, f64>(2)?,
+                row.get::<_, Option<f64>>(3)?,
+                row.get::<_, Option<f64>>(4)?,
+                row.get::<_, Option<f64>>(5)?,
+                row.get::<_, String>(6)?,
+            ))
+        });
+
+        let rows = match rows {
+            Ok(r) => r,
+            Err(e) => {
+                log::warn!("Failed to query pricing overrides: {e}");
+                return;
+            }
+        };
+
+        for row in rows.flatten() {
+            let (model_id, input, output, cache_read, cache_write, multiplier, source) = row;
+
+            if let Some(m) = multiplier {
+                self.fast_mode_multipliers.insert(model_id.clone(), m);
+            }
+
+            if source == "user" || (input > 0.0 || output > 0.0) {
+                let pricing = ModelPricing {
+                    input_cost_per_token: input,
+                    output_cost_per_token: output,
+                    cache_read_cost_per_token: cache_read.unwrap_or(input * 0.1),
+                    cache_write_cost_per_token: cache_write.unwrap_or(input * 1.25),
+                };
+                if source == "user" {
+                    self.prices.insert(model_id, pricing);
+                } else if !self.prices.contains_key(&model_id) {
+                    self.prices.insert(model_id, pricing);
+                }
+            }
+        }
     }
 
     pub fn calculate_cost(
@@ -63,26 +154,30 @@ impl PricingEngine {
         cache_read: u64,
         cache_write: u64,
         is_fast_mode: bool,
-    ) -> f64 {
+    ) -> PricingResult {
         let Some(pricing) = self.resolve_model(model) else {
-            return 0.0;
+            return PricingResult {
+                cost_usd: 0.0,
+                pricing_available: false,
+            };
         };
 
-        let multiplier = if is_fast_mode
-            && FAST_MODE_MULTIPLIER_MODELS
-                .iter()
-                .any(|&m| model.contains(m))
-        {
-            6.0_f64
+        let multiplier = if is_fast_mode {
+            self.resolve_fast_mode_multiplier(model)
         } else {
-            1.0_f64
+            1.0
         };
 
-        multiplier
+        let cost_usd = multiplier
             * (input_tokens as f64 * pricing.input_cost_per_token
                 + output_tokens as f64 * pricing.output_cost_per_token
                 + cache_read as f64 * pricing.cache_read_cost_per_token
-                + cache_write as f64 * pricing.cache_write_cost_per_token)
+                + cache_write as f64 * pricing.cache_write_cost_per_token);
+
+        PricingResult {
+            cost_usd,
+            pricing_available: true,
+        }
     }
 
     pub async fn refresh_from_litellm(&mut self) -> Result<(), Box<dyn std::error::Error>> {
@@ -116,36 +211,55 @@ impl PricingEngine {
             })
             .collect();
 
-        let timestamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or(Duration::ZERO)
-            .as_secs();
+        save_cache(&self.cache_path, &entries);
+        merge_entries_into_prices(&mut self.prices, entries);
+        Ok(())
+    }
 
-        let cache_file = PricingCacheFile {
-            timestamp,
-            entries: entries.clone(),
-        };
+    pub async fn fetch_from_openrouter(
+        &mut self,
+        model: &str,
+    ) -> Option<()> {
+        let response = reqwest::get(OPENROUTER_URL).await.ok()?;
+        let data: OpenRouterResponse = response.json().await.ok()?;
 
-        if let Ok(json) = serde_json::to_string(&cache_file) {
-            let _ = std::fs::write(&self.cache_path, json);
+        let stripped = strip_provider_prefix(model);
+        let found = data.data.iter().find(|m| {
+            m.id == model || m.id == stripped || m.id.ends_with(&format!("/{stripped}"))
+        })?;
+
+        let pricing = found.pricing.as_ref()?;
+        let input = pricing.prompt.as_ref()?.parse::<f64>().ok()?;
+        let output = pricing.completion.as_ref()?.parse::<f64>().ok()?;
+        let cache_read = pricing.cache_read.as_ref().and_then(|v| v.parse::<f64>().ok()).unwrap_or(input * 0.1);
+        let cache_write = pricing.cache_write.as_ref().and_then(|v| v.parse::<f64>().ok()).unwrap_or(input * 1.25);
+
+        self.prices.insert(
+            model.to_string(),
+            ModelPricing {
+                input_cost_per_token: input,
+                output_cost_per_token: output,
+                cache_read_cost_per_token: cache_read,
+                cache_write_cost_per_token: cache_write,
+            },
+        );
+
+        Some(())
+    }
+
+    pub async fn resolve_with_fallback(
+        &mut self,
+        model: &str,
+    ) -> bool {
+        if self.resolve_model(model).is_some() {
+            return true;
         }
 
-        self.prices = entries
-            .into_iter()
-            .map(|(key, cached)| {
-                (
-                    key,
-                    ModelPricing {
-                        input_cost_per_token: cached.input_cost_per_token,
-                        output_cost_per_token: cached.output_cost_per_token,
-                        cache_read_cost_per_token: cached.cache_read_cost_per_token,
-                        cache_write_cost_per_token: cached.cache_write_cost_per_token,
-                    },
-                )
-            })
-            .collect();
+        if self.refresh_from_litellm().await.is_ok() && self.resolve_model(model).is_some() {
+            return true;
+        }
 
-        Ok(())
+        self.fetch_from_openrouter(model).await.is_some()
     }
 
     fn resolve_model(&self, model: &str) -> Option<&ModelPricing> {
@@ -168,6 +282,26 @@ impl PricingEngine {
         }
 
         None
+    }
+
+    fn resolve_fast_mode_multiplier(&self, model: &str) -> f64 {
+        if let Some(&m) = self.fast_mode_multipliers.get(model) {
+            return m;
+        }
+
+        let pin_stripped = strip_pin_suffix(model);
+        let stripped = strip_provider_prefix(&pin_stripped);
+        if let Some(&m) = self.fast_mode_multipliers.get(stripped) {
+            return m;
+        }
+
+        for (key, &multiplier) in &self.fast_mode_multipliers {
+            if model.contains(key.as_str()) {
+                return multiplier;
+            }
+        }
+
+        DEFAULT_FAST_MODE_MULTIPLIER
     }
 }
 
@@ -229,6 +363,39 @@ fn cached_entries_to_pricing(
         .collect()
 }
 
+fn save_cache(cache_path: &Path, entries: &HashMap<String, CachedModelPricing>) {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO)
+        .as_secs();
+
+    let cache_file = PricingCacheFile {
+        timestamp,
+        entries: entries.clone(),
+    };
+
+    if let Ok(json) = serde_json::to_string(&cache_file) {
+        let _ = std::fs::write(cache_path, json);
+    }
+}
+
+fn merge_entries_into_prices(
+    prices: &mut HashMap<String, ModelPricing>,
+    entries: HashMap<String, CachedModelPricing>,
+) {
+    for (key, cached) in entries {
+        prices.insert(
+            key,
+            ModelPricing {
+                input_cost_per_token: cached.input_cost_per_token,
+                output_cost_per_token: cached.output_cost_per_token,
+                cache_read_cost_per_token: cached.cache_read_cost_per_token,
+                cache_write_cost_per_token: cached.cache_write_cost_per_token,
+            },
+        );
+    }
+}
+
 fn is_cache_stale(cache_path: &Path) -> bool {
     let Ok(content) = std::fs::read_to_string(cache_path) else {
         return true;
@@ -276,6 +443,10 @@ mod tests {
         let prices = parse_snapshot(BUNDLED_SNAPSHOT);
         PricingEngine {
             prices,
+            fast_mode_multipliers: HashMap::from([
+                ("claude-opus-4-7".to_string(), 6.0),
+                ("claude-opus-4-6".to_string(), 6.0),
+            ]),
             cache_path: PathBuf::from("/nonexistent/pricing-cache.json"),
         }
     }
@@ -283,32 +454,77 @@ mod tests {
     #[test]
     fn cost_calculation_basic() {
         let engine = engine_with_defaults();
-        let cost = engine.calculate_cost("claude-sonnet-4-5", 1000, 500, 0, 0, false);
+        let result = engine.calculate_cost("claude-sonnet-4-5", 1000, 500, 0, 0, false);
         let expected = 1000.0 * 0.000003 + 500.0 * 0.000015;
-        assert!((cost - expected).abs() < 1e-12);
+        assert!(result.pricing_available);
+        assert!((result.cost_usd - expected).abs() < 1e-12);
     }
 
     #[test]
     fn fast_mode_multiplier() {
         let engine = engine_with_defaults();
-        let cost_normal = engine.calculate_cost("claude-opus-4-7", 1000, 500, 0, 0, false);
-        let cost_fast = engine.calculate_cost("claude-opus-4-7", 1000, 500, 0, 0, true);
-        assert!((cost_fast - cost_normal * 6.0).abs() < 1e-12);
+        let result_normal = engine.calculate_cost("claude-opus-4-7", 1000, 500, 0, 0, false);
+        let result_fast = engine.calculate_cost("claude-opus-4-7", 1000, 500, 0, 0, true);
+        assert!((result_fast.cost_usd - result_normal.cost_usd * 6.0).abs() < 1e-12);
     }
 
     #[test]
     fn model_resolution_strips_prefix() {
         let engine = engine_with_defaults();
-        let cost_plain = engine.calculate_cost("claude-sonnet-4-5", 1000, 0, 0, 0, false);
-        let cost_prefixed =
+        let result_plain = engine.calculate_cost("claude-sonnet-4-5", 1000, 0, 0, 0, false);
+        let result_prefixed =
             engine.calculate_cost("anthropic/claude-sonnet-4-5", 1000, 0, 0, 0, false);
-        assert!((cost_plain - cost_prefixed).abs() < 1e-12);
+        assert!((result_plain.cost_usd - result_prefixed.cost_usd).abs() < 1e-12);
     }
 
     #[test]
-    fn unknown_model_returns_zero() {
+    fn unknown_model_returns_pricing_unavailable() {
         let engine = engine_with_defaults();
-        let cost = engine.calculate_cost("unknown-model-xyz", 1000, 500, 100, 50, false);
-        assert_eq!(cost, 0.0);
+        let result = engine.calculate_cost("unknown-model-xyz", 1000, 500, 100, 50, false);
+        assert_eq!(result.cost_usd, 0.0);
+        assert!(!result.pricing_available);
+    }
+
+    #[test]
+    fn db_overrides_take_priority() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        crate::database::schema::create_tables(&conn).unwrap();
+
+        conn.execute(
+            "INSERT INTO model_pricing_cache \
+             (model_id, input_cost_per_token, output_cost_per_token, source) \
+             VALUES ('claude-sonnet-4-5', 0.001, 0.002, 'user')",
+            [],
+        )
+        .unwrap();
+
+        let mut engine = engine_with_defaults();
+        engine.load_overrides_from_database(&conn);
+
+        let result = engine.calculate_cost("claude-sonnet-4-5", 1000, 500, 0, 0, false);
+        let expected = 1000.0 * 0.001 + 500.0 * 0.002;
+        assert!(result.pricing_available);
+        assert!((result.cost_usd - expected).abs() < 1e-12);
+    }
+
+    #[test]
+    fn fast_mode_multiplier_from_database() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        crate::database::schema::create_tables(&conn).unwrap();
+
+        conn.execute(
+            "INSERT INTO model_pricing_cache \
+             (model_id, input_cost_per_token, output_cost_per_token, fast_mode_multiplier, source) \
+             VALUES ('claude-opus-4-7', 0.0, 0.0, 8.0, 'litellm')",
+            [],
+        )
+        .unwrap();
+
+        let mut engine = engine_with_defaults();
+        engine.load_overrides_from_database(&conn);
+
+        let result_normal = engine.calculate_cost("claude-opus-4-7", 1000, 500, 0, 0, false);
+        let result_fast = engine.calculate_cost("claude-opus-4-7", 1000, 500, 0, 0, true);
+        assert!((result_fast.cost_usd - result_normal.cost_usd * 8.0).abs() < 1e-12);
     }
 }

--- a/src-tauri/src/metrics/queries.rs
+++ b/src-tauri/src/metrics/queries.rs
@@ -15,28 +15,92 @@ fn period_where_clause(filter: Option<&str>, column: &str) -> String {
     }
 }
 
+fn workspace_join_session_metrics(dashboard_id: Option<&str>) -> (String, String) {
+    match dashboard_id {
+        Some(_) => (
+            " JOIN sessions _ws ON session_metrics.session_id = _ws.id \
+              JOIN issues _wi ON _ws.issue_id = _wi.id"
+                .to_string(),
+            " AND _wi.dashboard_id = :dashboard_id".to_string(),
+        ),
+        None => (String::new(), String::new()),
+    }
+}
+
+fn workspace_join_turn_metrics(dashboard_id: Option<&str>) -> (String, String) {
+    match dashboard_id {
+        Some(_) => (
+            " JOIN sessions _ws ON turn_metrics.session_id = _ws.id \
+              JOIN issues _wi ON _ws.issue_id = _wi.id"
+                .to_string(),
+            " AND _wi.dashboard_id = :dashboard_id".to_string(),
+        ),
+        None => (String::new(), String::new()),
+    }
+}
+
+fn workspace_join_tool_usage(dashboard_id: Option<&str>) -> (String, String) {
+    match dashboard_id {
+        Some(_) => (
+            " JOIN sessions _ws ON tool_usage.session_id = _ws.id \
+              JOIN issues _wi ON _ws.issue_id = _wi.id"
+                .to_string(),
+            " AND _wi.dashboard_id = :dashboard_id".to_string(),
+        ),
+        None => (String::new(), String::new()),
+    }
+}
+
+fn query_single_row_f64_i64(
+    conn: &Connection,
+    sql: &str,
+    dashboard_id: Option<&str>,
+) -> Result<(f64, i64), rusqlite::Error> {
+    if let Some(did) = dashboard_id {
+        conn.query_row(sql, &[(":dashboard_id", did)], |row| {
+            Ok((row.get::<_, f64>(0)?, row.get::<_, i64>(1)?))
+        })
+    } else {
+        conn.query_row(sql, [], |row| {
+            Ok((row.get::<_, f64>(0)?, row.get::<_, i64>(1)?))
+        })
+    }
+}
+
+fn query_single_row_i64_i64(
+    conn: &Connection,
+    sql: &str,
+    dashboard_id: Option<&str>,
+) -> Result<(i64, i64), rusqlite::Error> {
+    if let Some(did) = dashboard_id {
+        conn.query_row(sql, &[(":dashboard_id", did)], |row| {
+            Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?))
+        })
+    } else {
+        conn.query_row(sql, [], |row| {
+            Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?))
+        })
+    }
+}
+
 pub fn query_usage_stats(
     conn: &Connection,
-    period: MetricsPeriod,
+    period: &MetricsPeriod,
+    dashboard_id: Option<&str>,
 ) -> Result<UsageStats, rusqlite::Error> {
     let date_filter = period.to_sql_date_filter();
-
-    let current_where = period_where_clause(date_filter, "started_at");
+    let current_where = period_where_clause(date_filter.as_deref(), "started_at");
+    let (ws_join, ws_filter) = workspace_join_session_metrics(dashboard_id);
 
     let stats_sql = format!(
-        "SELECT COALESCE(SUM(cost_usd), 0.0), COUNT(*) FROM session_metrics {current_where}"
+        "SELECT COALESCE(SUM(session_metrics.cost_usd), 0.0), COUNT(*) FROM session_metrics{ws_join} {current_where}{ws_filter}"
     );
-    let (total_cost_usd, session_count): (f64, i64) = conn.query_row(&stats_sql, [], |row| {
-        Ok((row.get::<_, f64>(0)?, row.get::<_, i64>(1)?))
-    })?;
+    let (total_cost_usd, session_count) = query_single_row_f64_i64(conn, &stats_sql, dashboard_id)?;
 
     let oneshot_sql = format!(
-        "SELECT COALESCE(SUM(one_shot_turns), 0), COALESCE(SUM(edit_turns), 0) FROM session_metrics {current_where}"
+        "SELECT COALESCE(SUM(session_metrics.one_shot_turns), 0), COALESCE(SUM(session_metrics.edit_turns), 0) FROM session_metrics{ws_join} {current_where}{ws_filter}"
     );
-    let (one_shot_sum, edit_turns_sum): (i64, i64) =
-        conn.query_row(&oneshot_sql, [], |row| {
-            Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?))
-        })?;
+    let (one_shot_sum, edit_turns_sum) = query_single_row_i64_i64(conn, &oneshot_sql, dashboard_id)?;
 
     let one_shot_rate = if edit_turns_sum > 0 {
         one_shot_sum as f64 / edit_turns_sum as f64 * 100.0
@@ -45,12 +109,9 @@ pub fn query_usage_stats(
     };
 
     let cache_sql = format!(
-        "SELECT COALESCE(SUM(cache_read_tokens), 0), COALESCE(SUM(input_tokens), 0) FROM session_metrics {current_where}"
+        "SELECT COALESCE(SUM(session_metrics.cache_read_tokens), 0), COALESCE(SUM(session_metrics.input_tokens), 0) FROM session_metrics{ws_join} {current_where}{ws_filter}"
     );
-    let (cache_read_sum, input_tokens_sum): (i64, i64) =
-        conn.query_row(&cache_sql, [], |row| {
-            Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?))
-        })?;
+    let (cache_read_sum, input_tokens_sum) = query_single_row_i64_i64(conn, &cache_sql, dashboard_id)?;
 
     let cache_hit_ratio = if cache_read_sum + input_tokens_sum > 0 {
         cache_read_sum as f64 / (cache_read_sum + input_tokens_sum) as f64 * 100.0
@@ -63,12 +124,9 @@ pub fn query_usage_stats(
         Some((prev_filter, _)) => {
             let prev_where = format!("WHERE {prev_filter}");
             let prev_sql = format!(
-                "SELECT COALESCE(SUM(cost_usd), 0.0), COUNT(*) FROM session_metrics {prev_where}"
+                "SELECT COALESCE(SUM(session_metrics.cost_usd), 0.0), COUNT(*) FROM session_metrics{ws_join} {prev_where}{ws_filter}"
             );
-            let (prev_cost, prev_count): (f64, i64) =
-                conn.query_row(&prev_sql, [], |row| {
-                    Ok((row.get::<_, f64>(0)?, row.get::<_, i64>(1)?))
-                })?;
+            let (prev_cost, prev_count) = query_single_row_f64_i64(conn, &prev_sql, dashboard_id)?;
 
             let delta_cost = if prev_cost > 0.0 {
                 Some((total_cost_usd - prev_cost) / prev_cost * 100.0)
@@ -98,54 +156,62 @@ pub fn query_usage_stats(
 
 pub fn query_daily_costs(
     conn: &Connection,
-    period: MetricsPeriod,
+    period: &MetricsPeriod,
+    dashboard_id: Option<&str>,
 ) -> Result<Vec<DailyCost>, rusqlite::Error> {
     let date_filter = period.to_sql_date_filter();
-    let where_clause = period_where_clause(date_filter, "started_at");
+    let where_clause = period_where_clause(date_filter.as_deref(), "started_at");
+    let (ws_join, ws_filter) = workspace_join_session_metrics(dashboard_id);
 
     let sql = format!(
-        "SELECT date(started_at) as day, COALESCE(SUM(cost_usd), 0), COUNT(*)
-         FROM session_metrics
-         {where_clause}
+        "SELECT date(session_metrics.started_at) as day, COALESCE(SUM(session_metrics.cost_usd), 0), COUNT(*)
+         FROM session_metrics{ws_join}
+         {where_clause}{ws_filter}
          GROUP BY day
          ORDER BY day ASC"
     );
 
     let mut stmt = conn.prepare(&sql)?;
-    let rows = stmt.query_map([], |row| {
+    let mapper = |row: &rusqlite::Row| {
         Ok(DailyCost {
             date: row.get::<_, String>(0)?,
             cost_usd: row.get::<_, f64>(1)?,
             session_count: row.get::<_, i64>(2)?,
         })
-    })?;
+    };
 
-    rows.collect()
+    if let Some(did) = dashboard_id {
+        stmt.query_map(&[(":dashboard_id", did)], mapper)?.collect()
+    } else {
+        stmt.query_map([], mapper)?.collect()
+    }
 }
 
 pub fn query_activity_breakdown(
     conn: &Connection,
-    period: MetricsPeriod,
+    period: &MetricsPeriod,
+    dashboard_id: Option<&str>,
 ) -> Result<Vec<ActivityBreakdown>, rusqlite::Error> {
     let date_filter = period.to_sql_date_filter();
-    let where_clause = period_where_clause(date_filter, "timestamp");
+    let where_clause = period_where_clause(date_filter.as_deref(), "timestamp");
+    let (ws_join, ws_filter) = workspace_join_turn_metrics(dashboard_id);
 
     let sql = format!(
-        "SELECT category,
-                COALESCE(SUM(cost_usd), 0),
+        "SELECT turn_metrics.category,
+                COALESCE(SUM(turn_metrics.cost_usd), 0),
                 COUNT(*),
-                CASE WHEN SUM(CASE WHEN has_edits = 1 THEN 1 ELSE 0 END) > 0
-                     THEN CAST(SUM(CASE WHEN has_edits = 1 AND retry_count = 0 THEN 1 ELSE 0 END) AS REAL) /
-                          SUM(CASE WHEN has_edits = 1 THEN 1 ELSE 0 END) * 100
+                CASE WHEN SUM(CASE WHEN turn_metrics.has_edits = 1 THEN 1 ELSE 0 END) > 0
+                     THEN CAST(SUM(CASE WHEN turn_metrics.has_edits = 1 AND turn_metrics.retry_count = 0 THEN 1 ELSE 0 END) AS REAL) /
+                          SUM(CASE WHEN turn_metrics.has_edits = 1 THEN 1 ELSE 0 END) * 100
                      ELSE 0 END
-         FROM turn_metrics
-         {where_clause}
-         GROUP BY category
-         ORDER BY SUM(cost_usd) DESC"
+         FROM turn_metrics{ws_join}
+         {where_clause}{ws_filter}
+         GROUP BY turn_metrics.category
+         ORDER BY SUM(turn_metrics.cost_usd) DESC"
     );
 
     let mut stmt = conn.prepare(&sql)?;
-    let rows = stmt.query_map([], |row| {
+    let mapper = |row: &rusqlite::Row| {
         let category: ActivityCategory = row.get(0)?;
         Ok(ActivityBreakdown {
             category,
@@ -153,31 +219,41 @@ pub fn query_activity_breakdown(
             turn_count: row.get::<_, i64>(2)?,
             one_shot_percent: row.get::<_, f64>(3)?,
         })
-    })?;
+    };
 
-    rows.collect()
+    if let Some(did) = dashboard_id {
+        stmt.query_map(&[(":dashboard_id", did)], mapper)?.collect()
+    } else {
+        stmt.query_map([], mapper)?.collect()
+    }
 }
 
 pub fn query_top_sessions(
     conn: &Connection,
-    period: MetricsPeriod,
+    period: &MetricsPeriod,
+    dashboard_id: Option<&str>,
     limit: usize,
 ) -> Result<Vec<TopSession>, rusqlite::Error> {
     let date_filter = period.to_sql_date_filter();
-    let where_clause = period_where_clause(date_filter, "sm.started_at");
+    let where_clause = period_where_clause(date_filter.as_deref(), "sm.started_at");
+
+    let ws_filter = match dashboard_id {
+        Some(_) => " AND i.dashboard_id = :dashboard_id",
+        None => "",
+    };
 
     let sql = format!(
         "SELECT sm.session_id, i.name, i.github_issue_number, sm.cost_usd, sm.turn_count, sm.tool_call_count, sm.started_at
          FROM session_metrics sm
          LEFT JOIN sessions s ON sm.session_id = s.id
          LEFT JOIN issues i ON s.issue_id = i.id
-         {where_clause}
+         {where_clause}{ws_filter}
          ORDER BY sm.cost_usd DESC
          LIMIT {limit}"
     );
 
     let mut stmt = conn.prepare(&sql)?;
-    let rows = stmt.query_map([], |row| {
+    let mapper = |row: &rusqlite::Row| {
         Ok(TopSession {
             session_id: row.get::<_, String>(0)?,
             issue_name: row.get::<_, Option<String>>(1)?,
@@ -187,48 +263,59 @@ pub fn query_top_sessions(
             tool_call_count: row.get::<_, i64>(5)?,
             started_at: row.get::<_, String>(6)?,
         })
-    })?;
+    };
 
-    rows.collect()
+    if let Some(did) = dashboard_id {
+        stmt.query_map(&[(":dashboard_id", did)], mapper)?.collect()
+    } else {
+        stmt.query_map([], mapper)?.collect()
+    }
 }
 
 pub fn query_tool_usage(
     conn: &Connection,
-    period: MetricsPeriod,
+    period: &MetricsPeriod,
+    dashboard_id: Option<&str>,
     limit: usize,
 ) -> Result<Vec<ToolUsageBreakdown>, rusqlite::Error> {
     let date_filter = period.to_sql_date_filter();
-    let where_clause = period_where_clause(date_filter, "timestamp");
+    let where_clause = period_where_clause(date_filter.as_deref(), "timestamp");
+    let (ws_join, ws_filter) = workspace_join_tool_usage(dashboard_id);
 
     let sql = format!(
-        "SELECT tool_name, COUNT(*) as cnt
-         FROM tool_usage
-         {where_clause}
-         GROUP BY tool_name
+        "SELECT tool_usage.tool_name, COUNT(*) as cnt
+         FROM tool_usage{ws_join}
+         {where_clause}{ws_filter}
+         GROUP BY tool_usage.tool_name
          ORDER BY cnt DESC
          LIMIT {limit}"
     );
 
     let mut stmt = conn.prepare(&sql)?;
-    let rows = stmt.query_map([], |row| {
+    let mapper = |row: &rusqlite::Row| {
         Ok(ToolUsageBreakdown {
             tool_name: row.get::<_, String>(0)?,
             call_count: row.get::<_, i64>(1)?,
         })
-    })?;
+    };
 
-    rows.collect()
+    if let Some(did) = dashboard_id {
+        stmt.query_map(&[(":dashboard_id", did)], mapper)?.collect()
+    } else {
+        stmt.query_map([], mapper)?.collect()
+    }
 }
 
 pub fn query_usage_dashboard(
     conn: &Connection,
-    period: MetricsPeriod,
+    period: &MetricsPeriod,
+    dashboard_id: Option<&str>,
 ) -> Result<UsageDashboardData, rusqlite::Error> {
-    let stats = query_usage_stats(conn, period)?;
-    let daily_costs = query_daily_costs(conn, period)?;
-    let activity_breakdown = query_activity_breakdown(conn, period)?;
-    let top_sessions = query_top_sessions(conn, period, 5)?;
-    let tool_usage = query_tool_usage(conn, period, 10)?;
+    let stats = query_usage_stats(conn, period, dashboard_id)?;
+    let daily_costs = query_daily_costs(conn, period, dashboard_id)?;
+    let activity_breakdown = query_activity_breakdown(conn, period, dashboard_id)?;
+    let top_sessions = query_top_sessions(conn, period, dashboard_id, 5)?;
+    let tool_usage = query_tool_usage(conn, period, dashboard_id, 10)?;
 
     Ok(UsageDashboardData {
         stats,
@@ -236,6 +323,7 @@ pub fn query_usage_dashboard(
         activity_breakdown,
         top_sessions,
         tool_usage,
+        pricing_available: true,
     })
 }
 
@@ -325,6 +413,30 @@ mod tests {
         .unwrap();
     }
 
+    fn insert_dashboard(conn: &rusqlite::Connection, id: &str) {
+        conn.execute(
+            "INSERT INTO dashboards (id, name, type) VALUES (?1, 'Test', 'repo')",
+            [id],
+        )
+        .unwrap();
+    }
+
+    fn insert_issue(conn: &rusqlite::Connection, id: &str, dashboard_id: &str) {
+        conn.execute(
+            "INSERT INTO issues (id, dashboard_id, name) VALUES (?1, ?2, 'Test Issue')",
+            rusqlite::params![id, dashboard_id],
+        )
+        .unwrap();
+    }
+
+    fn link_session_to_issue(conn: &rusqlite::Connection, session_id: &str, issue_id: &str) {
+        conn.execute(
+            "UPDATE sessions SET issue_id = ?1 WHERE id = ?2",
+            rusqlite::params![issue_id, session_id],
+        )
+        .unwrap();
+    }
+
     #[test]
     fn usage_stats_totals_are_correct() {
         let conn = setup_test_database();
@@ -335,7 +447,7 @@ mod tests {
         insert_session_metrics(&conn, "s1", 1.5, 1000, 200, 3, 5, 10, 20, "2026-05-01T10:00:00");
         insert_session_metrics(&conn, "s2", 2.5, 2000, 800, 2, 4, 8, 16, "2026-05-02T11:00:00");
 
-        let stats = query_usage_stats(&conn, MetricsPeriod::All).unwrap();
+        let stats = query_usage_stats(&conn, &MetricsPeriod::All, None).unwrap();
 
         assert!((stats.total_cost_usd - 4.0).abs() < 1e-9);
         assert_eq!(stats.session_count, 2);
@@ -347,7 +459,7 @@ mod tests {
     #[test]
     fn usage_stats_empty_returns_zeros() {
         let conn = setup_test_database();
-        let stats = query_usage_stats(&conn, MetricsPeriod::All).unwrap();
+        let stats = query_usage_stats(&conn, &MetricsPeriod::All, None).unwrap();
         assert_eq!(stats.total_cost_usd, 0.0);
         assert_eq!(stats.session_count, 0);
         assert_eq!(stats.one_shot_rate, 0.0);
@@ -367,7 +479,7 @@ mod tests {
         insert_session_metrics(&conn, "s2", 2.0, 0, 0, 0, 0, 1, 0, "2026-05-01T14:00:00");
         insert_session_metrics(&conn, "s3", 3.0, 0, 0, 0, 0, 1, 0, "2026-05-02T09:00:00");
 
-        let daily = query_daily_costs(&conn, MetricsPeriod::All).unwrap();
+        let daily = query_daily_costs(&conn, &MetricsPeriod::All, None).unwrap();
 
         assert_eq!(daily.len(), 2);
         assert_eq!(daily[0].date, "2026-05-01");
@@ -420,7 +532,7 @@ mod tests {
             "2026-05-01T08:03:00",
         );
 
-        let breakdown = query_activity_breakdown(&conn, MetricsPeriod::All).unwrap();
+        let breakdown = query_activity_breakdown(&conn, &MetricsPeriod::All, None).unwrap();
 
         assert_eq!(breakdown.len(), 2);
 
@@ -451,7 +563,7 @@ mod tests {
         insert_tool_usage(&conn, "tu2", "s1", "Edit", "2026-05-01T08:02:00");
         insert_tool_usage(&conn, "tu3", "s1", "Bash", "2026-05-01T08:03:00");
 
-        let usage = query_tool_usage(&conn, MetricsPeriod::All, 10).unwrap();
+        let usage = query_tool_usage(&conn, &MetricsPeriod::All, None, 10).unwrap();
 
         assert_eq!(usage.len(), 2);
         assert_eq!(usage[0].tool_name, "Edit");
@@ -472,7 +584,7 @@ mod tests {
         insert_session_metrics(&conn, "s2", 5.0, 0, 0, 0, 0, 8, 12, "2026-05-01T09:00:00");
         insert_session_metrics(&conn, "s3", 3.0, 0, 0, 0, 0, 4, 7, "2026-05-01T10:00:00");
 
-        let top = query_top_sessions(&conn, MetricsPeriod::All, 5).unwrap();
+        let top = query_top_sessions(&conn, &MetricsPeriod::All, None, 5).unwrap();
 
         assert_eq!(top.len(), 3);
         assert_eq!(top[0].session_id, "s2");
@@ -490,12 +602,60 @@ mod tests {
         insert_turn_metrics(&conn, "t1", "s1", 0, "coding", 1.0, 1, 0, "2026-05-01T08:01:00");
         insert_tool_usage(&conn, "tu1", "s1", "Read", "2026-05-01T08:01:00");
 
-        let dashboard = query_usage_dashboard(&conn, MetricsPeriod::All).unwrap();
+        let dashboard = query_usage_dashboard(&conn, &MetricsPeriod::All, None).unwrap();
 
         assert!((dashboard.stats.total_cost_usd - 2.0).abs() < 1e-9);
         assert_eq!(dashboard.daily_costs.len(), 1);
         assert_eq!(dashboard.activity_breakdown.len(), 1);
         assert_eq!(dashboard.top_sessions.len(), 1);
         assert_eq!(dashboard.tool_usage.len(), 1);
+        assert!(dashboard.pricing_available);
+    }
+
+    #[test]
+    fn workspace_scoping_filters_by_dashboard() {
+        let conn = setup_test_database();
+
+        insert_dashboard(&conn, "d1");
+        insert_dashboard(&conn, "d2");
+        insert_issue(&conn, "i1", "d1");
+        insert_issue(&conn, "i2", "d2");
+
+        insert_session(&conn, "s1", "2026-05-01T08:00:00");
+        insert_session(&conn, "s2", "2026-05-01T09:00:00");
+        link_session_to_issue(&conn, "s1", "i1");
+        link_session_to_issue(&conn, "s2", "i2");
+
+        insert_session_metrics(&conn, "s1", 1.0, 100, 0, 0, 0, 1, 0, "2026-05-01T08:00:00");
+        insert_session_metrics(&conn, "s2", 3.0, 200, 0, 0, 0, 1, 0, "2026-05-01T09:00:00");
+
+        let global = query_usage_stats(&conn, &MetricsPeriod::All, None).unwrap();
+        assert!((global.total_cost_usd - 4.0).abs() < 1e-9);
+        assert_eq!(global.session_count, 2);
+
+        let scoped = query_usage_stats(&conn, &MetricsPeriod::All, Some("d1")).unwrap();
+        assert!((scoped.total_cost_usd - 1.0).abs() < 1e-9);
+        assert_eq!(scoped.session_count, 1);
+    }
+
+    #[test]
+    fn custom_period_filters_date_range() {
+        let conn = setup_test_database();
+
+        insert_session(&conn, "s1", "2026-05-01T08:00:00");
+        insert_session(&conn, "s2", "2026-05-05T09:00:00");
+        insert_session(&conn, "s3", "2026-05-10T10:00:00");
+
+        insert_session_metrics(&conn, "s1", 1.0, 0, 0, 0, 0, 1, 0, "2026-05-01T08:00:00");
+        insert_session_metrics(&conn, "s2", 2.0, 0, 0, 0, 0, 1, 0, "2026-05-05T09:00:00");
+        insert_session_metrics(&conn, "s3", 3.0, 0, 0, 0, 0, 1, 0, "2026-05-10T10:00:00");
+
+        let custom = MetricsPeriod::Custom {
+            start: "2026-05-01".to_string(),
+            end: "2026-05-05".to_string(),
+        };
+        let stats = query_usage_stats(&conn, &custom, None).unwrap();
+        assert!((stats.total_cost_usd - 3.0).abs() < 1e-9);
+        assert_eq!(stats.session_count, 2);
     }
 }

--- a/src-tauri/src/models/metrics.rs
+++ b/src-tauri/src/models/metrics.rs
@@ -38,7 +38,7 @@ impl_sql_enum!(ActivityCategory {
 });
 
 /// Time period filter for dashboard queries.
-#[derive(Debug, Clone, Copy, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum MetricsPeriod {
     Today,
@@ -46,38 +46,42 @@ pub enum MetricsPeriod {
     Month,
     ThirtyDays,
     All,
+    Custom { start: String, end: String },
 }
 
 impl MetricsPeriod {
-    pub fn to_sql_date_filter(&self) -> Option<&'static str> {
+    pub fn to_sql_date_filter(&self) -> Option<String> {
         match self {
-            Self::Today => Some("date(started_at) = date('now')"),
-            Self::Week => Some("started_at >= datetime('now', '-7 days')"),
-            Self::ThirtyDays => Some("started_at >= datetime('now', '-30 days')"),
-            Self::Month => Some("started_at >= datetime('now', 'start of month')"),
+            Self::Today => Some("date(started_at) = date('now')".to_string()),
+            Self::Week => Some("started_at >= datetime('now', '-7 days')".to_string()),
+            Self::ThirtyDays => Some("started_at >= datetime('now', '-30 days')".to_string()),
+            Self::Month => Some("started_at >= datetime('now', 'start of month')".to_string()),
             Self::All => None,
+            Self::Custom { start, end } => Some(format!(
+                "date(started_at) >= date('{start}') AND date(started_at) <= date('{end}')"
+            )),
         }
     }
 
-    pub fn previous_period_filter(&self) -> Option<(&'static str, &'static str)> {
+    pub fn previous_period_filter(&self) -> Option<(String, String)> {
         match self {
             Self::Today => Some((
-                "date(started_at) = date('now', '-1 day')",
-                "date(started_at) = date('now')",
+                "date(started_at) = date('now', '-1 day')".to_string(),
+                "date(started_at) = date('now')".to_string(),
             )),
             Self::Week => Some((
-                "started_at >= datetime('now', '-14 days') AND started_at < datetime('now', '-7 days')",
-                "started_at >= datetime('now', '-7 days')",
+                "started_at >= datetime('now', '-14 days') AND started_at < datetime('now', '-7 days')".to_string(),
+                "started_at >= datetime('now', '-7 days')".to_string(),
             )),
             Self::ThirtyDays => Some((
-                "started_at >= datetime('now', '-60 days') AND started_at < datetime('now', '-30 days')",
-                "started_at >= datetime('now', '-30 days')",
+                "started_at >= datetime('now', '-60 days') AND started_at < datetime('now', '-30 days')".to_string(),
+                "started_at >= datetime('now', '-30 days')".to_string(),
             )),
             Self::Month => Some((
-                "started_at >= datetime('now', 'start of month', '-1 month') AND started_at < datetime('now', 'start of month')",
-                "started_at >= datetime('now', 'start of month')",
+                "started_at >= datetime('now', 'start of month', '-1 month') AND started_at < datetime('now', 'start of month')".to_string(),
+                "started_at >= datetime('now', 'start of month')".to_string(),
             )),
-            Self::All => None,
+            Self::All | Self::Custom { .. } => None,
         }
     }
 }
@@ -151,4 +155,5 @@ pub struct UsageDashboardData {
     pub activity_breakdown: Vec<ActivityBreakdown>,
     pub top_sessions: Vec<TopSession>,
     pub tool_usage: Vec<ToolUsageBreakdown>,
+    pub pricing_available: bool,
 }

--- a/src-tauri/src/session/session_actor.rs
+++ b/src-tauri/src/session/session_actor.rs
@@ -7,8 +7,11 @@ use tauri::{AppHandle, Emitter, Manager};
 use tokio::sync::mpsc;
 
 use super::provider::{ActorCommand, ProviderAdapter, SessionEvent, SessionHandle};
+use crate::metrics::achievement_tracker;
+use crate::models::achievement::AchievementKind;
 use crate::models::session::SessionState;
 use crate::notification::service::{session_state_to_event_type, NotificationService};
+use crate::SharedPricingEngine;
 
 /// Payload emitted to the frontend via Tauri events.
 #[derive(Debug, Clone, Serialize, TS)]
@@ -44,6 +47,7 @@ pub async fn run_actor(
                         };
                         handle_event(&session_id, &exit_event, &app_handle, &database_connection);
                         update_session_ended(&session_id, &database_connection);
+                        handle_session_completion(&session_id, &app_handle, &database_connection).await;
                         break;
                     }
                 }
@@ -90,6 +94,7 @@ pub async fn run_actor(
                         };
                         handle_event(&session_id, &term_event, &app_handle, &database_connection);
                         update_session_ended(&session_id, &database_connection);
+                        handle_session_completion(&session_id, &app_handle, &database_connection).await;
                         break;
                     }
                     None => {
@@ -372,5 +377,124 @@ fn update_cli_session_id(
             log::error!("Failed to update cli_session_id for {session_id}: {e}");
         }
     }
+}
+
+// --- Session completion: pricing, achievements, events ---
+
+struct SessionMetricsSnapshot {
+    model: Option<String>,
+    input_tokens: i64,
+    output_tokens: i64,
+    cache_read_tokens: i64,
+    cache_write_tokens: i64,
+    duration_seconds: Option<f64>,
+}
+
+fn read_session_metrics_snapshot(
+    session_id: &str,
+    conn: &Connection,
+) -> Option<SessionMetricsSnapshot> {
+    conn.query_row(
+        "SELECT model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, duration_seconds \
+         FROM session_metrics WHERE session_id = ?1",
+        [session_id],
+        |row| {
+            Ok(SessionMetricsSnapshot {
+                model: row.get(0)?,
+                input_tokens: row.get(1)?,
+                output_tokens: row.get(2)?,
+                cache_read_tokens: row.get(3)?,
+                cache_write_tokens: row.get(4)?,
+                duration_seconds: row.get(5)?,
+            })
+        },
+    )
+    .ok()
+}
+
+async fn handle_session_completion(
+    session_id: &str,
+    app_handle: &AppHandle,
+    database_connection: &std::sync::Arc<StdMutex<Connection>>,
+) {
+    let snapshot = {
+        let Ok(conn) = database_connection.lock() else {
+            return;
+        };
+        read_session_metrics_snapshot(session_id, &conn)
+    };
+
+    let Some(snapshot) = snapshot else {
+        let _ = app_handle.emit("metrics-updated", session_id);
+        return;
+    };
+
+    if let Some(ref model) = snapshot.model {
+        if let Some(pricing_state) = app_handle.try_state::<SharedPricingEngine>() {
+            let result = {
+                let engine = pricing_state.lock().await;
+                engine.calculate_cost(
+                    model,
+                    snapshot.input_tokens as u64,
+                    snapshot.output_tokens as u64,
+                    snapshot.cache_read_tokens as u64,
+                    snapshot.cache_write_tokens as u64,
+                    false,
+                )
+            };
+
+            if result.pricing_available {
+                if let Ok(conn) = database_connection.lock() {
+                    let _ = conn.execute(
+                        "UPDATE session_metrics SET cost_usd = ?1 WHERE session_id = ?2",
+                        rusqlite::params![result.cost_usd, session_id],
+                    );
+                    let _ = conn.execute(
+                        "UPDATE sessions SET cost_usd = ?1 WHERE id = ?2",
+                        rusqlite::params![result.cost_usd, session_id],
+                    );
+                }
+            }
+        }
+    }
+
+    let newly_unlocked = {
+        let Ok(conn) = database_connection.lock() else {
+            let _ = app_handle.emit("metrics-updated", session_id);
+            return;
+        };
+
+        let cache_total = snapshot.cache_read_tokens + snapshot.input_tokens;
+        let cache_hit_ratio = if cache_total > 0 {
+            snapshot.cache_read_tokens as f64 / cache_total as f64 * 100.0
+        } else {
+            0.0
+        };
+
+        let cost: f64 = conn
+            .query_row(
+                "SELECT COALESCE(cost_usd, 0.0) FROM session_metrics WHERE session_id = ?1",
+                [session_id],
+                |row| row.get(0),
+            )
+            .unwrap_or(0.0);
+
+        achievement_tracker::check_session_achievements(
+            &conn,
+            cost,
+            snapshot.duration_seconds,
+            cache_hit_ratio,
+        )
+    };
+
+    let _ = app_handle.emit("metrics-updated", session_id);
+
+    for kind in &newly_unlocked {
+        emit_achievement_unlocked(kind, app_handle);
+    }
+}
+
+fn emit_achievement_unlocked(kind: &AchievementKind, app_handle: &AppHandle) {
+    let _ = app_handle.emit("achievement-unlocked", kind.as_str());
 }
 

--- a/src/lib/tauri_mock.ts
+++ b/src/lib/tauri_mock.ts
@@ -120,6 +120,13 @@ const MOCK_COMMAND_HANDLERS: Record<string, MockHandler> = {
 	get_usage_dashboard: () => MOCK_USAGE_DASHBOARD,
 	get_achievements: () => MOCK_ACHIEVEMENTS,
 	import_historical_sessions: () => MOCK_IMPORT_SUMMARY,
+	get_exchange_rates: () => ({
+		EUR: 0.92,
+		GBP: 0.79,
+		CZK: 22.5,
+		JPY: 149.8,
+		CAD: 1.36,
+	}),
 
 	// ─── Dialog ──────────────────────────────────────────────────────────────
 	pick_folder: () => 'C:/mock/selected-folder',

--- a/src/lib/tauri_mock_data.ts
+++ b/src/lib/tauri_mock_data.ts
@@ -1048,6 +1048,7 @@ export const MOCK_USAGE_DASHBOARD = {
 		{ tool_name: 'mcp__svelte', call_count: 12 },
 		{ tool_name: 'TaskCreate', call_count: 8 },
 	],
+	pricing_available: true,
 };
 
 export const MOCK_ACHIEVEMENTS = [

--- a/src/lib/types/generated/UsageDashboardData.ts
+++ b/src/lib/types/generated/UsageDashboardData.ts
@@ -8,4 +8,4 @@ import type { UsageStats } from "./UsageStats";
 /**
  * Full dashboard data returned by get_usage_dashboard.
  */
-export type UsageDashboardData = { stats: UsageStats, daily_costs: Array<DailyCost>, activity_breakdown: Array<ActivityBreakdown>, top_sessions: Array<TopSession>, tool_usage: Array<ToolUsageBreakdown>, };
+export type UsageDashboardData = { stats: UsageStats, daily_costs: Array<DailyCost>, activity_breakdown: Array<ActivityBreakdown>, top_sessions: Array<TopSession>, tool_usage: Array<ToolUsageBreakdown>, pricing_available: boolean, };


### PR DESCRIPTION
## Summary

Foundation backend work for PRD #93 Metrics v2. Wires all dead code from PR #241 into live code paths and adds new capabilities.

- **PricingEngine**: `PricingResult` with `pricing_available` flag, DB overrides from `model_pricing_cache`, OpenRouter API fallback, DB-driven fast-mode multipliers (replaces hardcoded constant)
- **Session completion wiring**: recalculates `cost_usd` via PricingEngine, checks session achievements (GreenThumb, SpeedRunner, CacheMaster, BigSpender), emits `metrics-updated` and `achievement-unlocked` Tauri events
- **Issue creation wiring**: checks issue achievements (FirstSeed, Planted10, Planted50), emits `achievement-unlocked` event
- **Currency module**: Frankfurter API client (`api.frankfurter.dev`) with 24h file-cached exchange rates, new `get_exchange_rates` Tauri command
- **Workspace scoping**: `dashboard_id` parameter on `get_usage_dashboard` and all 5 query functions with JOIN chain through `sessions → issues`
- **Custom period**: `MetricsPeriod::Custom { start, end }` variant for arbitrary date range queries
- **Schema**: 3 new indexes (`turn_metrics(timestamp)`, `tool_usage(timestamp)`, `session_metrics(cost_usd DESC)`), `fast_mode_multiplier` + `source` columns on `model_pricing_cache`
- **Cleanup**: removed `#[allow(dead_code)]` from all 3 metrics modules

Fixes #247

## Test plan

- [x] 465 Rust unit tests pass (0 failures)
- [x] `cargo check` clean (no warnings with `deny(dead_code)`)
- [x] `pnpm check:fast` clean (prettier + oxlint)
- [x] `pnpm check:fallow` regression check passed
- [x] `svelte-check` typecheck passed (0 errors)
- [x] New tests: DB overrides priority, fast-mode multiplier from DB, unknown model returns `pricing_unavailable`, workspace scoping filters by dashboard, custom period date range
- [ ] Manual: `pnpm db:reset` + `pnpm tauri dev` → verify session completion writes real `cost_usd`
- [ ] Manual: create issue → verify achievement progress increments