### PR TITLE
fix: bug fixes and quick wins from manual testing

### DIFF
--- a/src/lib/components/BatchActionToolbar.svelte
+++ b/src/lib/components/BatchActionToolbar.svelte
@@ -176,13 +176,12 @@
 								<Button
 									{...props}
 									variant="ghost"
-									size="sm"
+									size="icon-sm"
 									onclick={onBatchPrune}
 									disabled={!hasActiveWorktrees}
 									aria-label="Clean selected worktrees"
 								>
 									<ScissorsIcon />
-									Clean Selected Worktrees
 								</Button>
 							{/snippet}
 						</Tooltip.Trigger>
@@ -210,12 +209,11 @@
 							<Button
 								{...props}
 								variant="ghost"
-								size="sm"
+								size="icon-sm"
 								onclick={onBatchPrune}
 								aria-label="Clean up worktrees"
 							>
 								<ScissorsIcon />
-								Clean Up Worktrees
 							</Button>
 						{/snippet}
 					</Tooltip.Trigger>

--- a/src/lib/components/DashboardEditDialog.svelte
+++ b/src/lib/components/DashboardEditDialog.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { untrack } from 'svelte';
 	import * as m from '$lib/paraglide/messages.js';
 	import type { UpdateDashboardRequest } from '$lib/modules/board';
 	import type { Dashboard } from '$lib/types/generated';
@@ -8,8 +9,10 @@
 	import { Label } from '$lib/components/ui/label/index.js';
 	import { ColorPickerContent } from '$lib/components/color-picker/index.js';
 	import { WORKSPACE_ACCENT_PALETTE } from '$lib/components/color-picker/color_utils.js';
+	import { useVersionControl } from '$lib/modules/version-control';
 	import PathInput from './PathInput.svelte';
 	import RepoCombobox from './RepoCombobox.svelte';
+	import GhSetupBanner from './GhSetupBanner.svelte';
 	import { buildUpdateDashboardRequest } from './dialog_helpers.js';
 
 	interface Props {
@@ -20,6 +23,8 @@
 	}
 
 	let { dashboard, onClose, onUpdate, onDelete }: Props = $props();
+
+	const versionControl = useVersionControl();
 
 	let name = $state('');
 	let githubRepo = $state('');
@@ -33,13 +38,15 @@
 
 	$effect(() => {
 		if (dashboard !== null) {
-			name = dashboard.name;
-			githubRepo = dashboard.github_repo ?? '';
-			localFolder = dashboard.local_folder ?? '';
-			defaultBaseBranch = dashboard.default_base_branch ?? '';
-			worktreeParentFolder = dashboard.worktree_parent_folder ?? '';
-			accentColor = dashboard.accent_color ?? WORKSPACE_ACCENT_PALETTE[0];
-			confirmDelete = false;
+			untrack(() => {
+				name = dashboard!.name;
+				githubRepo = dashboard!.github_repo ?? '';
+				localFolder = dashboard!.local_folder ?? '';
+				defaultBaseBranch = dashboard!.default_base_branch ?? '';
+				worktreeParentFolder = dashboard!.worktree_parent_folder ?? '';
+				accentColor = dashboard!.accent_color ?? WORKSPACE_ACCENT_PALETTE[0];
+				confirmDelete = false;
+			});
 		}
 	});
 
@@ -104,6 +111,8 @@
 					</div>
 
 					{#if dashboard.type === 'repo'}
+						<GhSetupBanner availability={versionControl.ghAvailability} />
+
 						<div class="flex flex-col gap-1.5">
 							<Label for="edit-dashboard-github-repo"
 								>{m.dashboard_field_github_repo()}</Label

--- a/src/lib/components/IssueCard.svelte
+++ b/src/lib/components/IssueCard.svelte
@@ -412,28 +412,26 @@
 			</div>
 
 			<!-- Row 2: GitHub issue badge + PR badge -->
-			{#if cache?.github_issue_state != null || cache?.pr_state != null}
-				<div class="flex flex-wrap items-center gap-1">
-					{#if cache?.github_issue_state}
-						<GitHubBadge
-							type="issue"
-							state={cache.github_issue_state}
-							url={issue.github_issue_url}
-							number={issue.github_issue_number}
-							disabled={!ghAvailable}
-						/>
-					{/if}
-					{#if cache?.pr_state}
-						<GitHubBadge
-							type="pr"
-							state={cache.pr_state}
-							url={cache.pr_url}
-							number={cache.pr_number}
-							disabled={!ghAvailable}
-						/>
-					{/if}
-				</div>
-			{/if}
+			<div class="flex min-h-[22px] flex-wrap items-center gap-1">
+				{#if cache?.github_issue_state}
+					<GitHubBadge
+						type="issue"
+						state={cache.github_issue_state}
+						url={issue.github_issue_url}
+						number={issue.github_issue_number}
+						disabled={!ghAvailable}
+					/>
+				{/if}
+				{#if cache?.pr_state}
+					<GitHubBadge
+						type="pr"
+						state={cache.pr_state}
+						url={cache.pr_url}
+						number={cache.pr_number}
+						disabled={!ghAvailable}
+					/>
+				{/if}
+			</div>
 
 			<!-- Row 3: GitHub issue labels (compacted: show first 3 + overflow count) -->
 			{#if issue.labels.length > 0}

--- a/src/lib/components/IssueCardContextMenu.svelte
+++ b/src/lib/components/IssueCardContextMenu.svelte
@@ -105,16 +105,18 @@
 					<ZapIcon class="size-4" />
 					Actions
 				</ContextMenu.SubTrigger>
-				<ContextMenu.SubContent alignOffset={-5} sideOffset={2}>
-					{#each allContextualActions as action (action.id)}
-						<ContextMenu.Item
-							disabled={action.disabled}
-							onclick={() => onContextualAction!(action.id)}
-						>
-							{ACTION_POOL[action.id].label}
-						</ContextMenu.Item>
-					{/each}
-				</ContextMenu.SubContent>
+				<ContextMenu.Portal>
+					<ContextMenu.SubContent alignOffset={0} sideOffset={10}>
+						{#each allContextualActions as action (action.id)}
+							<ContextMenu.Item
+								disabled={action.disabled}
+								onclick={() => onContextualAction!(action.id)}
+							>
+								{ACTION_POOL[action.id].label}
+							</ContextMenu.Item>
+						{/each}
+					</ContextMenu.SubContent>
+				</ContextMenu.Portal>
 			</ContextMenu.Sub>
 		{/if}
 
@@ -140,18 +142,20 @@
 				<PriorityIcon class="size-4" />
 				Priority
 			</ContextMenu.SubTrigger>
-			<ContextMenu.SubContent alignOffset={-5} sideOffset={2}>
-				{#each PRIORITY_OPTIONS as option (option.value)}
-					<ContextMenu.Item onclick={() => onChangePriority(issue.id, option.value)}>
-						{#if issue.priority === option.value}
-							<CheckIcon class="size-4" />
-						{:else}
-							<span class="inline-flex size-4 shrink-0"></span>
-						{/if}
-						{option.label()}
-					</ContextMenu.Item>
-				{/each}
-			</ContextMenu.SubContent>
+			<ContextMenu.Portal>
+				<ContextMenu.SubContent alignOffset={0} sideOffset={10}>
+					{#each PRIORITY_OPTIONS as option (option.value)}
+						<ContextMenu.Item onclick={() => onChangePriority(issue.id, option.value)}>
+							{#if issue.priority === option.value}
+								<CheckIcon class="size-4" />
+							{:else}
+								<span class="inline-flex size-4 shrink-0"></span>
+							{/if}
+							{option.label()}
+						</ContextMenu.Item>
+					{/each}
+				</ContextMenu.SubContent>
+			</ContextMenu.Portal>
 		</ContextMenu.Sub>
 
 		<!-- Change Color -->

--- a/src/lib/components/RepoCombobox.svelte
+++ b/src/lib/components/RepoCombobox.svelte
@@ -31,6 +31,7 @@
 	let loadingUserRepos = $state(false);
 	let searchingRemote = $state(false);
 	let searchDebounceTimer = $state<ReturnType<typeof setTimeout> | undefined>(undefined);
+	let inputRef = $state<HTMLInputElement | null>(null);
 
 	const localFiltered = $derived.by(() => {
 		if (searchValue === '') {
@@ -102,6 +103,10 @@
 
 	function handleOpenChangeComplete(isOpen: boolean) {
 		if (!isOpen) {
+			const typed = inputRef?.value.trim() ?? '';
+			if (typed !== '' && value !== typed) {
+				value = typed;
+			}
 			searchValue = '';
 			searchResults = [];
 		}
@@ -117,6 +122,7 @@
 >
 	<div class="relative">
 		<Combobox.Input
+			bind:ref={inputRef}
 			{id}
 			{placeholder}
 			oninput={handleInput}

--- a/src/lib/components/ui/context-menu/ContextMenu.stories.svelte
+++ b/src/lib/components/ui/context-menu/ContextMenu.stories.svelte
@@ -1,0 +1,179 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import * as ContextMenu from './index.js';
+	import ThemeDecorator from '$lib/storybook/ThemeDecorator.svelte';
+
+	const { Story } = defineMeta({
+		title: 'UI/ContextMenu',
+		component: ContextMenu.Root,
+		// @ts-expect-error — Storybook decorator typing doesn't match Svelte 5 Component type
+		decorators: [() => ThemeDecorator],
+		tags: ['autodocs'],
+	});
+</script>
+
+<script lang="ts">
+	import CopyIcon from '@lucide/svelte/icons/copy';
+	import ScissorsIcon from '@lucide/svelte/icons/scissors';
+	import ClipboardIcon from '@lucide/svelte/icons/clipboard';
+	import TrashIcon from '@lucide/svelte/icons/trash-2';
+
+	let checkboxChecked = $state(false);
+	let radioValue = $state('middle');
+</script>
+
+<Story name="Basic Menu">
+	{#snippet template()}
+		<ContextMenu.Root>
+			<ContextMenu.Trigger>
+				<div
+					class="flex h-36 w-72 items-center justify-center rounded-md border border-dashed border-border text-sm text-muted-foreground"
+				>
+					Right-click here
+				</div>
+			</ContextMenu.Trigger>
+			<ContextMenu.Content>
+				<ContextMenu.Item>Back</ContextMenu.Item>
+				<ContextMenu.Item>Forward</ContextMenu.Item>
+				<ContextMenu.Item>Reload</ContextMenu.Item>
+				<ContextMenu.Separator />
+				<ContextMenu.Item>View Source</ContextMenu.Item>
+				<ContextMenu.Item>Inspect</ContextMenu.Item>
+			</ContextMenu.Content>
+		</ContextMenu.Root>
+	{/snippet}
+</Story>
+
+<Story name="With Icons">
+	{#snippet template()}
+		<ContextMenu.Root>
+			<ContextMenu.Trigger>
+				<div
+					class="flex h-36 w-72 items-center justify-center rounded-md border border-dashed border-border text-sm text-muted-foreground"
+				>
+					Right-click here
+				</div>
+			</ContextMenu.Trigger>
+			<ContextMenu.Content>
+				<ContextMenu.Item>
+					<ScissorsIcon class="size-4" />
+					Cut
+					<ContextMenu.Shortcut>⌘X</ContextMenu.Shortcut>
+				</ContextMenu.Item>
+				<ContextMenu.Item>
+					<CopyIcon class="size-4" />
+					Copy
+					<ContextMenu.Shortcut>⌘C</ContextMenu.Shortcut>
+				</ContextMenu.Item>
+				<ContextMenu.Item>
+					<ClipboardIcon class="size-4" />
+					Paste
+					<ContextMenu.Shortcut>⌘V</ContextMenu.Shortcut>
+				</ContextMenu.Item>
+				<ContextMenu.Separator />
+				<ContextMenu.Item variant="destructive">
+					<TrashIcon class="size-4" />
+					Delete
+					<ContextMenu.Shortcut>⌫</ContextMenu.Shortcut>
+				</ContextMenu.Item>
+			</ContextMenu.Content>
+		</ContextMenu.Root>
+	{/snippet}
+</Story>
+
+<Story name="With Submenus">
+	{#snippet template()}
+		<ContextMenu.Root>
+			<ContextMenu.Trigger>
+				<div
+					class="flex h-36 w-72 items-center justify-center rounded-md border border-dashed border-border text-sm text-muted-foreground"
+				>
+					Right-click here
+				</div>
+			</ContextMenu.Trigger>
+			<ContextMenu.Content>
+				<ContextMenu.Item>New File</ContextMenu.Item>
+				<ContextMenu.Item>New Window</ContextMenu.Item>
+				<ContextMenu.Separator />
+				<ContextMenu.Sub>
+					<ContextMenu.SubTrigger>Share</ContextMenu.SubTrigger>
+					<ContextMenu.Portal>
+						<ContextMenu.SubContent>
+							<ContextMenu.Item>Email</ContextMenu.Item>
+							<ContextMenu.Item>Messages</ContextMenu.Item>
+							<ContextMenu.Item>Slack</ContextMenu.Item>
+						</ContextMenu.SubContent>
+					</ContextMenu.Portal>
+				</ContextMenu.Sub>
+				<ContextMenu.Separator />
+				<ContextMenu.Item>Settings</ContextMenu.Item>
+			</ContextMenu.Content>
+		</ContextMenu.Root>
+	{/snippet}
+</Story>
+
+<Story name="Disabled Items">
+	{#snippet template()}
+		<ContextMenu.Root>
+			<ContextMenu.Trigger>
+				<div
+					class="flex h-36 w-72 items-center justify-center rounded-md border border-dashed border-border text-sm text-muted-foreground"
+				>
+					Right-click here
+				</div>
+			</ContextMenu.Trigger>
+			<ContextMenu.Content>
+				<ContextMenu.Item>Undo</ContextMenu.Item>
+				<ContextMenu.Item>Redo</ContextMenu.Item>
+				<ContextMenu.Separator />
+				<ContextMenu.Item disabled>Cut</ContextMenu.Item>
+				<ContextMenu.Item disabled>Copy</ContextMenu.Item>
+				<ContextMenu.Item>Paste</ContextMenu.Item>
+			</ContextMenu.Content>
+		</ContextMenu.Root>
+	{/snippet}
+</Story>
+
+<Story name="Checkbox Items">
+	{#snippet template()}
+		<ContextMenu.Root>
+			<ContextMenu.Trigger>
+				<div
+					class="flex h-36 w-72 items-center justify-center rounded-md border border-dashed border-border text-sm text-muted-foreground"
+				>
+					Right-click here
+				</div>
+			</ContextMenu.Trigger>
+			<ContextMenu.Content>
+				<ContextMenu.CheckboxItem bind:checked={checkboxChecked}>
+					Show Minimap
+				</ContextMenu.CheckboxItem>
+				<ContextMenu.CheckboxItem checked={true}>Word Wrap</ContextMenu.CheckboxItem>
+				<ContextMenu.CheckboxItem checked={false}>Sticky Scroll</ContextMenu.CheckboxItem>
+			</ContextMenu.Content>
+		</ContextMenu.Root>
+	{/snippet}
+</Story>
+
+<Story name="Radio Items">
+	{#snippet template()}
+		<ContextMenu.Root>
+			<ContextMenu.Trigger>
+				<div
+					class="flex h-36 w-72 items-center justify-center rounded-md border border-dashed border-border text-sm text-muted-foreground"
+				>
+					Right-click here
+				</div>
+			</ContextMenu.Trigger>
+			<ContextMenu.Content>
+				<ContextMenu.Label>Panel Position</ContextMenu.Label>
+				<ContextMenu.Separator />
+				<ContextMenu.RadioGroup bind:value={radioValue}>
+					<ContextMenu.RadioItem value="top">Top</ContextMenu.RadioItem>
+					<ContextMenu.RadioItem value="middle">Middle</ContextMenu.RadioItem>
+					<ContextMenu.RadioItem value="bottom">Bottom</ContextMenu.RadioItem>
+				</ContextMenu.RadioGroup>
+			</ContextMenu.Content>
+		</ContextMenu.Root>
+	{/snippet}
+</Story>

--- a/src/lib/modules/toasts/mock_toast_bridge.test.ts
+++ b/src/lib/modules/toasts/mock_toast_bridge.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { registerMockToastBridge, showMockToast } from './mock_toast_bridge.js';
+
+describe('showMockToast', () => {
+	beforeEach(() => {
+		// Reset showFn to null before each test
+		registerMockToastBridge(null as unknown as (title: string, body: string) => void);
+	});
+
+	it('produces a toast for every rapid same-command call', () => {
+		const spy = vi.fn();
+		registerMockToastBridge(spy);
+
+		showMockToast('setup_worktree');
+		showMockToast('setup_worktree');
+
+		expect(spy).toHaveBeenCalledTimes(2);
+	});
+
+	it('no-ops when showFn is null', () => {
+		// showFn is null from beforeEach — should not throw
+		expect(() => showMockToast('setup_worktree')).not.toThrow();
+	});
+
+	it('uses fallback message for unknown commands', () => {
+		const spy = vi.fn();
+		registerMockToastBridge(spy);
+
+		showMockToast('unknown_command');
+
+		expect(spy).toHaveBeenCalledWith(
+			'Desktop app required',
+			'unknown_command is simulated in browser mode',
+		);
+	});
+
+	it('uses correct body for known commands', () => {
+		const spy = vi.fn();
+		registerMockToastBridge(spy);
+
+		showMockToast('setup_worktree');
+
+		expect(spy).toHaveBeenCalledWith(
+			'Desktop app required',
+			'Worktree setup is simulated in browser mode',
+		);
+	});
+});

--- a/src/lib/modules/toasts/mock_toast_bridge.ts
+++ b/src/lib/modules/toasts/mock_toast_bridge.ts
@@ -26,22 +26,10 @@ const COMMAND_BODIES: Record<string, string> = {
 	discover_ai_config: 'AI config discovery requires the desktop app',
 };
 
-// ─── Dedup ───────────────────────────────────────────────────────────────────
-
-const DEDUP_MS = 3000;
-const lastShown = new Map<string, number>();
-
 export function showMockToast(command: string): void {
 	if (showFn === null) {
 		return;
 	}
-
-	const now = Date.now();
-	const last = lastShown.get(command) ?? 0;
-	if (now - last < DEDUP_MS) {
-		return;
-	}
-	lastShown.set(command, now);
 
 	const body = COMMAND_BODIES[command] ?? `${command} is simulated in browser mode`;
 	showFn('Desktop app required', body);

--- a/src/lib/modules/visualization/forest_interaction.test.ts
+++ b/src/lib/modules/visualization/forest_interaction.test.ts
@@ -122,6 +122,17 @@ describe('resolveGlowOverlay', () => {
 		expect(result.glow.pulse).toBe(false);
 	});
 
+	it('suppresses active glow when a different tree is hovered', () => {
+		const result = resolveGlowOverlay(
+			createParams({
+				issueId: 'issue-1',
+				activeIssueId: 'issue-1',
+				hoveredIssueId: 'issue-2',
+			}),
+		);
+		expect(result).toEqual(STATE_DISABLED);
+	});
+
 	it('active takes priority over state-driven errored glow', () => {
 		const result = resolveGlowOverlay(
 			createParams({
@@ -187,6 +198,17 @@ describe('resolveGlowOverlay', () => {
 			}),
 		);
 		expect(result.glow.color).toBe(ISSUE_COLOR);
+	});
+
+	it('suppresses active glow when a different tree is hovered', () => {
+		const result = resolveGlowOverlay(
+			createParams({
+				issueId: 'issue-1',
+				activeIssueId: 'issue-1',
+				hoveredIssueId: 'issue-2',
+			}),
+		);
+		expect(result).toEqual(STATE_DISABLED);
 	});
 
 	it('batch-selected takes priority over state-driven overlay', () => {

--- a/src/lib/modules/visualization/forest_interaction.ts
+++ b/src/lib/modules/visualization/forest_interaction.ts
@@ -14,7 +14,20 @@ export interface ResolveGlowOverlayParams {
 
 export function resolveGlowOverlay(params: ResolveGlowOverlayParams): OverlayConfig {
 	// Priority: hover(1) > active(2) > batch-selected(3) > state-driven(4-6)
-	if (params.issueId === params.hoveredIssueId || params.issueId === params.activeIssueId) {
+	if (params.issueId === params.hoveredIssueId) {
+		return {
+			glow: {
+				enabled: true,
+				color: params.issueColor,
+				intensity: INTERACTION_GLOW_INTENSITY,
+				pulse: false,
+			},
+		};
+	}
+	if (
+		params.issueId === params.activeIssueId &&
+		(params.hoveredIssueId === null || params.hoveredIssueId === params.activeIssueId)
+	) {
 		return {
 			glow: {
 				enabled: true,


### PR DESCRIPTION
## Summary

Resolves #258 — collection of 7 small independent fixes from manual testing session.

- **Tree highlight bug**: suppress active glow when a different tree is hovered; active glow returns when hover ends
- **Toast deduplication removal**: each Tauri-only action click now produces a toast (removed 3s dedup window)
- **Prune button → icon-only**: both default and batch-selected prune buttons use `icon-sm` with tooltip
- **Badge row spacing**: always render badge row container with `min-h-[22px]` for consistent card layout
- **Context menu submenu offset**: wrap `SubContent` in `Portal` with `sideOffset={10}` for correct alignment
- **Repo picker persistence**: commit free-text on combobox close via input ref, guard `$effect` with `untrack`, add `GhSetupBanner` to `DashboardEditDialog`
- **ContextMenu Storybook stories**: basic, with icons, with submenus, disabled items, checkbox items, radio items

## Test plan

- [x] `resolveGlowOverlay` — new test: active tree suppressed when different hovered (TDD)
- [x] `showMockToast` — 4 tests: rapid calls, null showFn, fallback message, known command (TDD)
- [x] `pnpm check:all` — format, lint, fallow, typecheck, eslint all green
- [x] `pnpm test` — 918 tests pass (75 files)
- [x] Pre-commit hooks (oxlint + prettier) pass
- [x] Pre-push hooks (fallow + typecheck + tests) pass

Fixes #258