### PR TITLE
#264 fix(notification): resolve 5 critical sound engine bugs

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2566,6 +2566,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "minimp3-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e21c73734c69dc95696c9ed8926a2b393171d98b3f5f5935686a26a487ab9b90"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "minimp3_fixed"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b0f14e7e75da97ae396c2656b10262a3d4afa2ec98f35795630eff0c8b951b"
+dependencies = [
+ "minimp3-sys",
+ "slice-ring-buffer",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3843,6 +3863,7 @@ dependencies = [
  "cpal",
  "hound",
  "lewton",
+ "minimp3_fixed",
 ]
 
 [[package]]
@@ -4328,6 +4349,17 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slice-ring-buffer"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84ae312bda09b2368f79f985fdb4df4a0b5cbc75546b511303972d195f8c27d6"
+dependencies = [
+ "libc",
+ "mach2",
+ "winapi",
+]
 
 [[package]]
 name = "smallvec"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -35,7 +35,7 @@ thiserror = "2"
 sysinfo = "0.32"
 dirs = "6"
 chrono = { version = "0.4", features = ["serde"] }
-rodio = { version = "0.20", default-features = false, features = ["wav", "vorbis"] }
+rodio = { version = "0.20", default-features = false, features = ["wav", "vorbis", "minimp3"] }
 tauri-plugin-dialog = "2"
 tauri-plugin-notification = "2"
 ts-rs = { version = "10", features = ["serde-compat", "serde-json-impl"] }

--- a/src-tauri/src/commands/notification_commands.rs
+++ b/src-tauri/src/commands/notification_commands.rs
@@ -79,10 +79,10 @@ pub fn update_notification_config(
 }
 
 #[tauri::command]
-pub fn test_notification_sound(
+pub async fn test_notification_sound(
     app_handle: AppHandle,
     event_type: NotificationEventType,
-    state: State<DatabaseState>,
+    state: State<'_, DatabaseState>,
 ) -> Result<(), String> {
     let connection = state.read()?;
 
@@ -103,7 +103,6 @@ pub fn test_notification_sound(
     let resource_directory = service.resource_directory().clone();
     let app_data_directory = service.app_data_directory().clone();
 
-    // Load volume settings
     let global_volume: f64 = connection
         .query_row(
             "SELECT value FROM app_settings WHERE key = 'notification_volume'",
@@ -132,15 +131,11 @@ pub fn test_notification_sound(
     )
     .ok_or(format!("Sound file not found: {sound_file}"))?;
 
-    std::thread::spawn(move || {
-        if let Err(error) =
-            crate::notification::sound::play_sound_blocking(&resolved_path, volume)
-        {
-            log::error!("Test sound playback failed: {error}");
-        }
-    });
-
-    Ok(())
+    tokio::task::spawn_blocking(move || {
+        crate::notification::sound::play_sound_blocking(&resolved_path, volume)
+    })
+    .await
+    .map_err(|error| format!("Playback task failed: {error}"))?
 }
 
 // ─── Volume commands ─────────────────────────────────────────────────────────

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -120,7 +120,7 @@ pub fn run() {
                 resource_directory,
                 app_data_directory.clone(),
             ));
-            app.manage(playback_queue::start_playback_queue());
+            app.manage(playback_queue::LazyPlaybackQueue::new());
 
             // Auto-start discovery polling (3-second interval)
             let poller = app.state::<DiscoveryPoller>();
@@ -259,7 +259,7 @@ pub fn run() {
                 let poller = app_handle.state::<DiscoveryPoller>();
                 poller.stop();
 
-                let queue = app_handle.state::<playback_queue::PlaybackQueueHandle>();
+                let queue = app_handle.state::<playback_queue::LazyPlaybackQueue>();
                 queue.shutdown();
 
                 let pm = app_handle.state::<ProcessManager>();

--- a/src-tauri/src/notification/playback_queue.rs
+++ b/src-tauri/src/notification/playback_queue.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::OnceLock;
 use std::time::Instant;
 
 use tauri::async_runtime;
@@ -21,7 +22,7 @@ struct QueuedSound {
 
 enum QueueMessage {
     Enqueue {
-        path: PathBuf,
+        candidates: Vec<PathBuf>,
         volume: f32,
         event_type: NotificationEventType,
         session_id: String,
@@ -30,46 +31,133 @@ enum QueueMessage {
 }
 
 /// Handle to enqueue sounds into the playback queue.
-pub struct PlaybackQueueHandle {
+struct PlaybackQueueHandle {
     sender: mpsc::UnboundedSender<QueueMessage>,
 }
 
 impl PlaybackQueueHandle {
-    pub fn enqueue(
+    fn enqueue(
         &self,
-        path: PathBuf,
+        candidates: Vec<PathBuf>,
         volume: f32,
         event_type: NotificationEventType,
         session_id: String,
     ) {
         let _ = self.sender.send(QueueMessage::Enqueue {
-            path,
+            candidates,
             volume,
             event_type,
             session_id,
         });
     }
 
-    pub fn shutdown(&self) {
+    fn shutdown(&self) {
         let _ = self.sender.send(QueueMessage::Shutdown);
     }
 }
 
+/// Lazily-initialized playback queue that defers Tokio runtime access until first use.
+/// Safe to construct during Tauri setup (before the async runtime is available).
+pub struct LazyPlaybackQueue {
+    inner: OnceLock<PlaybackQueueHandle>,
+}
+
+impl LazyPlaybackQueue {
+    pub fn new() -> Self {
+        Self {
+            inner: OnceLock::new(),
+        }
+    }
+
+    pub fn enqueue(
+        &self,
+        candidates: Vec<PathBuf>,
+        volume: f32,
+        event_type: NotificationEventType,
+        session_id: String,
+    ) {
+        let handle = self.inner.get_or_init(start_playback_queue);
+        handle.enqueue(candidates, volume, event_type, session_id);
+    }
+
+    pub fn shutdown(&self) {
+        if let Some(handle) = self.inner.get() {
+            handle.shutdown();
+        }
+    }
+}
+
 /// Start the playback queue actor. Returns a handle for enqueuing sounds.
-pub fn start_playback_queue() -> PlaybackQueueHandle {
+fn start_playback_queue() -> PlaybackQueueHandle {
     let (sender, receiver) = mpsc::unbounded_channel();
     async_runtime::spawn(playback_queue_actor(receiver));
     PlaybackQueueHandle { sender }
 }
 
+fn pick_sound_index(candidate_count: usize, last_played: Option<usize>) -> usize {
+    if candidate_count <= 1 {
+        return 0;
+    }
+    let seed = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos() as usize;
+    match last_played {
+        Some(excluded) => {
+            let idx = seed % (candidate_count - 1);
+            if idx >= excluded {
+                idx + 1
+            } else {
+                idx
+            }
+        }
+        None => seed % candidate_count,
+    }
+}
+
+/// Extract pack prefix from the first candidate path (e.g. "grove" from ".../sounds/grove/file.wav").
+fn extract_pack_prefix(candidates: &[PathBuf]) -> String {
+    candidates
+        .first()
+        .and_then(|path| {
+            // Walk up from file to find a recognizable pack folder name
+            path.parent().and_then(|parent| {
+                parent
+                    .file_name()
+                    .map(|name| name.to_string_lossy().into_owned())
+            })
+        })
+        .unwrap_or_default()
+}
+
+fn pick_from_candidates(
+    candidates: &[PathBuf],
+    event_type: NotificationEventType,
+    rotation_map: &mut HashMap<(NotificationEventType, String), usize>,
+) -> Option<PathBuf> {
+    if candidates.is_empty() {
+        return None;
+    }
+    if candidates.len() == 1 {
+        return Some(candidates[0].clone());
+    }
+    let pack_prefix = extract_pack_prefix(candidates);
+    let rotation_key = (event_type, pack_prefix);
+    let last_played = rotation_map.get(&rotation_key).copied();
+    let selected = pick_sound_index(candidates.len(), last_played);
+    rotation_map.insert(rotation_key, selected);
+    Some(candidates[selected].clone())
+}
+
 async fn playback_queue_actor(mut receiver: mpsc::UnboundedReceiver<QueueMessage>) {
     let mut debounce_map: HashMap<(String, NotificationEventType), Instant> = HashMap::new();
+    let mut rotation_map: HashMap<(NotificationEventType, String), usize> = HashMap::new();
 
     while let Some(message) = receiver.recv().await {
         match message {
             QueueMessage::Shutdown => break,
             QueueMessage::Enqueue {
-                path,
+                candidates,
                 volume,
                 event_type,
                 session_id,
@@ -95,12 +183,18 @@ async fn playback_queue_actor(mut receiver: mpsc::UnboundedReceiver<QueueMessage
                     debounce_map.insert(debounce_key, now);
                 }
 
+                // Pick from candidates using rotation
+                let path = match pick_from_candidates(&candidates, event_type, &mut rotation_map) {
+                    Some(path) => path,
+                    None => continue,
+                };
+
                 // Collect any queued sounds into a batch
                 let mut batch = vec![QueuedSound { path, volume }];
                 while batch.len() < MAX_QUEUE_SIZE {
                     match receiver.try_recv() {
                         Ok(QueueMessage::Enqueue {
-                            path,
+                            candidates: next_candidates,
                             volume,
                             event_type: next_event_type,
                             session_id: next_session_id,
@@ -118,7 +212,13 @@ async fn playback_queue_actor(mut receiver: mpsc::UnboundedReceiver<QueueMessage
                                 }
                                 debounce_map.insert(debounce_key, now);
                             }
-                            batch.push(QueuedSound { path, volume });
+                            if let Some(path) = pick_from_candidates(
+                                &next_candidates,
+                                next_event_type,
+                                &mut rotation_map,
+                            ) {
+                                batch.push(QueuedSound { path, volume });
+                            }
                         }
                         Ok(QueueMessage::Shutdown) => return,
                         Err(_) => break,
@@ -172,6 +272,34 @@ fn debounce_window_for(event_type: NotificationEventType) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn lazy_playback_queue_creation_does_not_panic() {
+        let _queue = LazyPlaybackQueue::new();
+        // No Tokio runtime exists — this must not panic
+    }
+
+    #[test]
+    fn pick_sound_index_single_candidate_returns_zero() {
+        assert_eq!(pick_sound_index(1, None), 0);
+    }
+
+    #[test]
+    fn pick_sound_index_excludes_last_played() {
+        for _ in 0..50 {
+            let picked = pick_sound_index(3, Some(1));
+            assert_ne!(picked, 1, "Should never repeat last-played index");
+            assert!(picked < 3);
+        }
+    }
+
+    #[test]
+    fn pick_sound_index_no_exclusion_returns_valid_index() {
+        for _ in 0..50 {
+            let picked = pick_sound_index(5, None);
+            assert!(picked < 5);
+        }
+    }
 
     #[test]
     fn debounce_windows_correct() {

--- a/src-tauri/src/notification/service.rs
+++ b/src-tauri/src/notification/service.rs
@@ -11,8 +11,9 @@ use crate::models::notification::{
 };
 use crate::models::session::SessionState;
 
-use super::playback_queue::PlaybackQueueHandle;
+use super::playback_queue::LazyPlaybackQueue;
 use super::sound;
+use super::sound_pack;
 
 /// Manages notification dispatch across all channels (toast, sound, window attention).
 pub struct NotificationService {
@@ -126,36 +127,96 @@ impl NotificationService {
         database_connection: &std::sync::Arc<Mutex<Connection>>,
     ) {
         let global_volume = self.load_global_volume(database_connection);
-        let per_sound_volume = self.load_sound_volume_override(
-            event_type,
-            sound_file,
-            database_connection,
-        );
+        let per_sound_volume =
+            self.load_sound_volume_override(event_type, sound_file, database_connection);
         let volume = global_volume * per_sound_volume;
 
-        let resolved_path = sound::resolve_sound_path(
+        let candidates = self.resolve_sound_candidates(sound_file, event_type);
+
+        if candidates.is_empty() {
+            log::warn!("Sound file not found: {sound_file}");
+            return;
+        }
+
+        if let Some(queue) = app_handle.try_state::<LazyPlaybackQueue>() {
+            queue.enqueue(candidates, volume as f32, event_type, session_id.to_owned());
+        } else {
+            // Fallback: direct playback on thread (shouldn't happen in normal operation)
+            let volume_f32 = volume as f32;
+            let path = candidates.into_iter().next().unwrap();
+            std::thread::spawn(move || {
+                if let Err(error) = sound::play_sound_blocking(&path, volume_f32) {
+                    log::error!("Sound playback failed: {error}");
+                }
+            });
+        }
+    }
+
+    fn resolve_sound_candidates(
+        &self,
+        sound_file: &str,
+        event_type: NotificationEventType,
+    ) -> Vec<PathBuf> {
+        // Try to find all sounds in the same category from the pack
+        if let Some(pack_prefix) = sound_file.split('/').next() {
+            // Try bundled packs first
+            let bundled_pack_dir = self.resource_directory.join("sounds").join(pack_prefix);
+            if let Ok(manifest) = sound_pack::load_manifest(&bundled_pack_dir) {
+                if let Some(sounds) = manifest.categories.get(event_type.as_str()) {
+                    if sounds.len() > 1 {
+                        let resolved: Vec<PathBuf> = sounds
+                            .iter()
+                            .filter_map(|entry| {
+                                let relative = format!("{}/{}", pack_prefix, entry.file);
+                                sound::resolve_sound_path(
+                                    &relative,
+                                    &self.resource_directory,
+                                    &self.app_data_directory,
+                                )
+                            })
+                            .collect();
+                        if !resolved.is_empty() {
+                            return resolved;
+                        }
+                    }
+                }
+            }
+
+            // Try user-installed packs
+            let user_pack_dir = self
+                .app_data_directory
+                .join("sound-packs")
+                .join(pack_prefix);
+            if let Ok(manifest) = sound_pack::load_manifest(&user_pack_dir) {
+                if let Some(sounds) = manifest.categories.get(event_type.as_str()) {
+                    if sounds.len() > 1 {
+                        let resolved: Vec<PathBuf> = sounds
+                            .iter()
+                            .filter_map(|entry| {
+                                let relative = format!("{}/{}", pack_prefix, entry.file);
+                                sound::resolve_sound_path(
+                                    &relative,
+                                    &self.resource_directory,
+                                    &self.app_data_directory,
+                                )
+                            })
+                            .collect();
+                        if !resolved.is_empty() {
+                            return resolved;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Fallback: single resolved file
+        match sound::resolve_sound_path(
             sound_file,
             &self.resource_directory,
             &self.app_data_directory,
-        );
-
-        match resolved_path {
-            Some(path) => {
-                if let Some(queue) = app_handle.try_state::<PlaybackQueueHandle>() {
-                    queue.enqueue(path, volume as f32, event_type, session_id.to_owned());
-                } else {
-                    // Fallback: direct playback on thread (shouldn't happen in normal operation)
-                    let volume_f32 = volume as f32;
-                    std::thread::spawn(move || {
-                        if let Err(error) = sound::play_sound_blocking(&path, volume_f32) {
-                            log::error!("Sound playback failed: {error}");
-                        }
-                    });
-                }
-            }
-            None => {
-                log::warn!("Sound file not found: {sound_file}");
-            }
+        ) {
+            Some(path) => vec![path],
+            None => vec![],
         }
     }
 

--- a/src/lib/components/NotificationSettingsPanel.svelte
+++ b/src/lib/components/NotificationSettingsPanel.svelte
@@ -2,6 +2,7 @@
 	import * as m from '$lib/paraglide/messages.js';
 	import type { NotificationEventType } from '$lib/types/generated';
 	import { useNotifications, groupConfigsByTier } from '$lib/modules/notifications';
+	import { useToasts } from '$lib/modules/toasts/index.js';
 	import { onMount } from 'svelte';
 	import { Switch } from '$lib/components/ui/switch/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
@@ -13,6 +14,7 @@
 	import TrashIcon from '@lucide/svelte/icons/trash-2';
 
 	const notificationStore = useNotifications();
+	const toasts = useToasts();
 
 	const EVENT_LABELS: Record<NotificationEventType, () => string> = {
 		'session.start': () => m.notification_event_session_start(),
@@ -85,7 +87,11 @@
 		try {
 			await notificationStore.testNotificationSound(eventType);
 		} catch (error) {
-			console.error('Failed to test sound:', error);
+			toasts.show({
+				tone: 'danger',
+				title: 'Sound playback failed',
+				body: String(error),
+			});
 		}
 	}
 

--- a/src/lib/modules/toasts/mock_toast_bridge.test.ts
+++ b/src/lib/modules/toasts/mock_toast_bridge.test.ts
@@ -69,4 +69,12 @@ describe('showMockToast', () => {
 			'Running actions requires the desktop app',
 		);
 	});
+
+	it('shows toast for test_notification_sound', () => {
+		const calls: Array<{ title: string; body: string }> = [];
+		registerMockToastBridge((title, body) => calls.push({ title, body }));
+		showMockToast('test_notification_sound');
+		expect(calls).toHaveLength(1);
+		expect(calls[0].body).toContain('desktop app');
+	});
 });

--- a/src/lib/modules/toasts/mock_toast_bridge.ts
+++ b/src/lib/modules/toasts/mock_toast_bridge.ts
@@ -42,6 +42,7 @@ const COMMAND_BODIES: Record<string, string> = {
 	kill_workspace_process: 'Killing processes requires the desktop app',
 	github_device_flow_start: 'GitHub authentication requires the desktop app',
 	github_device_flow_poll: 'GitHub authentication requires the desktop app',
+	test_notification_sound: 'Sound testing requires the desktop app',
 };
 
 export function showMockToast(command: string, args?: Record<string, unknown>): void {

--- a/src/lib/tauri_mock.ts
+++ b/src/lib/tauri_mock.ts
@@ -44,6 +44,7 @@ const TAURI_ONLY_COMMANDS = new Set([
 	'kill_workspace_process',
 	'github_device_flow_start',
 	'github_device_flow_poll',
+	'test_notification_sound',
 ]);
 
 const MOCK_COMMAND_HANDLERS: Record<string, MockHandler> = {


### PR DESCRIPTION
## Description
- **Lazy PlaybackQueue initialization** — Wrapped PlaybackQueueHandle in LazyPlaybackQueue using OnceLock. Queue actor now spawns on first enqueue() call instead of during Tauri setup, preventing Tokio runtime panic.
- **Error surfacing** — Made test_notification_sound async with spawn_blocking. Playback errors now propagate to frontend; NotificationSettingsPanel displays danger toast on failure.
- **MP3 support** — Added minimp3 feature to rodio in Cargo.toml. MP3 files now decode and play correctly.
- **Sound rotation** — Implemented pick_sound_index with rotation map in queue actor. Service resolves all candidate sounds from pack manifest for event category. Consecutive plays never repeat the last-played sound.
- **Browser mock bridge** — Added test_notification_sound to TAURI_ONLY_COMMANDS and COMMAND_BODIES. Browser mode now shows "Desktop app required" toast.

## Resolves
Closes #264

## Testing
- [x] 4 new Rust tests added (lazy init, rotation indexing)
- [x] 1 new TypeScript test added (mock bridge toast)
- [x] Manual testing of sound playback with MP3 files