### PR TITLE
feat: assigned issues panel as dedicated tab with sortable table and batch actions

### DIFF
--- a/designs/cost-link/variants/variant-c.html
+++ b/designs/cost-link/variants/variant-c.html
@@ -1,490 +1,576 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>CostLink — Variant C: Icon-Appended</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@300;400;500;600&display=swap" rel="stylesheet" />
-  <style>
-    /* ── Grovekeeper design tokens — Forest Moss palette ────────── */
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>CostLink — Variant C: Icon-Appended</title>
+		<link rel="preconnect" href="https://fonts.googleapis.com" />
+		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+		<link
+			href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@300;400;500;600&display=swap"
+			rel="stylesheet"
+		/>
+		<style>
+			/* ── Grovekeeper design tokens — Forest Moss palette ────────── */
 
-    :root {
-      /* Brand greens (deep moss + olive) */
-      --moss-50:  oklch(0.972 0.018 130);
-      --moss-100: oklch(0.940 0.034 130);
-      --moss-200: oklch(0.880 0.058 130);
-      --moss-300: oklch(0.795 0.082 130);
-      --moss-400: oklch(0.690 0.098 132);
-      --moss-500: oklch(0.580 0.096 134);
-      --moss-600: oklch(0.480 0.082 138);
-      --moss-700: oklch(0.395 0.066 142);
-      --moss-800: oklch(0.300 0.048 145);
-      --moss-900: oklch(0.215 0.032 148);
-      --moss-950: oklch(0.155 0.024 150);
+			:root {
+				/* Brand greens (deep moss + olive) */
+				--moss-50: oklch(0.972 0.018 130);
+				--moss-100: oklch(0.94 0.034 130);
+				--moss-200: oklch(0.88 0.058 130);
+				--moss-300: oklch(0.795 0.082 130);
+				--moss-400: oklch(0.69 0.098 132);
+				--moss-500: oklch(0.58 0.096 134);
+				--moss-600: oklch(0.48 0.082 138);
+				--moss-700: oklch(0.395 0.066 142);
+				--moss-800: oklch(0.3 0.048 145);
+				--moss-900: oklch(0.215 0.032 148);
+				--moss-950: oklch(0.155 0.024 150);
 
-      /* Olive / amber accent (autumn fruit) */
-      --amber-300: oklch(0.840 0.130 78);
-      --amber-400: oklch(0.770 0.150 65);
-      --amber-500: oklch(0.690 0.165 55);
-      --amber-600: oklch(0.595 0.160 48);
+				/* Olive / amber accent (autumn fruit) */
+				--amber-300: oklch(0.84 0.13 78);
+				--amber-400: oklch(0.77 0.15 65);
+				--amber-500: oklch(0.69 0.165 55);
+				--amber-600: oklch(0.595 0.16 48);
 
-      /* Bark (warm brown for trunks, secondary accents) */
-      --bark-300: oklch(0.700 0.060 60);
-      --bark-500: oklch(0.500 0.075 55);
-      --bark-700: oklch(0.345 0.055 50);
+				/* Bark (warm brown for trunks, secondary accents) */
+				--bark-300: oklch(0.7 0.06 60);
+				--bark-500: oklch(0.5 0.075 55);
+				--bark-700: oklch(0.345 0.055 50);
 
-      /* Azure (cool blue accent scale) */
-      --azure-300: oklch(0.750 0.090 230);
-      --azure-400: oklch(0.660 0.120 230);
-      --azure-500: oklch(0.570 0.130 235);
-      --azure-600: oklch(0.490 0.115 240);
-      --azure-700: oklch(0.400 0.095 240);
+				/* Azure (cool blue accent scale) */
+				--azure-300: oklch(0.75 0.09 230);
+				--azure-400: oklch(0.66 0.12 230);
+				--azure-500: oklch(0.57 0.13 235);
+				--azure-600: oklch(0.49 0.115 240);
+				--azure-700: oklch(0.4 0.095 240);
 
-      /* Plum (purple accent) */
-      --plum-300: oklch(0.720 0.100 320);
-      --plum-400: oklch(0.640 0.130 320);
-      --plum-500: oklch(0.560 0.150 320);
-      --plum-600: oklch(0.480 0.130 320);
-      --plum-700: oklch(0.400 0.110 320);
+				/* Plum (purple accent) */
+				--plum-300: oklch(0.72 0.1 320);
+				--plum-400: oklch(0.64 0.13 320);
+				--plum-500: oklch(0.56 0.15 320);
+				--plum-600: oklch(0.48 0.13 320);
+				--plum-700: oklch(0.4 0.11 320);
 
-      /* Teal (blue-green accent) */
-      --teal-300: oklch(0.780 0.075 195);
-      --teal-400: oklch(0.700 0.095 195);
-      --teal-500: oklch(0.620 0.110 195);
-      --teal-600: oklch(0.540 0.095 195);
-      --teal-700: oklch(0.460 0.080 195);
+				/* Teal (blue-green accent) */
+				--teal-300: oklch(0.78 0.075 195);
+				--teal-400: oklch(0.7 0.095 195);
+				--teal-500: oklch(0.62 0.11 195);
+				--teal-600: oklch(0.54 0.095 195);
+				--teal-700: oklch(0.46 0.08 195);
 
-      /* Rose (warm pink-red accent) */
-      --rose-300: oklch(0.800 0.105 15);
-      --rose-400: oklch(0.720 0.135 15);
-      --rose-500: oklch(0.640 0.155 15);
-      --rose-600: oklch(0.560 0.135 15);
-      --rose-700: oklch(0.480 0.115 15);
+				/* Rose (warm pink-red accent) */
+				--rose-300: oklch(0.8 0.105 15);
+				--rose-400: oklch(0.72 0.135 15);
+				--rose-500: oklch(0.64 0.155 15);
+				--rose-600: oklch(0.56 0.135 15);
+				--rose-700: oklch(0.48 0.115 15);
 
-      /* Coral (warm orange-red accent) */
-      --coral-300: oklch(0.780 0.105 30);
-      --coral-400: oklch(0.700 0.135 30);
-      --coral-500: oklch(0.620 0.155 30);
-      --coral-600: oklch(0.540 0.135 30);
-      --coral-700: oklch(0.460 0.115 30);
+				/* Coral (warm orange-red accent) */
+				--coral-300: oklch(0.78 0.105 30);
+				--coral-400: oklch(0.7 0.135 30);
+				--coral-500: oklch(0.62 0.155 30);
+				--coral-600: oklch(0.54 0.135 30);
+				--coral-700: oklch(0.46 0.115 30);
 
-      /* Gold (warm yellow accent) */
-      --gold-300: oklch(0.810 0.090 90);
-      --gold-400: oklch(0.730 0.115 90);
-      --gold-500: oklch(0.650 0.135 90);
-      --gold-600: oklch(0.570 0.115 90);
-      --gold-700: oklch(0.490 0.095 90);
+				/* Gold (warm yellow accent) */
+				--gold-300: oklch(0.81 0.09 90);
+				--gold-400: oklch(0.73 0.115 90);
+				--gold-500: oklch(0.65 0.135 90);
+				--gold-600: oklch(0.57 0.115 90);
+				--gold-700: oklch(0.49 0.095 90);
 
-      /* Sage (muted green accent) */
-      --sage-300: oklch(0.760 0.055 160);
-      --sage-400: oklch(0.680 0.070 160);
-      --sage-500: oklch(0.600 0.085 160);
-      --sage-600: oklch(0.520 0.070 160);
-      --sage-700: oklch(0.440 0.060 160);
+				/* Sage (muted green accent) */
+				--sage-300: oklch(0.76 0.055 160);
+				--sage-400: oklch(0.68 0.07 160);
+				--sage-500: oklch(0.6 0.085 160);
+				--sage-600: oklch(0.52 0.07 160);
+				--sage-700: oklch(0.44 0.06 160);
 
-      /* Indigo (deep blue-violet accent) */
-      --indigo-300: oklch(0.700 0.095 275);
-      --indigo-400: oklch(0.620 0.120 275);
-      --indigo-500: oklch(0.540 0.140 275);
-      --indigo-600: oklch(0.460 0.120 275);
-      --indigo-700: oklch(0.380 0.100 275);
+				/* Indigo (deep blue-violet accent) */
+				--indigo-300: oklch(0.7 0.095 275);
+				--indigo-400: oklch(0.62 0.12 275);
+				--indigo-500: oklch(0.54 0.14 275);
+				--indigo-600: oklch(0.46 0.12 275);
+				--indigo-700: oklch(0.38 0.1 275);
 
-      /* Fuchsia (vivid magenta accent) */
-      --fuchsia-300: oklch(0.740 0.105 350);
-      --fuchsia-400: oklch(0.660 0.135 350);
-      --fuchsia-500: oklch(0.580 0.155 350);
-      --fuchsia-600: oklch(0.500 0.135 350);
-      --fuchsia-700: oklch(0.420 0.115 350);
+				/* Fuchsia (vivid magenta accent) */
+				--fuchsia-300: oklch(0.74 0.105 350);
+				--fuchsia-400: oklch(0.66 0.135 350);
+				--fuchsia-500: oklch(0.58 0.155 350);
+				--fuchsia-600: oklch(0.5 0.135 350);
+				--fuchsia-700: oklch(0.42 0.115 350);
 
-      /* Sky (gradient bg for forest view) */
-      --sky-light-top: oklch(0.965 0.018 220);
-      --sky-light-bot: oklch(0.940 0.025 130);
-      --sky-dark-top:  oklch(0.225 0.028 240);
-      --sky-dark-bot:  oklch(0.180 0.030 150);
+				/* Sky (gradient bg for forest view) */
+				--sky-light-top: oklch(0.965 0.018 220);
+				--sky-light-bot: oklch(0.94 0.025 130);
+				--sky-dark-top: oklch(0.225 0.028 240);
+				--sky-dark-bot: oklch(0.18 0.03 150);
 
-      /* Status accents */
-      --status-success: oklch(0.660 0.135 145);
-      --status-warning: oklch(0.770 0.155 75);
-      --status-danger:  oklch(0.620 0.205 25);
-      --status-info:    oklch(0.660 0.105 220);
-      --status-merged:  oklch(0.580 0.140 310);
+				/* Status accents */
+				--status-success: oklch(0.66 0.135 145);
+				--status-warning: oklch(0.77 0.155 75);
+				--status-danger: oklch(0.62 0.205 25);
+				--status-info: oklch(0.66 0.105 220);
+				--status-merged: oklch(0.58 0.14 310);
 
-      /* Priority levels */
-      --priority-top:    oklch(0.620 0.205 25);
-      --priority-high:   oklch(0.720 0.160 55);
-      --priority-medium: oklch(0.820 0.160 85);
-      --priority-low:    oklch(0.660 0.105 220);
-      --priority-lowest: oklch(0.550 0.020 250);
+				/* Priority levels */
+				--priority-top: oklch(0.62 0.205 25);
+				--priority-high: oklch(0.72 0.16 55);
+				--priority-medium: oklch(0.82 0.16 85);
+				--priority-low: oklch(0.66 0.105 220);
+				--priority-lowest: oklch(0.55 0.02 250);
 
-      /* GitHub state colors */
-      --gh-open:   oklch(0.660 0.135 145);
-      --gh-closed: oklch(0.580 0.140 310);
-      --gh-merged: oklch(0.580 0.140 310);
-      --gh-draft:  oklch(0.550 0.020 250);
+				/* GitHub state colors */
+				--gh-open: oklch(0.66 0.135 145);
+				--gh-closed: oklch(0.58 0.14 310);
+				--gh-merged: oklch(0.58 0.14 310);
+				--gh-draft: oklch(0.55 0.02 250);
 
-      /* Session state colors */
-      --session-running:      oklch(0.660 0.135 145);
-      --session-errored:      oklch(0.620 0.205 25);
-      --session-idle:         oklch(0.660 0.105 220);
-      --session-paused:       oklch(0.550 0.020 250);
-      --session-finished:     oklch(0.450 0.015 250);
-      --session-needs-input:  oklch(0.770 0.155 75);
-      --session-needs-review: oklch(0.660 0.105 220);
+				/* Session state colors */
+				--session-running: oklch(0.66 0.135 145);
+				--session-errored: oklch(0.62 0.205 25);
+				--session-idle: oklch(0.66 0.105 220);
+				--session-paused: oklch(0.55 0.02 250);
+				--session-finished: oklch(0.45 0.015 250);
+				--session-needs-input: oklch(0.77 0.155 75);
+				--session-needs-review: oklch(0.66 0.105 220);
 
-      /* ── Typography ─────────────────────────────────────────── */
-      --font-sans: "Geist", "Inter", ui-sans-serif, system-ui, sans-serif;
-      --font-mono: "Geist Mono", ui-monospace, "JetBrains Mono", Menlo, monospace;
+				/* ── Typography ─────────────────────────────────────────── */
+				--font-sans: 'Geist', 'Inter', ui-sans-serif, system-ui, sans-serif;
+				--font-mono: 'Geist Mono', ui-monospace, 'JetBrains Mono', Menlo, monospace;
 
-      /* Font sizes */
-      --text-2xs: 10.5px;
-      --text-xs:  11px;
-      --text-sm:  12px;
-      --text-md:  13px;
-      --text-base:14px;
-      --text-lg:  15px;
-      --text-xl:  17px;
-      --text-2xl: 22px;
-      --text-3xl: 28px;
-      --text-4xl: 36px;
-      --text-5xl: 48px;
+				/* Font sizes */
+				--text-2xs: 10.5px;
+				--text-xs: 11px;
+				--text-sm: 12px;
+				--text-md: 13px;
+				--text-base: 14px;
+				--text-lg: 15px;
+				--text-xl: 17px;
+				--text-2xl: 22px;
+				--text-3xl: 28px;
+				--text-4xl: 36px;
+				--text-5xl: 48px;
 
-      /* Line heights */
-      --leading-tight:  1.15;
-      --leading-snug:   1.25;
-      --leading-normal: 1.4;
-      --leading-relaxed:1.55;
-      --leading-loose:  1.7;
+				/* Line heights */
+				--leading-tight: 1.15;
+				--leading-snug: 1.25;
+				--leading-normal: 1.4;
+				--leading-relaxed: 1.55;
+				--leading-loose: 1.7;
 
-      /* Font weights */
-      --weight-regular:  400;
-      --weight-medium:   500;
-      --weight-semibold: 600;
-      --weight-bold:     700;
+				/* Font weights */
+				--weight-regular: 400;
+				--weight-medium: 500;
+				--weight-semibold: 600;
+				--weight-bold: 700;
 
-      /* Letter spacing */
-      --tracking-tight:  -0.02em;
-      --tracking-snug:   -0.01em;
-      --tracking-normal: 0;
-      --tracking-wide:   0.04em;
-      --tracking-wider:  0.08em;
+				/* Letter spacing */
+				--tracking-tight: -0.02em;
+				--tracking-snug: -0.01em;
+				--tracking-normal: 0;
+				--tracking-wide: 0.04em;
+				--tracking-wider: 0.08em;
 
-      /* ── Spacing scale (4px base) ───────────────────────────── */
-      --space-0:  0;
-      --space-1:  2px;
-      --space-2:  4px;
-      --space-3:  6px;
-      --space-4:  8px;
-      --space-5:  10px;
-      --space-6:  12px;
-      --space-7:  14px;
-      --space-8:  16px;
-      --space-10: 20px;
-      --space-12: 24px;
-      --space-14: 28px;
-      --space-16: 32px;
-      --space-20: 40px;
-      --space-24: 48px;
-      --space-32: 64px;
+				/* ── Spacing scale (4px base) ───────────────────────────── */
+				--space-0: 0;
+				--space-1: 2px;
+				--space-2: 4px;
+				--space-3: 6px;
+				--space-4: 8px;
+				--space-5: 10px;
+				--space-6: 12px;
+				--space-7: 14px;
+				--space-8: 16px;
+				--space-10: 20px;
+				--space-12: 24px;
+				--space-14: 28px;
+				--space-16: 32px;
+				--space-20: 40px;
+				--space-24: 48px;
+				--space-32: 64px;
 
-      /* ── Radii ──────────────────────────────────────────────── */
-      --radius-none: 0;
-      --radius-xs: 4px;
-      --radius-sm: 6px;
-      --radius-md: 8px;
-      --radius-lg: 10px;
-      --radius-xl: 14px;
-      --radius-2xl: 20px;
-      --radius-full: 9999px;
+				/* ── Radii ──────────────────────────────────────────────── */
+				--radius-none: 0;
+				--radius-xs: 4px;
+				--radius-sm: 6px;
+				--radius-md: 8px;
+				--radius-lg: 10px;
+				--radius-xl: 14px;
+				--radius-2xl: 20px;
+				--radius-full: 9999px;
 
-      /* ── Borders ────────────────────────────────────────────── */
-      --border-width-1: 1px;
-      --border-width-2: 1.5px;
-      --border-width-3: 2px;
-      --focus-ring-width: 3px;
-      --focus-ring-offset: 2px;
+				/* ── Borders ────────────────────────────────────────────── */
+				--border-width-1: 1px;
+				--border-width-2: 1.5px;
+				--border-width-3: 2px;
+				--focus-ring-width: 3px;
+				--focus-ring-offset: 2px;
 
-      /* ── Shadows ────────────────────────────────────────────── */
-      --shadow-sm: 0 1px 2px rgba(20, 30, 22, 0.06);
-      --shadow-md: 0 2px 8px rgba(20, 30, 22, 0.08), 0 1px 2px rgba(20, 30, 22, 0.04);
-      --shadow-lg: 0 12px 32px rgba(20, 30, 22, 0.14), 0 2px 6px rgba(20, 30, 22, 0.06);
-      --shadow-xl: 0 24px 56px rgba(20, 30, 22, 0.20), 0 4px 12px rgba(20, 30, 22, 0.08);
-      --shadow-inset: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+				/* ── Shadows ────────────────────────────────────────────── */
+				--shadow-sm: 0 1px 2px rgba(20, 30, 22, 0.06);
+				--shadow-md: 0 2px 8px rgba(20, 30, 22, 0.08), 0 1px 2px rgba(20, 30, 22, 0.04);
+				--shadow-lg: 0 12px 32px rgba(20, 30, 22, 0.14), 0 2px 6px rgba(20, 30, 22, 0.06);
+				--shadow-xl: 0 24px 56px rgba(20, 30, 22, 0.2), 0 4px 12px rgba(20, 30, 22, 0.08);
+				--shadow-inset: inset 0 1px 0 rgba(255, 255, 255, 0.05);
 
-      /* ── Sizing — control heights ──────────────────────────── */
-      --size-control-sm: 26px;
-      --size-control-md: 32px;
-      --size-control-lg: 38px;
+				/* ── Sizing — control heights ──────────────────────────── */
+				--size-control-sm: 26px;
+				--size-control-md: 32px;
+				--size-control-lg: 38px;
 
-      /* ── Z-index scale ─────────────────────────────────────── */
-      --z-base: 0;
-      --z-raised: 10;
-      --z-dropdown: 20;
-      --z-sticky: 30;
-      --z-overlay: 40;
-      --z-modal: 50;
-      --z-toast: 60;
-      --z-tooltip: 70;
+				/* ── Z-index scale ─────────────────────────────────────── */
+				--z-base: 0;
+				--z-raised: 10;
+				--z-dropdown: 20;
+				--z-sticky: 30;
+				--z-overlay: 40;
+				--z-modal: 50;
+				--z-toast: 60;
+				--z-tooltip: 70;
 
-      /* ── Motion ─────────────────────────────────────────────── */
-      --duration-1: 90ms;
-      --duration-2: 120ms;
-      --duration-3: 160ms;
-      --duration-4: 220ms;
-      --duration-5: 320ms;
-      --ease-standard: cubic-bezier(.2,.7,.3,1);
-      --ease-out:      cubic-bezier(.16,.84,.44,1);
-      --ease-in:       cubic-bezier(.5,0,.75,0);
+				/* ── Motion ─────────────────────────────────────────────── */
+				--duration-1: 90ms;
+				--duration-2: 120ms;
+				--duration-3: 160ms;
+				--duration-4: 220ms;
+				--duration-5: 320ms;
+				--ease-standard: cubic-bezier(0.2, 0.7, 0.3, 1);
+				--ease-out: cubic-bezier(0.16, 0.84, 0.44, 1);
+				--ease-in: cubic-bezier(0.5, 0, 0.75, 0);
 
-      /* ── Layout ─────────────────────────────────────────────── */
-      --sidebar-width:  240px;
-      --sidebar-width-collapsed: 56px;
-    }
+				/* ── Layout ─────────────────────────────────────────────── */
+				--sidebar-width: 240px;
+				--sidebar-width-collapsed: 56px;
+			}
 
-    /* Dark theme */
-    .theme-dark, [data-theme='dark'] {
-      color-scheme: dark;
-      --background:        oklch(0.155 0.018 150);
-      --surface:           oklch(0.190 0.020 150);
-      --surface-2:         oklch(0.225 0.022 150);
-      --surface-hover:     oklch(0.265 0.024 150);
-      --surface-3:         oklch(0.265 0.024 150);
-      --foreground:        oklch(0.965 0.010 130);
-      --foreground-muted:  oklch(0.730 0.018 135);
-      --foreground-subtle: oklch(0.560 0.020 140);
-      --border:            oklch(0.295 0.022 148);
-      --border-strong:     oklch(0.380 0.028 145);
-      --primary:           var(--moss-400);
-      --primary-fg:        oklch(0.135 0.020 150);
-      --primary-soft:      oklch(0.305 0.045 145);
-      --accent:            var(--moss-400);
-      --accent-fg:         oklch(0.135 0.02 150);
-      --ring:              var(--moss-400);
-      --sidebar-bg:        oklch(0.180 0.022 150);
-      --sidebar-fg:        oklch(0.770 0.020 140);
-      --code-bg:           oklch(0.215 0.020 150);
-      --sky-top:           var(--sky-dark-top);
-      --sky-bot:           var(--sky-dark-bot);
-      --ground-color:      oklch(0.300 0.060 140);
-      --ground-dark:       oklch(0.180 0.040 50);
-    }
+			/* Dark theme */
+			.theme-dark,
+			[data-theme='dark'] {
+				color-scheme: dark;
+				--background: oklch(0.155 0.018 150);
+				--surface: oklch(0.19 0.02 150);
+				--surface-2: oklch(0.225 0.022 150);
+				--surface-hover: oklch(0.265 0.024 150);
+				--surface-3: oklch(0.265 0.024 150);
+				--foreground: oklch(0.965 0.01 130);
+				--foreground-muted: oklch(0.73 0.018 135);
+				--foreground-subtle: oklch(0.56 0.02 140);
+				--border: oklch(0.295 0.022 148);
+				--border-strong: oklch(0.38 0.028 145);
+				--primary: var(--moss-400);
+				--primary-fg: oklch(0.135 0.02 150);
+				--primary-soft: oklch(0.305 0.045 145);
+				--accent: var(--moss-400);
+				--accent-fg: oklch(0.135 0.02 150);
+				--ring: var(--moss-400);
+				--sidebar-bg: oklch(0.18 0.022 150);
+				--sidebar-fg: oklch(0.77 0.02 140);
+				--code-bg: oklch(0.215 0.02 150);
+				--sky-top: var(--sky-dark-top);
+				--sky-bot: var(--sky-dark-bot);
+				--ground-color: oklch(0.3 0.06 140);
+				--ground-dark: oklch(0.18 0.04 50);
+			}
 
-    /* Base */
-    .gk-root {
-      font-family: var(--font-sans);
-      color: var(--foreground);
-      background: var(--background);
-      font-feature-settings: "ss01", "cv11";
-      font-synthesis: none;
-      -webkit-font-smoothing: antialiased;
-      text-rendering: optimizeLegibility;
-    }
+			/* Base */
+			.gk-root {
+				font-family: var(--font-sans);
+				color: var(--foreground);
+				background: var(--background);
+				font-feature-settings: 'ss01', 'cv11';
+				font-synthesis: none;
+				-webkit-font-smoothing: antialiased;
+				text-rendering: optimizeLegibility;
+			}
 
-    .gk-root, .gk-root * {
-      box-sizing: border-box;
-    }
+			.gk-root,
+			.gk-root * {
+				box-sizing: border-box;
+			}
 
-    .font-mono { font-family: var(--font-mono); }
+			.font-mono {
+				font-family: var(--font-mono);
+			}
 
-    /* Gk type scale */
-    .gk-h1 { font-size: var(--text-2xl); font-weight: var(--weight-semibold); letter-spacing: var(--tracking-snug); line-height: var(--leading-tight); color: var(--foreground); }
-    .gk-h2 { font-size: var(--text-xl); font-weight: var(--weight-semibold); letter-spacing: var(--tracking-snug); line-height: var(--leading-snug); color: var(--foreground); }
-    .gk-h3 { font-size: var(--text-base); font-weight: var(--weight-semibold); letter-spacing: var(--tracking-snug); line-height: var(--leading-snug); color: var(--foreground); }
-    .gk-body { font-size: var(--text-md); line-height: var(--leading-relaxed); color: var(--foreground); }
-    .gk-small { font-size: var(--text-sm); color: var(--foreground-muted); line-height: var(--leading-normal); }
-    .gk-tiny { font-size: var(--text-xs); color: var(--foreground-subtle); letter-spacing: var(--tracking-wide); }
-    .gk-eyebrow {
-      font-size: var(--text-2xs);
-      font-weight: var(--weight-semibold);
-      color: var(--foreground-subtle);
-      letter-spacing: var(--tracking-wider);
-      text-transform: uppercase;
-      font-family: var(--font-sans);
-    }
+			/* Gk type scale */
+			.gk-h1 {
+				font-size: var(--text-2xl);
+				font-weight: var(--weight-semibold);
+				letter-spacing: var(--tracking-snug);
+				line-height: var(--leading-tight);
+				color: var(--foreground);
+			}
+			.gk-h2 {
+				font-size: var(--text-xl);
+				font-weight: var(--weight-semibold);
+				letter-spacing: var(--tracking-snug);
+				line-height: var(--leading-snug);
+				color: var(--foreground);
+			}
+			.gk-h3 {
+				font-size: var(--text-base);
+				font-weight: var(--weight-semibold);
+				letter-spacing: var(--tracking-snug);
+				line-height: var(--leading-snug);
+				color: var(--foreground);
+			}
+			.gk-body {
+				font-size: var(--text-md);
+				line-height: var(--leading-relaxed);
+				color: var(--foreground);
+			}
+			.gk-small {
+				font-size: var(--text-sm);
+				color: var(--foreground-muted);
+				line-height: var(--leading-normal);
+			}
+			.gk-tiny {
+				font-size: var(--text-xs);
+				color: var(--foreground-subtle);
+				letter-spacing: var(--tracking-wide);
+			}
+			.gk-eyebrow {
+				font-size: var(--text-2xs);
+				font-weight: var(--weight-semibold);
+				color: var(--foreground-subtle);
+				letter-spacing: var(--tracking-wider);
+				text-transform: uppercase;
+				font-family: var(--font-sans);
+			}
 
-    /* Card */
-    .gk-card {
-      background: var(--surface);
-      border: 1px solid var(--border);
-      border-radius: var(--radius-lg);
-      box-shadow: var(--shadow-sm);
-    }
-    .gk-card-padded { padding: 16px; }
+			/* Card */
+			.gk-card {
+				background: var(--surface);
+				border: 1px solid var(--border);
+				border-radius: var(--radius-lg);
+				box-shadow: var(--shadow-sm);
+			}
+			.gk-card-padded {
+				padding: 16px;
+			}
 
-    /* Badges */
-    .gk-badge {
-      display: inline-flex;
-      align-items: center;
-      gap: 4px;
-      height: 20px;
-      padding: 0 7px;
-      font-size: 11px;
-      font-weight: 500;
-      border-radius: 999px;
-      background: var(--surface-2);
-      color: var(--foreground-muted);
-      border: 1px solid var(--border);
-      font-family: var(--font-sans);
-      letter-spacing: 0.01em;
-      white-space: nowrap;
-    }
-    .gk-badge-dot { width: 6px; height: 6px; border-radius: 50%; background: currentColor; flex-shrink: 0; }
-    .gk-badge-success { background: color-mix(in oklch, var(--status-success) 14%, transparent); color: var(--status-success); border-color: color-mix(in oklch, var(--status-success) 30%, transparent); }
-    .gk-badge-warning { background: color-mix(in oklch, var(--status-warning) 14%, transparent); color: color-mix(in oklch, var(--status-warning) 70%, var(--foreground)); border-color: color-mix(in oklch, var(--status-warning) 30%, transparent); }
+			/* Badges */
+			.gk-badge {
+				display: inline-flex;
+				align-items: center;
+				gap: 4px;
+				height: 20px;
+				padding: 0 7px;
+				font-size: 11px;
+				font-weight: 500;
+				border-radius: 999px;
+				background: var(--surface-2);
+				color: var(--foreground-muted);
+				border: 1px solid var(--border);
+				font-family: var(--font-sans);
+				letter-spacing: 0.01em;
+				white-space: nowrap;
+			}
+			.gk-badge-dot {
+				width: 6px;
+				height: 6px;
+				border-radius: 50%;
+				background: currentColor;
+				flex-shrink: 0;
+			}
+			.gk-badge-success {
+				background: color-mix(in oklch, var(--status-success) 14%, transparent);
+				color: var(--status-success);
+				border-color: color-mix(in oklch, var(--status-success) 30%, transparent);
+			}
+			.gk-badge-warning {
+				background: color-mix(in oklch, var(--status-warning) 14%, transparent);
+				color: color-mix(in oklch, var(--status-warning) 70%, var(--foreground));
+				border-color: color-mix(in oklch, var(--status-warning) 30%, transparent);
+			}
 
-    /* Divider */
-    .gk-hr { height: 1px; background: var(--border); border: none; margin: 0; }
+			/* Divider */
+			.gk-hr {
+				height: 1px;
+				background: var(--border);
+				border: none;
+				margin: 0;
+			}
 
-    /* CodeBurn panel */
-    .cb-panel {
-      background: var(--surface);
-      border: 1px solid var(--border);
-      border-radius: var(--radius-md);
-      padding: 12px 14px 10px;
-      display: flex;
-      flex-direction: column;
-      gap: 8px;
-      min-width: 0;
-    }
-    .cb-panel-title {
-      font-family: var(--font-mono);
-      font-size: 11px;
-      font-weight: 600;
-      color: var(--foreground-muted);
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
-      display: flex;
-      align-items: baseline;
-      gap: 8px;
-      padding-bottom: 6px;
-      border-bottom: 1px dashed var(--border);
-    }
-    .cb-panel-title::before { content: "["; color: var(--foreground-subtle); font-weight: 400; }
-    .cb-panel-title::after  { content: "]"; color: var(--foreground-subtle); font-weight: 400; margin-right: auto; }
-    .cb-panel-sub {
-      font-family: var(--font-mono);
-      font-size: 10.5px;
-      font-weight: 400;
-      color: var(--foreground-subtle);
-      text-transform: none;
-      letter-spacing: 0;
-      margin-left: auto;
-    }
+			/* CodeBurn panel */
+			.cb-panel {
+				background: var(--surface);
+				border: 1px solid var(--border);
+				border-radius: var(--radius-md);
+				padding: 12px 14px 10px;
+				display: flex;
+				flex-direction: column;
+				gap: 8px;
+				min-width: 0;
+			}
+			.cb-panel-title {
+				font-family: var(--font-mono);
+				font-size: 11px;
+				font-weight: 600;
+				color: var(--foreground-muted);
+				text-transform: uppercase;
+				letter-spacing: 0.08em;
+				display: flex;
+				align-items: baseline;
+				gap: 8px;
+				padding-bottom: 6px;
+				border-bottom: 1px dashed var(--border);
+			}
+			.cb-panel-title::before {
+				content: '[';
+				color: var(--foreground-subtle);
+				font-weight: 400;
+			}
+			.cb-panel-title::after {
+				content: ']';
+				color: var(--foreground-subtle);
+				font-weight: 400;
+				margin-right: auto;
+			}
+			.cb-panel-sub {
+				font-family: var(--font-mono);
+				font-size: 10.5px;
+				font-weight: 400;
+				color: var(--foreground-subtle);
+				text-transform: none;
+				letter-spacing: 0;
+				margin-left: auto;
+			}
 
-    /* Tooltip */
-    .gk-tooltip {
-      background: oklch(0.12 0.02 150);
-      color: oklch(0.97 0.01 130);
-      border: 1px solid color-mix(in oklch, oklch(0.12 0.02 150) 60%, var(--border));
-      font-size: 11px;
-      padding: 5px 8px;
-      border-radius: 6px;
-      box-shadow: var(--shadow-md);
-      font-family: var(--font-sans);
-      position: absolute;
-      white-space: nowrap;
-      pointer-events: none;
-      z-index: var(--z-tooltip);
-    }
+			/* Tooltip */
+			.gk-tooltip {
+				background: oklch(0.12 0.02 150);
+				color: oklch(0.97 0.01 130);
+				border: 1px solid color-mix(in oklch, oklch(0.12 0.02 150) 60%, var(--border));
+				font-size: 11px;
+				padding: 5px 8px;
+				border-radius: 6px;
+				box-shadow: var(--shadow-md);
+				font-family: var(--font-sans);
+				position: absolute;
+				white-space: nowrap;
+				pointer-events: none;
+				z-index: var(--z-tooltip);
+			}
 
-    /* Scrollbar */
-    .gk-root ::-webkit-scrollbar { width: 10px; height: 10px; }
-    .gk-root ::-webkit-scrollbar-track { background: transparent; }
-    .gk-root ::-webkit-scrollbar-thumb { background: var(--border); border: 2px solid transparent; background-clip: padding-box; border-radius: 999px; }
-    .gk-root ::-webkit-scrollbar-thumb:hover { background: var(--border-strong); background-clip: padding-box; }
+			/* Scrollbar */
+			.gk-root ::-webkit-scrollbar {
+				width: 10px;
+				height: 10px;
+			}
+			.gk-root ::-webkit-scrollbar-track {
+				background: transparent;
+			}
+			.gk-root ::-webkit-scrollbar-thumb {
+				background: var(--border);
+				border: 2px solid transparent;
+				background-clip: padding-box;
+				border-radius: 999px;
+			}
+			.gk-root ::-webkit-scrollbar-thumb:hover {
+				background: var(--border-strong);
+				background-clip: padding-box;
+			}
 
-    /* State showcase cells */
-    .cs-cell {
-      display: flex;
-      flex-direction: column;
-      gap: 8px;
-      padding: 14px 14px 12px;
-      background: var(--surface);
-      border: 1px solid var(--border);
-      border-radius: 8px;
-      min-height: 88px;
-      position: relative;
-    }
-    .cs-cell-label {
-      font-size: 10px;
-      font-family: var(--font-mono);
-      color: var(--foreground-subtle);
-      letter-spacing: 0.04em;
-      text-transform: lowercase;
-    }
-    .cs-cell-stage {
-      flex: 1;
-      display: flex;
-      align-items: center;
-      justify-content: flex-start;
-      flex-wrap: wrap;
-      gap: 8px;
-    }
-    .cs-cell-grid {
-      display: grid;
-      gap: 10px;
-      margin-bottom: 18px;
-    }
-    .cs-cell-grid.cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
-    .cs-cell-grid.cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
-    .cs-cell-grid.cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+			/* State showcase cells */
+			.cs-cell {
+				display: flex;
+				flex-direction: column;
+				gap: 8px;
+				padding: 14px 14px 12px;
+				background: var(--surface);
+				border: 1px solid var(--border);
+				border-radius: 8px;
+				min-height: 88px;
+				position: relative;
+			}
+			.cs-cell-label {
+				font-size: 10px;
+				font-family: var(--font-mono);
+				color: var(--foreground-subtle);
+				letter-spacing: 0.04em;
+				text-transform: lowercase;
+			}
+			.cs-cell-stage {
+				flex: 1;
+				display: flex;
+				align-items: center;
+				justify-content: flex-start;
+				flex-wrap: wrap;
+				gap: 8px;
+			}
+			.cs-cell-grid {
+				display: grid;
+				gap: 10px;
+				margin-bottom: 18px;
+			}
+			.cs-cell-grid.cols-4 {
+				grid-template-columns: repeat(4, minmax(0, 1fr));
+			}
+			.cs-cell-grid.cols-3 {
+				grid-template-columns: repeat(3, minmax(0, 1fr));
+			}
+			.cs-cell-grid.cols-2 {
+				grid-template-columns: repeat(2, minmax(0, 1fr));
+			}
 
-    /* ── Page layout ────────────────────────────────────────────── */
-    body {
-      margin: 0;
-      padding: 0;
-    }
+			/* ── Page layout ────────────────────────────────────────────── */
+			body {
+				margin: 0;
+				padding: 0;
+			}
 
-    .page-layout {
-      min-height: 100vh;
-      padding: 40px 48px 64px;
-      max-width: 1100px;
-      margin: 0 auto;
-    }
+			.page-layout {
+				min-height: 100vh;
+				padding: 40px 48px 64px;
+				max-width: 1100px;
+				margin: 0 auto;
+			}
 
-    .page-header {
-      margin-bottom: 40px;
-      padding-bottom: 20px;
-      border-bottom: 1px solid var(--border);
-    }
+			.page-header {
+				margin-bottom: 40px;
+				padding-bottom: 20px;
+				border-bottom: 1px solid var(--border);
+			}
 
-    .page-header .variant-meta {
-      display: flex;
-      align-items: center;
-      gap: 10px;
-      margin-bottom: 8px;
-    }
+			.page-header .variant-meta {
+				display: flex;
+				align-items: center;
+				gap: 10px;
+				margin-bottom: 8px;
+			}
 
-    .page-header h1 {
-      margin: 0 0 4px 0;
-    }
+			.page-header h1 {
+				margin: 0 0 4px 0;
+			}
 
-    .page-header p {
-      margin: 0;
-      max-width: 560px;
-    }
+			.page-header p {
+				margin: 0;
+				max-width: 560px;
+			}
 
-    .section {
-      margin-bottom: 40px;
-    }
+			.section {
+				margin-bottom: 40px;
+			}
 
-    .section-title {
-      margin: 0 0 14px 0;
-      display: flex;
-      align-items: center;
-      gap: 10px;
-    }
+			.section-title {
+				margin: 0 0 14px 0;
+				display: flex;
+				align-items: center;
+				gap: 10px;
+			}
 
-    .section-title::after {
-      content: "";
-      flex: 1;
-      height: 1px;
-      background: var(--border);
-    }
+			.section-title::after {
+				content: '';
+				flex: 1;
+				height: 1px;
+				background: var(--border);
+			}
 
-    /* ── CostLink component ─────────────────────────────────────── */
-    /*
+			/* ── CostLink component ─────────────────────────────────────── */
+			/*
       Variant C: Icon-Appended
       At rest: plain monospaced cost text in foreground-muted
       On hover: arrow-up-right icon fades in to the right, text shifts to primary
@@ -492,1011 +578,1565 @@
       Active: slight scale-down feedback
     */
 
-    .cb-cost-link {
-      /* Inline-flex so it sits naturally in text flow */
-      display: inline-flex;
-      align-items: center;
-      gap: 0;
-      position: relative;
-
-      /* Monospaced for tabular-nums alignment */
-      font-family: var(--font-mono);
-      font-variant-numeric: tabular-nums;
-      font-feature-settings: "tnum";
-
-      /* No underline — navigation is signaled by icon + color, not underline */
-      text-decoration: none;
-      cursor: pointer;
-      outline: none;
-      border: none;
-      background: transparent;
-      padding: 1px 2px;
-      border-radius: var(--radius-xs);
-
-      /* Color at rest: muted, reads as data, not a link */
-      color: var(--foreground-muted);
-
-      /* Transitions */
-      transition:
-        color var(--duration-2) var(--ease-standard),
-        background var(--duration-2) var(--ease-standard);
-
-      /* Prevents layout shift when icon appears */
-      white-space: nowrap;
-    }
-
-    /* Size: sm — 10.5px, matches --text-2xs */
-    .cb-cost-link-sm {
-      font-size: 10.5px;
-      line-height: 14px;
-    }
-
-    /* Size: md — 12px, matches --text-sm */
-    .cb-cost-link-md {
-      font-size: 12px;
-      line-height: 16px;
-    }
-
-    /* The cost text itself — inherits font from parent */
-    .cb-cost-link__text {
-      /* Slight letter-spacing tightening for mono numerics */
-      letter-spacing: -0.01em;
-    }
-
-    /* The arrow icon — hidden at rest */
-    .cb-cost-link__icon {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      width: 0;
-      overflow: hidden;
-      opacity: 0;
-      /* Slides in from left — compact feel, no layout jump */
-      transform: translateX(-2px) translateY(1px);
-      transition:
-        opacity var(--duration-3) var(--ease-out),
-        width var(--duration-3) var(--ease-out),
-        transform var(--duration-3) var(--ease-out);
-      flex-shrink: 0;
-    }
-
-    /* sm: icon is 8px */
-    .cb-cost-link-sm .cb-cost-link__icon {
-      /* height matches line-height of adjacent text */
-      height: 14px;
-    }
-
-    /* md: icon is 8px, height matches md line-height */
-    .cb-cost-link-md .cb-cost-link__icon {
-      height: 16px;
-    }
-
-    /* ── Hover state ── */
-    .cb-cost-link:hover,
-    .cb-cost-link[data-state="hover"] {
-      color: var(--primary);
-      background: color-mix(in oklch, var(--primary) 8%, transparent);
-    }
-
-    .cb-cost-link:hover .cb-cost-link__icon,
-    .cb-cost-link[data-state="hover"] .cb-cost-link__icon {
-      opacity: 1;
-      width: 10px;  /* slight breathing room */
-      transform: translateX(0) translateY(1px);
-    }
-
-    /* ── Focus state ── */
-    .cb-cost-link:focus-visible,
-    .cb-cost-link[data-state="focus"] {
-      outline: 2px solid var(--ring);
-      outline-offset: 2px;
-      color: var(--primary);
-    }
-
-    .cb-cost-link:focus-visible .cb-cost-link__icon,
-    .cb-cost-link[data-state="focus"] .cb-cost-link__icon {
-      opacity: 1;
-      width: 10px;
-      transform: translateX(0) translateY(1px);
-    }
-
-    /* ── Active / pressed state ── */
-    .cb-cost-link:active,
-    .cb-cost-link[data-state="active"] {
-      color: var(--primary);
-      transform: scale(0.94);
-      background: color-mix(in oklch, var(--primary) 14%, transparent);
-    }
-
-    .cb-cost-link:active .cb-cost-link__icon,
-    .cb-cost-link[data-state="active"] .cb-cost-link__icon {
-      opacity: 1;
-      width: 10px;
-      transform: translateX(0) translateY(1px);
-    }
-
-    /* ── Tooltip wrapper ── */
-    .cb-cost-link-wrapper {
-      position: relative;
-      display: inline-flex;
-      align-items: center;
-    }
-
-    .cb-cost-link-wrapper .cb-cost-link-tooltip {
-      position: absolute;
-      bottom: calc(100% + 6px);
-      left: 50%;
-      transform: translateX(-50%);
-      background: oklch(0.12 0.02 150);
-      color: oklch(0.97 0.01 130);
-      border: 1px solid color-mix(in oklch, oklch(0.32 0.022 148) 80%, transparent);
-      font-size: 11px;
-      padding: 4px 8px;
-      border-radius: 6px;
-      box-shadow: var(--shadow-md);
-      font-family: var(--font-sans);
-      white-space: nowrap;
-      pointer-events: none;
-      z-index: var(--z-tooltip);
-      opacity: 0;
-      transform: translateX(-50%) translateY(4px);
-      transition:
-        opacity var(--duration-3) var(--ease-out),
-        transform var(--duration-3) var(--ease-out);
-    }
-
-    /* Tooltip arrow */
-    .cb-cost-link-wrapper .cb-cost-link-tooltip::after {
-      content: "";
-      position: absolute;
-      top: 100%;
-      left: 50%;
-      transform: translateX(-50%);
-      border: 4px solid transparent;
-      border-top-color: oklch(0.12 0.02 150);
-    }
-
-    .cb-cost-link-wrapper:hover .cb-cost-link-tooltip {
-      opacity: 1;
-      transform: translateX(-50%) translateY(0);
-    }
-
-    /* ── Frozen/locked states for showcase ── */
-    .cb-cost-link[data-state="default"] {
-      /* Plain rest state — explicit */
-      color: var(--foreground-muted);
-      background: transparent;
-    }
-
-    /* Disable live hover on frozen state demos */
-    .cb-cost-link[data-state="default"]:hover,
-    .cb-cost-link[data-state="active"]:hover {
-      /* Let data-state rule win */
-    }
-
-    /* Force active state to show even without real :active */
-    .cb-cost-link[data-state="active"] {
-      color: var(--primary);
-      transform: scale(0.94);
-      background: color-mix(in oklch, var(--primary) 14%, transparent);
-    }
-
-    .cb-cost-link[data-state="active"] .cb-cost-link__icon {
-      opacity: 1;
-      width: 10px;
-      transform: translateX(0) translateY(1px);
-    }
-
-    /* Force hover state for showcase */
-    .cb-cost-link[data-state="hover"] {
-      color: var(--primary);
-      background: color-mix(in oklch, var(--primary) 8%, transparent);
-    }
-
-    .cb-cost-link[data-state="hover"] .cb-cost-link__icon {
-      opacity: 1;
-      width: 10px;
-      transform: translateX(0) translateY(1px);
-    }
-
-    /* Force focus state for showcase */
-    .cb-cost-link[data-state="focus"] {
-      outline: 2px solid var(--ring);
-      outline-offset: 2px;
-      color: var(--primary);
-    }
-
-    .cb-cost-link[data-state="focus"] .cb-cost-link__icon {
-      opacity: 1;
-      width: 10px;
-      transform: translateX(0) translateY(1px);
-    }
-
-    /* ── Context: Workspace Card ────────────────────────────────── */
-    .workspace-card {
-      background: var(--surface);
-      border: 1px solid var(--border);
-      border-radius: var(--radius-lg);
-      box-shadow: var(--shadow-sm);
-      width: 280px;
-      overflow: hidden;
-    }
-
-    .workspace-card__header {
-      padding: 12px 14px 10px;
-      display: flex;
-      align-items: flex-start;
-      justify-content: space-between;
-      gap: 8px;
-    }
-
-    .workspace-card__name {
-      font-size: 13px;
-      font-weight: 600;
-      color: var(--foreground);
-      letter-spacing: -0.01em;
-      line-height: 1.2;
-    }
-
-    .workspace-card__path {
-      font-family: var(--font-mono);
-      font-size: 10px;
-      color: var(--foreground-subtle);
-      margin-top: 2px;
-    }
-
-    .workspace-card__status-dot {
-      width: 7px;
-      height: 7px;
-      border-radius: 50%;
-      background: var(--session-running);
-      flex-shrink: 0;
-      margin-top: 4px;
-      box-shadow: 0 0 0 2px color-mix(in oklch, var(--session-running) 20%, transparent);
-    }
-
-    .workspace-card__body {
-      padding: 0 14px 10px;
-    }
-
-    .workspace-card__task {
-      font-size: 11.5px;
-      color: var(--foreground-muted);
-      line-height: 1.4;
-      display: -webkit-box;
-      -webkit-line-clamp: 2;
-      -webkit-box-orient: vertical;
-      overflow: hidden;
-    }
-
-    .workspace-card__footer {
-      padding: 8px 14px;
-      border-top: 1px solid var(--border);
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      background: color-mix(in oklch, var(--surface-2) 40%, transparent);
-    }
-
-    .workspace-card__footer-meta {
-      display: flex;
-      align-items: center;
-      gap: 12px;
-    }
-
-    .workspace-card__footer-item {
-      display: flex;
-      align-items: center;
-      gap: 4px;
-      font-size: 11px;
-      color: var(--foreground-subtle);
-      font-family: var(--font-mono);
-    }
-
-    .workspace-card__footer-label {
-      font-size: 10px;
-      color: var(--foreground-subtle);
-      font-family: var(--font-sans);
-    }
-
-    /* ── Context: Session Sidebar ───────────────────────────────── */
-    .session-sidebar {
-      width: 240px;
-      background: var(--sidebar-bg, var(--surface));
-      border: 1px solid var(--border);
-      border-radius: var(--radius-lg);
-      overflow: hidden;
-      box-shadow: var(--shadow-sm);
-    }
-
-    .session-sidebar__header {
-      padding: 10px 12px 8px;
-      border-bottom: 1px solid var(--border);
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-    }
-
-    .session-sidebar__title {
-      font-size: 11px;
-      font-weight: 600;
-      color: var(--foreground-muted);
-      letter-spacing: 0.04em;
-      text-transform: uppercase;
-      font-family: var(--font-mono);
-    }
-
-    .session-sidebar__running-dot {
-      width: 6px;
-      height: 6px;
-      border-radius: 50%;
-      background: var(--session-running);
-      animation: pulse-dot 2s ease-in-out infinite;
-    }
-
-    @keyframes pulse-dot {
-      0%, 100% { opacity: 1; }
-      50% { opacity: 0.4; }
-    }
-
-    .session-sidebar__rows {
-      padding: 8px 0;
-    }
-
-    .session-sidebar__row {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      padding: 5px 12px;
-      gap: 8px;
-    }
-
-    .session-sidebar__row-label {
-      font-size: 11px;
-      color: var(--foreground-subtle);
-      font-family: var(--font-sans);
-      flex-shrink: 0;
-    }
-
-    .session-sidebar__row-value {
-      font-family: var(--font-mono);
-      font-size: 11px;
-      color: var(--foreground-muted);
-      font-variant-numeric: tabular-nums;
-    }
-
-    .session-sidebar__divider {
-      height: 1px;
-      background: var(--border);
-      margin: 4px 0;
-    }
-
-    /* ── Standalone inline usage example ───────────────────────── */
-    .inline-usage-example {
-      background: color-mix(in oklch, var(--surface-2) 60%, transparent);
-      border: 1px solid var(--border);
-      border-radius: var(--radius-md);
-      padding: 16px 18px;
-      font-size: 13px;
-      color: var(--foreground-muted);
-      line-height: 1.6;
-    }
-
-    .inline-usage-example .highlight-segment {
-      color: var(--foreground);
-      font-weight: 500;
-    }
-
-    /* ── Size comparison table ──────────────────────────────────── */
-    .size-table {
-      width: 100%;
-      border-collapse: collapse;
-    }
-
-    .size-table th {
-      font-family: var(--font-mono);
-      font-size: 10px;
-      color: var(--foreground-subtle);
-      letter-spacing: 0.06em;
-      text-transform: uppercase;
-      text-align: left;
-      padding: 0 12px 8px 0;
-      font-weight: 500;
-      border-bottom: 1px solid var(--border);
-    }
-
-    .size-table td {
-      padding: 10px 12px 10px 0;
-      border-bottom: 1px solid color-mix(in oklch, var(--border) 50%, transparent);
-      vertical-align: middle;
-    }
-
-    .size-table td:first-child {
-      font-family: var(--font-mono);
-      font-size: 10.5px;
-      color: var(--foreground-subtle);
-      white-space: nowrap;
-    }
-
-    .size-table tr:last-child td {
-      border-bottom: none;
-    }
-
-    /* ── Magnitude demo ─────────────────────────────────────────── */
-    .magnitude-row {
-      display: flex;
-      align-items: center;
-      gap: 24px;
-      flex-wrap: wrap;
-    }
-
-    .magnitude-item {
-      display: flex;
-      flex-direction: column;
-      gap: 4px;
-    }
-
-    .magnitude-item__label {
-      font-family: var(--font-mono);
-      font-size: 10px;
-      color: var(--foreground-subtle);
-      letter-spacing: 0.04em;
-    }
-
-    /* ── Responsive ─────────────────────────────────────────────── */
-    @media (max-width: 700px) {
-      .page-layout {
-        padding: 24px 20px 40px;
-      }
-
-      .cs-cell-grid.cols-4 {
-        grid-template-columns: repeat(2, 1fr);
-      }
-
-      .cs-cell-grid.cols-3 {
-        grid-template-columns: repeat(2, 1fr);
-      }
-
-      .context-demos {
-        flex-direction: column !important;
-        align-items: flex-start !important;
-      }
-    }
-  </style>
-</head>
-<body>
-<div class="gk-root theme-dark">
-  <div class="page-layout">
-
-    <!-- Page header -->
-    <div class="page-header">
-      <div class="variant-meta">
-        <span class="gk-eyebrow">Design System</span>
-        <span style="color: var(--border); font-size: 11px;">·</span>
-        <span class="gk-eyebrow" style="color: var(--primary);">Variant C — Icon-Appended</span>
-      </div>
-      <h1 class="gk-h1" style="margin: 0 0 6px 0;">CostLink</h1>
-      <p class="gk-body" style="color: var(--foreground-muted); margin: 0;">
-        Clickable cost value that navigates to the Usage page. At rest: plain monospaced text.
-        On hover: arrow-up-right icon fades in + text shifts to primary. Used inline in workspace
-        cards, session sidebars, and summary rows.
-      </p>
-    </div>
-
-    <!-- Section 1: State showcase -->
-    <div class="section">
-      <h2 class="gk-h3 section-title">States — size md (12px)</h2>
-
-      <div class="cs-cell-grid cols-4">
-        <!-- Default -->
-        <div class="cs-cell">
-          <span class="cs-cell-label">default</span>
-          <div class="cs-cell-stage">
-            <div class="cb-cost-link-wrapper">
-              <a href="#" class="cb-cost-link cb-cost-link-md" data-state="default" tabindex="-1" aria-label="$4.82 — View usage details">
-                <span class="cb-cost-link__text">$4.82</span>
-                <span class="cb-cost-link__icon" aria-hidden="true">
-                  <svg width="8" height="8" viewBox="0 0 8 8" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path d="M1.5 6.5L6.5 1.5M6.5 1.5H2.5M6.5 1.5V5.5" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
-                  </svg>
-                </span>
-              </a>
-            </div>
-          </div>
-        </div>
-
-        <!-- Hover — icon visible, text primary -->
-        <div class="cs-cell">
-          <span class="cs-cell-label">hover</span>
-          <div class="cs-cell-stage">
-            <div class="cb-cost-link-wrapper">
-              <a href="#" class="cb-cost-link cb-cost-link-md" data-state="hover" tabindex="-1" aria-label="$4.82 — View usage details">
-                <span class="cb-cost-link__text">$4.82</span>
-                <span class="cb-cost-link__icon" aria-hidden="true">
-                  <svg width="8" height="8" viewBox="0 0 8 8" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path d="M1.5 6.5L6.5 1.5M6.5 1.5H2.5M6.5 1.5V5.5" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
-                  </svg>
-                </span>
-              </a>
-              <div class="cb-cost-link-tooltip">View usage details</div>
-            </div>
-          </div>
-        </div>
-
-        <!-- Focus -->
-        <div class="cs-cell">
-          <span class="cs-cell-label">focus</span>
-          <div class="cs-cell-stage">
-            <div class="cb-cost-link-wrapper">
-              <a href="#" class="cb-cost-link cb-cost-link-md" data-state="focus" tabindex="-1" aria-label="$4.82 — View usage details">
-                <span class="cb-cost-link__text">$4.82</span>
-                <span class="cb-cost-link__icon" aria-hidden="true">
-                  <svg width="8" height="8" viewBox="0 0 8 8" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path d="M1.5 6.5L6.5 1.5M6.5 1.5H2.5M6.5 1.5V5.5" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
-                  </svg>
-                </span>
-              </a>
-            </div>
-          </div>
-        </div>
-
-        <!-- Active / pressed -->
-        <div class="cs-cell">
-          <span class="cs-cell-label">active / pressed</span>
-          <div class="cs-cell-stage">
-            <div class="cb-cost-link-wrapper">
-              <a href="#" class="cb-cost-link cb-cost-link-md" data-state="active" tabindex="-1" aria-label="$4.82 — View usage details">
-                <span class="cb-cost-link__text">$4.82</span>
-                <span class="cb-cost-link__icon" aria-hidden="true">
-                  <svg width="8" height="8" viewBox="0 0 8 8" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path d="M1.5 6.5L6.5 1.5M6.5 1.5H2.5M6.5 1.5V5.5" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
-                  </svg>
-                </span>
-              </a>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <!-- States — sm -->
-      <h2 class="gk-h3 section-title" style="margin-top: 24px;">States — size sm (10.5px)</h2>
-
-      <div class="cs-cell-grid cols-4">
-        <!-- Default sm -->
-        <div class="cs-cell">
-          <span class="cs-cell-label">default</span>
-          <div class="cs-cell-stage">
-            <div class="cb-cost-link-wrapper">
-              <a href="#" class="cb-cost-link cb-cost-link-sm" data-state="default" tabindex="-1" aria-label="$4.82 — View usage details">
-                <span class="cb-cost-link__text">$4.82</span>
-                <span class="cb-cost-link__icon" aria-hidden="true">
-                  <svg width="8" height="8" viewBox="0 0 8 8" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path d="M1.5 6.5L6.5 1.5M6.5 1.5H2.5M6.5 1.5V5.5" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
-                  </svg>
-                </span>
-              </a>
-            </div>
-          </div>
-        </div>
-
-        <!-- Hover sm -->
-        <div class="cs-cell">
-          <span class="cs-cell-label">hover</span>
-          <div class="cs-cell-stage">
-            <div class="cb-cost-link-wrapper">
-              <a href="#" class="cb-cost-link cb-cost-link-sm" data-state="hover" tabindex="-1" aria-label="$4.82 — View usage details">
-                <span class="cb-cost-link__text">$4.82</span>
-                <span class="cb-cost-link__icon" aria-hidden="true">
-                  <svg width="8" height="8" viewBox="0 0 8 8" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path d="M1.5 6.5L6.5 1.5M6.5 1.5H2.5M6.5 1.5V5.5" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
-                  </svg>
-                </span>
-              </a>
-              <div class="cb-cost-link-tooltip">View usage details</div>
-            </div>
-          </div>
-        </div>
-
-        <!-- Focus sm -->
-        <div class="cs-cell">
-          <span class="cs-cell-label">focus</span>
-          <div class="cs-cell-stage">
-            <div class="cb-cost-link-wrapper">
-              <a href="#" class="cb-cost-link cb-cost-link-sm" data-state="focus" tabindex="-1" aria-label="$4.82 — View usage details">
-                <span class="cb-cost-link__text">$4.82</span>
-                <span class="cb-cost-link__icon" aria-hidden="true">
-                  <svg width="8" height="8" viewBox="0 0 8 8" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path d="M1.5 6.5L6.5 1.5M6.5 1.5H2.5M6.5 1.5V5.5" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
-                  </svg>
-                </span>
-              </a>
-            </div>
-          </div>
-        </div>
-
-        <!-- Active sm -->
-        <div class="cs-cell">
-          <span class="cs-cell-label">active / pressed</span>
-          <div class="cs-cell-stage">
-            <div class="cb-cost-link-wrapper">
-              <a href="#" class="cb-cost-link cb-cost-link-sm" data-state="active" tabindex="-1" aria-label="$4.82 — View usage details">
-                <span class="cb-cost-link__text">$4.82</span>
-                <span class="cb-cost-link__icon" aria-hidden="true">
-                  <svg width="8" height="8" viewBox="0 0 8 8" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path d="M1.5 6.5L6.5 1.5M6.5 1.5H2.5M6.5 1.5V5.5" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
-                  </svg>
-                </span>
-              </a>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <!-- Section 2: Cost magnitudes -->
-    <div class="section">
-      <h2 class="gk-h3 section-title">Cost magnitudes — hover one to see icon</h2>
-
-      <div class="cs-cell" style="padding: 20px 18px;">
-        <div class="magnitude-row">
-          <!-- $0.12 — micro session -->
-          <div class="magnitude-item">
-            <span class="magnitude-item__label">micro session</span>
-            <div class="cb-cost-link-wrapper">
-              <a href="#" class="cb-cost-link cb-cost-link-md" aria-label="$0.12 — View usage details">
-                <span class="cb-cost-link__text">$0.12</span>
-                <span class="cb-cost-link__icon" aria-hidden="true">
-                  <svg width="8" height="8" viewBox="0 0 8 8" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path d="M1.5 6.5L6.5 1.5M6.5 1.5H2.5M6.5 1.5V5.5" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
-                  </svg>
-                </span>
-              </a>
-              <div class="cb-cost-link-tooltip">View usage details</div>
-            </div>
-          </div>
-
-          <!-- $4.82 — typical session -->
-          <div class="magnitude-item">
-            <span class="magnitude-item__label">typical session</span>
-            <div class="cb-cost-link-wrapper">
-              <a href="#" class="cb-cost-link cb-cost-link-md" aria-label="$4.82 — View usage details">
-                <span class="cb-cost-link__text">$4.82</span>
-                <span class="cb-cost-link__icon" aria-hidden="true">
-                  <svg width="8" height="8" viewBox="0 0 8 8" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path d="M1.5 6.5L6.5 1.5M6.5 1.5H2.5M6.5 1.5V5.5" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
-                  </svg>
-                </span>
-              </a>
-              <div class="cb-cost-link-tooltip">View usage details</div>
-            </div>
-          </div>
-
-          <!-- $124.50 — heavy workspace -->
-          <div class="magnitude-item">
-            <span class="magnitude-item__label">heavy workspace</span>
-            <div class="cb-cost-link-wrapper">
-              <a href="#" class="cb-cost-link cb-cost-link-md" aria-label="$124.50 — View usage details">
-                <span class="cb-cost-link__text">$124.50</span>
-                <span class="cb-cost-link__icon" aria-hidden="true">
-                  <svg width="8" height="8" viewBox="0 0 8 8" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path d="M1.5 6.5L6.5 1.5M6.5 1.5H2.5M6.5 1.5V5.5" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
-                  </svg>
-                </span>
-              </a>
-              <div class="cb-cost-link-tooltip">View usage details</div>
-            </div>
-          </div>
-
-          <!-- $0.12 sm -->
-          <div class="magnitude-item">
-            <span class="magnitude-item__label">micro · sm</span>
-            <div class="cb-cost-link-wrapper">
-              <a href="#" class="cb-cost-link cb-cost-link-sm" aria-label="$0.12 — View usage details">
-                <span class="cb-cost-link__text">$0.12</span>
-                <span class="cb-cost-link__icon" aria-hidden="true">
-                  <svg width="8" height="8" viewBox="0 0 8 8" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path d="M1.5 6.5L6.5 1.5M6.5 1.5H2.5M6.5 1.5V5.5" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
-                  </svg>
-                </span>
-              </a>
-              <div class="cb-cost-link-tooltip">View usage details</div>
-            </div>
-          </div>
-
-          <!-- $124.50 sm -->
-          <div class="magnitude-item">
-            <span class="magnitude-item__label">heavy · sm</span>
-            <div class="cb-cost-link-wrapper">
-              <a href="#" class="cb-cost-link cb-cost-link-sm" aria-label="$124.50 — View usage details">
-                <span class="cb-cost-link__text">$124.50</span>
-                <span class="cb-cost-link__icon" aria-hidden="true">
-                  <svg width="8" height="8" viewBox="0 0 8 8" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path d="M1.5 6.5L6.5 1.5M6.5 1.5H2.5M6.5 1.5V5.5" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
-                  </svg>
-                </span>
-              </a>
-              <div class="cb-cost-link-tooltip">View usage details</div>
-            </div>
-          </div>
-
-          <!-- Hover-pinned example -->
-          <div class="magnitude-item">
-            <span class="magnitude-item__label" style="color: var(--primary);">hover pinned ↓</span>
-            <div class="cb-cost-link-wrapper">
-              <a href="#" class="cb-cost-link cb-cost-link-md" data-state="hover" tabindex="-1" aria-label="$4.82 — View usage details">
-                <span class="cb-cost-link__text">$4.82</span>
-                <span class="cb-cost-link__icon" aria-hidden="true">
-                  <svg width="8" height="8" viewBox="0 0 8 8" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path d="M1.5 6.5L6.5 1.5M6.5 1.5H2.5M6.5 1.5V5.5" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
-                  </svg>
-                </span>
-              </a>
-              <div class="cb-cost-link-tooltip" style="opacity: 1; transform: translateX(-50%) translateY(0);">View usage details</div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <!-- Section 3: In-context demos -->
-    <div class="section">
-      <h2 class="gk-h3 section-title">In context</h2>
-
-      <div class="context-demos" style="display: flex; align-items: flex-start; gap: 16px; flex-wrap: wrap;">
-
-        <!-- Workspace card -->
-        <div class="workspace-card">
-          <div class="workspace-card__header">
-            <div>
-              <div class="workspace-card__name">grovekeeper</div>
-              <div class="workspace-card__path">~/projects/grovekeeper</div>
-            </div>
-            <div class="workspace-card__status-dot"></div>
-          </div>
-          <div class="workspace-card__body">
-            <div class="workspace-card__task">
-              Implement session sidebar cost tracking with real-time token usage updates
-            </div>
-          </div>
-          <div class="workspace-card__footer">
-            <div class="workspace-card__footer-meta">
-              <div class="workspace-card__footer-item">
-                <svg width="10" height="10" viewBox="0 0 10 10" fill="none" style="opacity: 0.5;">
-                  <circle cx="5" cy="5" r="4" stroke="currentColor" stroke-width="1.25"/>
-                  <path d="M5 3V5.5L6.5 6.5" stroke="currentColor" stroke-width="1.25" stroke-linecap="round"/>
-                </svg>
-                <span>2h 14m</span>
-              </div>
-              <div class="workspace-card__footer-item">
-                <svg width="10" height="10" viewBox="0 0 10 10" fill="none" style="opacity: 0.5;">
-                  <path d="M2 7L4.5 3L7 5.5L8.5 3" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
-                </svg>
-                <span>84k tok</span>
-              </div>
-            </div>
-            <div style="display: flex; align-items: center; gap: 5px;">
-              <span class="workspace-card__footer-label">cost</span>
-              <!-- CostLink sm in workspace card footer -->
-              <div class="cb-cost-link-wrapper">
-                <a href="#" class="cb-cost-link cb-cost-link-sm" aria-label="$4.82 — View usage details">
-                  <span class="cb-cost-link__text">$4.82</span>
-                  <span class="cb-cost-link__icon" aria-hidden="true">
-                    <svg width="8" height="8" viewBox="0 0 8 8" fill="none" xmlns="http://www.w3.org/2000/svg">
-                      <path d="M1.5 6.5L6.5 1.5M6.5 1.5H2.5M6.5 1.5V5.5" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
-                    </svg>
-                  </span>
-                </a>
-                <div class="cb-cost-link-tooltip">View usage details</div>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <!-- Session sidebar -->
-        <div class="session-sidebar">
-          <div class="session-sidebar__header">
-            <span class="session-sidebar__title">Session</span>
-            <div class="session-sidebar__running-dot"></div>
-          </div>
-          <div class="session-sidebar__rows">
-            <div class="session-sidebar__row">
-              <span class="session-sidebar__row-label">Model</span>
-              <span class="session-sidebar__row-value">claude-sonnet-4-6</span>
-            </div>
-            <div class="session-sidebar__row">
-              <span class="session-sidebar__row-label">Duration</span>
-              <span class="session-sidebar__row-value">47m 12s</span>
-            </div>
-            <div class="session-sidebar__row">
-              <span class="session-sidebar__row-label">Tokens in</span>
-              <span class="session-sidebar__row-value">192,840</span>
-            </div>
-            <div class="session-sidebar__row">
-              <span class="session-sidebar__row-label">Tokens out</span>
-              <span class="session-sidebar__row-value">38,220</span>
-            </div>
-            <div class="session-sidebar__divider"></div>
-            <div class="session-sidebar__row">
-              <span class="session-sidebar__row-label">Cost</span>
-              <!-- CostLink md in session sidebar -->
-              <div class="cb-cost-link-wrapper">
-                <a href="#" class="cb-cost-link cb-cost-link-md" aria-label="$0.12 — View usage details">
-                  <span class="cb-cost-link__text">$0.12</span>
-                  <span class="cb-cost-link__icon" aria-hidden="true">
-                    <svg width="8" height="8" viewBox="0 0 8 8" fill="none" xmlns="http://www.w3.org/2000/svg">
-                      <path d="M1.5 6.5L6.5 1.5M6.5 1.5H2.5M6.5 1.5V5.5" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
-                    </svg>
-                  </span>
-                </a>
-                <div class="cb-cost-link-tooltip">View usage details</div>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <!-- Inline prose example -->
-        <div class="inline-usage-example" style="flex: 1; min-width: 220px;">
-          <p style="margin: 0 0 10px 0; font-size: 12px; color: var(--foreground-subtle); font-family: var(--font-mono); letter-spacing: 0.04em; text-transform: uppercase;">Inline prose usage</p>
-          <p style="margin: 0; font-size: 13px; line-height: 1.65; color: var(--foreground-muted);">
-            Session <span class="highlight-segment">feat/cost-tracking</span> completed 38 tool calls
-            and consumed <span class="highlight-segment">231k tokens</span> at a total cost of
-            <!-- CostLink inline in text -->
-            <div class="cb-cost-link-wrapper" style="display: inline-flex;">
-              <a href="#" class="cb-cost-link cb-cost-link-md" aria-label="$124.50 — View usage details">
-                <span class="cb-cost-link__text">$124.50</span>
-                <span class="cb-cost-link__icon" aria-hidden="true">
-                  <svg width="8" height="8" viewBox="0 0 8 8" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path d="M1.5 6.5L6.5 1.5M6.5 1.5H2.5M6.5 1.5V5.5" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
-                  </svg>
-                </span>
-              </a>
-              <div class="cb-cost-link-tooltip">View usage details</div>
-            </div>
-            — well within the monthly budget of $200.
-          </p>
-          <p style="margin: 12px 0 0 0; font-size: 12px; color: var(--foreground-subtle); font-style: italic;">
-            Hover the cost value above to see the icon appear.
-          </p>
-        </div>
-
-      </div>
-    </div>
-
-    <!-- Section 4: Size comparison -->
-    <div class="section">
-      <h2 class="gk-h3 section-title">Size reference</h2>
-      <div class="cs-cell">
-        <table class="size-table">
-          <thead>
-            <tr>
-              <th>Size</th>
-              <th>Token</th>
-              <th>Font size</th>
-              <th>Use case</th>
-              <th>Example</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>sm</td>
-              <td><code style="font-family: var(--font-mono); font-size: 10.5px; color: var(--primary);">cb-cost-link-sm</code></td>
-              <td style="font-family: var(--font-mono); font-size: 11px; color: var(--foreground-muted);">10.5px / --text-2xs</td>
-              <td style="font-size: 12px; color: var(--foreground-muted);">Workspace card footer, compact rows</td>
-              <td>
-                <div class="cb-cost-link-wrapper">
-                  <a href="#" class="cb-cost-link cb-cost-link-sm" aria-label="$4.82">
-                    <span class="cb-cost-link__text">$4.82</span>
-                    <span class="cb-cost-link__icon" aria-hidden="true">
-                      <svg width="8" height="8" viewBox="0 0 8 8" fill="none">
-                        <path d="M1.5 6.5L6.5 1.5M6.5 1.5H2.5M6.5 1.5V5.5" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
-                      </svg>
-                    </span>
-                  </a>
-                  <div class="cb-cost-link-tooltip">View usage details</div>
-                </div>
-              </td>
-            </tr>
-            <tr>
-              <td>md</td>
-              <td><code style="font-family: var(--font-mono); font-size: 10.5px; color: var(--primary);">cb-cost-link-md</code></td>
-              <td style="font-family: var(--font-mono); font-size: 11px; color: var(--foreground-muted);">12px / --text-sm</td>
-              <td style="font-size: 12px; color: var(--foreground-muted);">Session sidebar, inline prose, summary rows</td>
-              <td>
-                <div class="cb-cost-link-wrapper">
-                  <a href="#" class="cb-cost-link cb-cost-link-md" aria-label="$4.82">
-                    <span class="cb-cost-link__text">$4.82</span>
-                    <span class="cb-cost-link__icon" aria-hidden="true">
-                      <svg width="8" height="8" viewBox="0 0 8 8" fill="none">
-                        <path d="M1.5 6.5L6.5 1.5M6.5 1.5H2.5M6.5 1.5V5.5" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
-                      </svg>
-                    </span>
-                  </a>
-                  <div class="cb-cost-link-tooltip">View usage details</div>
-                </div>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </div>
-
-    <!-- Section 5: CodeBurn panel context -->
-    <div class="section">
-      <h2 class="gk-h3 section-title">CodeBurn panel context</h2>
-      <div class="cb-panel" style="max-width: 420px;">
-        <div class="cb-panel-title">
-          Usage summary
-          <span class="cb-panel-sub">May 2026</span>
-        </div>
-        <div style="display: flex; flex-direction: column; gap: 6px;">
-          <!-- Row 1 -->
-          <div style="display: grid; grid-template-columns: 1fr auto auto; align-items: center; gap: 10px; padding: 4px 0; border-bottom: 1px solid color-mix(in oklch, var(--border) 40%, transparent);">
-            <span style="font-size: 12px; color: var(--foreground-muted);">grovekeeper</span>
-            <span style="font-family: var(--font-mono); font-size: 10.5px; color: var(--foreground-subtle);">842k tok</span>
-            <div class="cb-cost-link-wrapper">
-              <a href="#" class="cb-cost-link cb-cost-link-sm" aria-label="$124.50 — View usage details">
-                <span class="cb-cost-link__text">$124.50</span>
-                <span class="cb-cost-link__icon" aria-hidden="true">
-                  <svg width="8" height="8" viewBox="0 0 8 8" fill="none">
-                    <path d="M1.5 6.5L6.5 1.5M6.5 1.5H2.5M6.5 1.5V5.5" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
-                  </svg>
-                </span>
-              </a>
-              <div class="cb-cost-link-tooltip">View usage details</div>
-            </div>
-          </div>
-          <!-- Row 2 -->
-          <div style="display: grid; grid-template-columns: 1fr auto auto; align-items: center; gap: 10px; padding: 4px 0; border-bottom: 1px solid color-mix(in oklch, var(--border) 40%, transparent);">
-            <span style="font-size: 12px; color: var(--foreground-muted);">low-poly-2d-trees</span>
-            <span style="font-family: var(--font-mono); font-size: 10.5px; color: var(--foreground-subtle);">31k tok</span>
-            <div class="cb-cost-link-wrapper">
-              <a href="#" class="cb-cost-link cb-cost-link-sm" aria-label="$4.82 — View usage details">
-                <span class="cb-cost-link__text">$4.82</span>
-                <span class="cb-cost-link__icon" aria-hidden="true">
-                  <svg width="8" height="8" viewBox="0 0 8 8" fill="none">
-                    <path d="M1.5 6.5L6.5 1.5M6.5 1.5H2.5M6.5 1.5V5.5" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
-                  </svg>
-                </span>
-              </a>
-              <div class="cb-cost-link-tooltip">View usage details</div>
-            </div>
-          </div>
-          <!-- Row 3 -->
-          <div style="display: grid; grid-template-columns: 1fr auto auto; align-items: center; gap: 10px; padding: 4px 0;">
-            <span style="font-size: 12px; color: var(--foreground-muted);">dotfiles</span>
-            <span style="font-family: var(--font-mono); font-size: 10.5px; color: var(--foreground-subtle);">820 tok</span>
-            <div class="cb-cost-link-wrapper">
-              <a href="#" class="cb-cost-link cb-cost-link-sm" aria-label="$0.12 — View usage details">
-                <span class="cb-cost-link__text">$0.12</span>
-                <span class="cb-cost-link__icon" aria-hidden="true">
-                  <svg width="8" height="8" viewBox="0 0 8 8" fill="none">
-                    <path d="M1.5 6.5L6.5 1.5M6.5 1.5H2.5M6.5 1.5V5.5" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
-                  </svg>
-                </span>
-              </a>
-              <div class="cb-cost-link-tooltip">View usage details</div>
-            </div>
-          </div>
-        </div>
-        <!-- Total row -->
-        <div style="display: flex; align-items: center; justify-content: space-between; padding-top: 8px; border-top: 1px dashed var(--border); margin-top: 2px;">
-          <span style="font-family: var(--font-mono); font-size: 10.5px; color: var(--foreground-subtle); text-transform: uppercase; letter-spacing: 0.06em;">Total</span>
-          <div class="cb-cost-link-wrapper">
-            <a href="#" class="cb-cost-link cb-cost-link-md" style="font-weight: 600; color: var(--foreground);" aria-label="$129.44 — View usage details">
-              <span class="cb-cost-link__text">$129.44</span>
-              <span class="cb-cost-link__icon" aria-hidden="true">
-                <svg width="8" height="8" viewBox="0 0 8 8" fill="none">
-                  <path d="M1.5 6.5L6.5 1.5M6.5 1.5H2.5M6.5 1.5V5.5" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
-                </svg>
-              </span>
-            </a>
-            <div class="cb-cost-link-tooltip">View usage details</div>
-          </div>
-        </div>
-      </div>
-    </div>
-
-  </div>
-</div>
-</body>
+			.cb-cost-link {
+				/* Inline-flex so it sits naturally in text flow */
+				display: inline-flex;
+				align-items: center;
+				gap: 0;
+				position: relative;
+
+				/* Monospaced for tabular-nums alignment */
+				font-family: var(--font-mono);
+				font-variant-numeric: tabular-nums;
+				font-feature-settings: 'tnum';
+
+				/* No underline — navigation is signaled by icon + color, not underline */
+				text-decoration: none;
+				cursor: pointer;
+				outline: none;
+				border: none;
+				background: transparent;
+				padding: 1px 2px;
+				border-radius: var(--radius-xs);
+
+				/* Color at rest: muted, reads as data, not a link */
+				color: var(--foreground-muted);
+
+				/* Transitions */
+				transition:
+					color var(--duration-2) var(--ease-standard),
+					background var(--duration-2) var(--ease-standard);
+
+				/* Prevents layout shift when icon appears */
+				white-space: nowrap;
+			}
+
+			/* Size: sm — 10.5px, matches --text-2xs */
+			.cb-cost-link-sm {
+				font-size: 10.5px;
+				line-height: 14px;
+			}
+
+			/* Size: md — 12px, matches --text-sm */
+			.cb-cost-link-md {
+				font-size: 12px;
+				line-height: 16px;
+			}
+
+			/* The cost text itself — inherits font from parent */
+			.cb-cost-link__text {
+				/* Slight letter-spacing tightening for mono numerics */
+				letter-spacing: -0.01em;
+			}
+
+			/* The arrow icon — hidden at rest */
+			.cb-cost-link__icon {
+				display: inline-flex;
+				align-items: center;
+				justify-content: center;
+				width: 0;
+				overflow: hidden;
+				opacity: 0;
+				/* Slides in from left — compact feel, no layout jump */
+				transform: translateX(-2px) translateY(1px);
+				transition:
+					opacity var(--duration-3) var(--ease-out),
+					width var(--duration-3) var(--ease-out),
+					transform var(--duration-3) var(--ease-out);
+				flex-shrink: 0;
+			}
+
+			/* sm: icon is 8px */
+			.cb-cost-link-sm .cb-cost-link__icon {
+				/* height matches line-height of adjacent text */
+				height: 14px;
+			}
+
+			/* md: icon is 8px, height matches md line-height */
+			.cb-cost-link-md .cb-cost-link__icon {
+				height: 16px;
+			}
+
+			/* ── Hover state ── */
+			.cb-cost-link:hover,
+			.cb-cost-link[data-state='hover'] {
+				color: var(--primary);
+				background: color-mix(in oklch, var(--primary) 8%, transparent);
+			}
+
+			.cb-cost-link:hover .cb-cost-link__icon,
+			.cb-cost-link[data-state='hover'] .cb-cost-link__icon {
+				opacity: 1;
+				width: 10px; /* slight breathing room */
+				transform: translateX(0) translateY(1px);
+			}
+
+			/* ── Focus state ── */
+			.cb-cost-link:focus-visible,
+			.cb-cost-link[data-state='focus'] {
+				outline: 2px solid var(--ring);
+				outline-offset: 2px;
+				color: var(--primary);
+			}
+
+			.cb-cost-link:focus-visible .cb-cost-link__icon,
+			.cb-cost-link[data-state='focus'] .cb-cost-link__icon {
+				opacity: 1;
+				width: 10px;
+				transform: translateX(0) translateY(1px);
+			}
+
+			/* ── Active / pressed state ── */
+			.cb-cost-link:active,
+			.cb-cost-link[data-state='active'] {
+				color: var(--primary);
+				transform: scale(0.94);
+				background: color-mix(in oklch, var(--primary) 14%, transparent);
+			}
+
+			.cb-cost-link:active .cb-cost-link__icon,
+			.cb-cost-link[data-state='active'] .cb-cost-link__icon {
+				opacity: 1;
+				width: 10px;
+				transform: translateX(0) translateY(1px);
+			}
+
+			/* ── Tooltip wrapper ── */
+			.cb-cost-link-wrapper {
+				position: relative;
+				display: inline-flex;
+				align-items: center;
+			}
+
+			.cb-cost-link-wrapper .cb-cost-link-tooltip {
+				position: absolute;
+				bottom: calc(100% + 6px);
+				left: 50%;
+				transform: translateX(-50%);
+				background: oklch(0.12 0.02 150);
+				color: oklch(0.97 0.01 130);
+				border: 1px solid color-mix(in oklch, oklch(0.32 0.022 148) 80%, transparent);
+				font-size: 11px;
+				padding: 4px 8px;
+				border-radius: 6px;
+				box-shadow: var(--shadow-md);
+				font-family: var(--font-sans);
+				white-space: nowrap;
+				pointer-events: none;
+				z-index: var(--z-tooltip);
+				opacity: 0;
+				transform: translateX(-50%) translateY(4px);
+				transition:
+					opacity var(--duration-3) var(--ease-out),
+					transform var(--duration-3) var(--ease-out);
+			}
+
+			/* Tooltip arrow */
+			.cb-cost-link-wrapper .cb-cost-link-tooltip::after {
+				content: '';
+				position: absolute;
+				top: 100%;
+				left: 50%;
+				transform: translateX(-50%);
+				border: 4px solid transparent;
+				border-top-color: oklch(0.12 0.02 150);
+			}
+
+			.cb-cost-link-wrapper:hover .cb-cost-link-tooltip {
+				opacity: 1;
+				transform: translateX(-50%) translateY(0);
+			}
+
+			/* ── Frozen/locked states for showcase ── */
+			.cb-cost-link[data-state='default'] {
+				/* Plain rest state — explicit */
+				color: var(--foreground-muted);
+				background: transparent;
+			}
+
+			/* Disable live hover on frozen state demos */
+			.cb-cost-link[data-state='default']:hover,
+			.cb-cost-link[data-state='active']:hover {
+				/* Let data-state rule win */
+			}
+
+			/* Force active state to show even without real :active */
+			.cb-cost-link[data-state='active'] {
+				color: var(--primary);
+				transform: scale(0.94);
+				background: color-mix(in oklch, var(--primary) 14%, transparent);
+			}
+
+			.cb-cost-link[data-state='active'] .cb-cost-link__icon {
+				opacity: 1;
+				width: 10px;
+				transform: translateX(0) translateY(1px);
+			}
+
+			/* Force hover state for showcase */
+			.cb-cost-link[data-state='hover'] {
+				color: var(--primary);
+				background: color-mix(in oklch, var(--primary) 8%, transparent);
+			}
+
+			.cb-cost-link[data-state='hover'] .cb-cost-link__icon {
+				opacity: 1;
+				width: 10px;
+				transform: translateX(0) translateY(1px);
+			}
+
+			/* Force focus state for showcase */
+			.cb-cost-link[data-state='focus'] {
+				outline: 2px solid var(--ring);
+				outline-offset: 2px;
+				color: var(--primary);
+			}
+
+			.cb-cost-link[data-state='focus'] .cb-cost-link__icon {
+				opacity: 1;
+				width: 10px;
+				transform: translateX(0) translateY(1px);
+			}
+
+			/* ── Context: Workspace Card ────────────────────────────────── */
+			.workspace-card {
+				background: var(--surface);
+				border: 1px solid var(--border);
+				border-radius: var(--radius-lg);
+				box-shadow: var(--shadow-sm);
+				width: 280px;
+				overflow: hidden;
+			}
+
+			.workspace-card__header {
+				padding: 12px 14px 10px;
+				display: flex;
+				align-items: flex-start;
+				justify-content: space-between;
+				gap: 8px;
+			}
+
+			.workspace-card__name {
+				font-size: 13px;
+				font-weight: 600;
+				color: var(--foreground);
+				letter-spacing: -0.01em;
+				line-height: 1.2;
+			}
+
+			.workspace-card__path {
+				font-family: var(--font-mono);
+				font-size: 10px;
+				color: var(--foreground-subtle);
+				margin-top: 2px;
+			}
+
+			.workspace-card__status-dot {
+				width: 7px;
+				height: 7px;
+				border-radius: 50%;
+				background: var(--session-running);
+				flex-shrink: 0;
+				margin-top: 4px;
+				box-shadow: 0 0 0 2px color-mix(in oklch, var(--session-running) 20%, transparent);
+			}
+
+			.workspace-card__body {
+				padding: 0 14px 10px;
+			}
+
+			.workspace-card__task {
+				font-size: 11.5px;
+				color: var(--foreground-muted);
+				line-height: 1.4;
+				display: -webkit-box;
+				-webkit-line-clamp: 2;
+				-webkit-box-orient: vertical;
+				overflow: hidden;
+			}
+
+			.workspace-card__footer {
+				padding: 8px 14px;
+				border-top: 1px solid var(--border);
+				display: flex;
+				align-items: center;
+				justify-content: space-between;
+				background: color-mix(in oklch, var(--surface-2) 40%, transparent);
+			}
+
+			.workspace-card__footer-meta {
+				display: flex;
+				align-items: center;
+				gap: 12px;
+			}
+
+			.workspace-card__footer-item {
+				display: flex;
+				align-items: center;
+				gap: 4px;
+				font-size: 11px;
+				color: var(--foreground-subtle);
+				font-family: var(--font-mono);
+			}
+
+			.workspace-card__footer-label {
+				font-size: 10px;
+				color: var(--foreground-subtle);
+				font-family: var(--font-sans);
+			}
+
+			/* ── Context: Session Sidebar ───────────────────────────────── */
+			.session-sidebar {
+				width: 240px;
+				background: var(--sidebar-bg, var(--surface));
+				border: 1px solid var(--border);
+				border-radius: var(--radius-lg);
+				overflow: hidden;
+				box-shadow: var(--shadow-sm);
+			}
+
+			.session-sidebar__header {
+				padding: 10px 12px 8px;
+				border-bottom: 1px solid var(--border);
+				display: flex;
+				align-items: center;
+				justify-content: space-between;
+			}
+
+			.session-sidebar__title {
+				font-size: 11px;
+				font-weight: 600;
+				color: var(--foreground-muted);
+				letter-spacing: 0.04em;
+				text-transform: uppercase;
+				font-family: var(--font-mono);
+			}
+
+			.session-sidebar__running-dot {
+				width: 6px;
+				height: 6px;
+				border-radius: 50%;
+				background: var(--session-running);
+				animation: pulse-dot 2s ease-in-out infinite;
+			}
+
+			@keyframes pulse-dot {
+				0%,
+				100% {
+					opacity: 1;
+				}
+				50% {
+					opacity: 0.4;
+				}
+			}
+
+			.session-sidebar__rows {
+				padding: 8px 0;
+			}
+
+			.session-sidebar__row {
+				display: flex;
+				align-items: center;
+				justify-content: space-between;
+				padding: 5px 12px;
+				gap: 8px;
+			}
+
+			.session-sidebar__row-label {
+				font-size: 11px;
+				color: var(--foreground-subtle);
+				font-family: var(--font-sans);
+				flex-shrink: 0;
+			}
+
+			.session-sidebar__row-value {
+				font-family: var(--font-mono);
+				font-size: 11px;
+				color: var(--foreground-muted);
+				font-variant-numeric: tabular-nums;
+			}
+
+			.session-sidebar__divider {
+				height: 1px;
+				background: var(--border);
+				margin: 4px 0;
+			}
+
+			/* ── Standalone inline usage example ───────────────────────── */
+			.inline-usage-example {
+				background: color-mix(in oklch, var(--surface-2) 60%, transparent);
+				border: 1px solid var(--border);
+				border-radius: var(--radius-md);
+				padding: 16px 18px;
+				font-size: 13px;
+				color: var(--foreground-muted);
+				line-height: 1.6;
+			}
+
+			.inline-usage-example .highlight-segment {
+				color: var(--foreground);
+				font-weight: 500;
+			}
+
+			/* ── Size comparison table ──────────────────────────────────── */
+			.size-table {
+				width: 100%;
+				border-collapse: collapse;
+			}
+
+			.size-table th {
+				font-family: var(--font-mono);
+				font-size: 10px;
+				color: var(--foreground-subtle);
+				letter-spacing: 0.06em;
+				text-transform: uppercase;
+				text-align: left;
+				padding: 0 12px 8px 0;
+				font-weight: 500;
+				border-bottom: 1px solid var(--border);
+			}
+
+			.size-table td {
+				padding: 10px 12px 10px 0;
+				border-bottom: 1px solid color-mix(in oklch, var(--border) 50%, transparent);
+				vertical-align: middle;
+			}
+
+			.size-table td:first-child {
+				font-family: var(--font-mono);
+				font-size: 10.5px;
+				color: var(--foreground-subtle);
+				white-space: nowrap;
+			}
+
+			.size-table tr:last-child td {
+				border-bottom: none;
+			}
+
+			/* ── Magnitude demo ─────────────────────────────────────────── */
+			.magnitude-row {
+				display: flex;
+				align-items: center;
+				gap: 24px;
+				flex-wrap: wrap;
+			}
+
+			.magnitude-item {
+				display: flex;
+				flex-direction: column;
+				gap: 4px;
+			}
+
+			.magnitude-item__label {
+				font-family: var(--font-mono);
+				font-size: 10px;
+				color: var(--foreground-subtle);
+				letter-spacing: 0.04em;
+			}
+
+			/* ── Responsive ─────────────────────────────────────────────── */
+			@media (max-width: 700px) {
+				.page-layout {
+					padding: 24px 20px 40px;
+				}
+
+				.cs-cell-grid.cols-4 {
+					grid-template-columns: repeat(2, 1fr);
+				}
+
+				.cs-cell-grid.cols-3 {
+					grid-template-columns: repeat(2, 1fr);
+				}
+
+				.context-demos {
+					flex-direction: column !important;
+					align-items: flex-start !important;
+				}
+			}
+		</style>
+	</head>
+	<body>
+		<div class="gk-root theme-dark">
+			<div class="page-layout">
+				<!-- Page header -->
+				<div class="page-header">
+					<div class="variant-meta">
+						<span class="gk-eyebrow">Design System</span>
+						<span style="color: var(--border); font-size: 11px">·</span>
+						<span class="gk-eyebrow" style="color: var(--primary)"
+							>Variant C — Icon-Appended</span
+						>
+					</div>
+					<h1 class="gk-h1" style="margin: 0 0 6px 0">CostLink</h1>
+					<p class="gk-body" style="color: var(--foreground-muted); margin: 0">
+						Clickable cost value that navigates to the Usage page. At rest: plain
+						monospaced text. On hover: arrow-up-right icon fades in + text shifts to
+						primary. Used inline in workspace cards, session sidebars, and summary rows.
+					</p>
+				</div>
+
+				<!-- Section 1: State showcase -->
+				<div class="section">
+					<h2 class="gk-h3 section-title">States — size md (12px)</h2>
+
+					<div class="cs-cell-grid cols-4">
+						<!-- Default -->
+						<div class="cs-cell">
+							<span class="cs-cell-label">default</span>
+							<div class="cs-cell-stage">
+								<div class="cb-cost-link-wrapper">
+									<a
+										href="#"
+										class="cb-cost-link cb-cost-link-md"
+										data-state="default"
+										tabindex="-1"
+										aria-label="$4.82 — View usage details"
+									>
+										<span class="cb-cost-link__text">$4.82</span>
+										<span class="cb-cost-link__icon" aria-hidden="true">
+											<svg
+												width="8"
+												height="8"
+												viewBox="0 0 8 8"
+												fill="none"
+												xmlns="http://www.w3.org/2000/svg"
+											>
+												<path
+													d="M1.5 6.5L6.5 1.5M6.5 1.5H2.5M6.5 1.5V5.5"
+													stroke="currentColor"
+													stroke-width="1.25"
+													stroke-linecap="round"
+													stroke-linejoin="round"
+												/>
+											</svg>
+										</span>
+									</a>
+								</div>
+							</div>
+						</div>
+
+						<!-- Hover — icon visible, text primary -->
+						<div class="cs-cell">
+							<span class="cs-cell-label">hover</span>
+							<div class="cs-cell-stage">
+								<div class="cb-cost-link-wrapper">
+									<a
+										href="#"
+										class="cb-cost-link cb-cost-link-md"
+										data-state="hover"
+										tabindex="-1"
+										aria-label="$4.82 — View usage details"
+									>
+										<span class="cb-cost-link__text">$4.82</span>
+										<span class="cb-cost-link__icon" aria-hidden="true">
+											<svg
+												width="8"
+												height="8"
+												viewBox="0 0 8 8"
+												fill="none"
+												xmlns="http://www.w3.org/2000/svg"
+											>
+												<path
+													d="M1.5 6.5L6.5 1.5M6.5 1.5H2.5M6.5 1.5V5.5"
+													stroke="currentColor"
+													stroke-width="1.25"
+													stroke-linecap="round"
+													stroke-linejoin="round"
+												/>
+											</svg>
+										</span>
+									</a>
+									<div class="cb-cost-link-tooltip">View usage details</div>
+								</div>
+							</div>
+						</div>
+
+						<!-- Focus -->
+						<div class="cs-cell">
+							<span class="cs-cell-label">focus</span>
+							<div class="cs-cell-stage">
+								<div class="cb-cost-link-wrapper">
+									<a
+										href="#"
+										class="cb-cost-link cb-cost-link-md"
+										data-state="focus"
+										tabindex="-1"
+										aria-label="$4.82 — View usage details"
+									>
+										<span class="cb-cost-link__text">$4.82</span>
+										<span class="cb-cost-link__icon" aria-hidden="true">
+											<svg
+												width="8"
+												height="8"
+												viewBox="0 0 8 8"
+												fill="none"
+												xmlns="http://www.w3.org/2000/svg"
+											>
+												<path
+													d="M1.5 6.5L6.5 1.5M6.5 1.5H2.5M6.5 1.5V5.5"
+													stroke="currentColor"
+													stroke-width="1.25"
+													stroke-linecap="round"
+													stroke-linejoin="round"
+												/>
+											</svg>
+										</span>
+									</a>
+								</div>
+							</div>
+						</div>
+
+						<!-- Active / pressed -->
+						<div class="cs-cell">
+							<span class="cs-cell-label">active / pressed</span>
+							<div class="cs-cell-stage">
+								<div class="cb-cost-link-wrapper">
+									<a
+										href="#"
+										class="cb-cost-link cb-cost-link-md"
+										data-state="active"
+										tabindex="-1"
+										aria-label="$4.82 — View usage details"
+									>
+										<span class="cb-cost-link__text">$4.82</span>
+										<span class="cb-cost-link__icon" aria-hidden="true">
+											<svg
+												width="8"
+												height="8"
+												viewBox="0 0 8 8"
+												fill="none"
+												xmlns="http://www.w3.org/2000/svg"
+											>
+												<path
+													d="M1.5 6.5L6.5 1.5M6.5 1.5H2.5M6.5 1.5V5.5"
+													stroke="currentColor"
+													stroke-width="1.25"
+													stroke-linecap="round"
+													stroke-linejoin="round"
+												/>
+											</svg>
+										</span>
+									</a>
+								</div>
+							</div>
+						</div>
+					</div>
+
+					<!-- States — sm -->
+					<h2 class="gk-h3 section-title" style="margin-top: 24px">
+						States — size sm (10.5px)
+					</h2>
+
+					<div class="cs-cell-grid cols-4">
+						<!-- Default sm -->
+						<div class="cs-cell">
+							<span class="cs-cell-label">default</span>
+							<div class="cs-cell-stage">
+								<div class="cb-cost-link-wrapper">
+									<a
+										href="#"
+										class="cb-cost-link cb-cost-link-sm"
+										data-state="default"
+										tabindex="-1"
+										aria-label="$4.82 — View usage details"
+									>
+										<span class="cb-cost-link__text">$4.82</span>
+										<span class="cb-cost-link__icon" aria-hidden="true">
+											<svg
+												width="8"
+												height="8"
+												viewBox="0 0 8 8"
+												fill="none"
+												xmlns="http://www.w3.org/2000/svg"
+											>
+												<path
+													d="M1.5 6.5L6.5 1.5M6.5 1.5H2.5M6.5 1.5V5.5"
+													stroke="currentColor"
+													stroke-width="1.25"
+													stroke-linecap="round"
+													stroke-linejoin="round"
+												/>
+											</svg>
+										</span>
+									</a>
+								</div>
+							</div>
+						</div>
+
+						<!-- Hover sm -->
+						<div class="cs-cell">
+							<span class="cs-cell-label">hover</span>
+							<div class="cs-cell-stage">
+								<div class="cb-cost-link-wrapper">
+									<a
+										href="#"
+										class="cb-cost-link cb-cost-link-sm"
+										data-state="hover"
+										tabindex="-1"
+										aria-label="$4.82 — View usage details"
+									>
+										<span class="cb-cost-link__text">$4.82</span>
+										<span class="cb-cost-link__icon" aria-hidden="true">
+											<svg
+												width="8"
+												height="8"
+												viewBox="0 0 8 8"
+												fill="none"
+												xmlns="http://www.w3.org/2000/svg"
+											>
+												<path
+													d="M1.5 6.5L6.5 1.5M6.5 1.5H2.5M6.5 1.5V5.5"
+													stroke="currentColor"
+													stroke-width="1.25"
+													stroke-linecap="round"
+													stroke-linejoin="round"
+												/>
+											</svg>
+										</span>
+									</a>
+									<div class="cb-cost-link-tooltip">View usage details</div>
+								</div>
+							</div>
+						</div>
+
+						<!-- Focus sm -->
+						<div class="cs-cell">
+							<span class="cs-cell-label">focus</span>
+							<div class="cs-cell-stage">
+								<div class="cb-cost-link-wrapper">
+									<a
+										href="#"
+										class="cb-cost-link cb-cost-link-sm"
+										data-state="focus"
+										tabindex="-1"
+										aria-label="$4.82 — View usage details"
+									>
+										<span class="cb-cost-link__text">$4.82</span>
+										<span class="cb-cost-link__icon" aria-hidden="true">
+											<svg
+												width="8"
+												height="8"
+												viewBox="0 0 8 8"
+												fill="none"
+												xmlns="http://www.w3.org/2000/svg"
+											>
+												<path
+													d="M1.5 6.5L6.5 1.5M6.5 1.5H2.5M6.5 1.5V5.5"
+													stroke="currentColor"
+													stroke-width="1.25"
+													stroke-linecap="round"
+													stroke-linejoin="round"
+												/>
+											</svg>
+										</span>
+									</a>
+								</div>
+							</div>
+						</div>
+
+						<!-- Active sm -->
+						<div class="cs-cell">
+							<span class="cs-cell-label">active / pressed</span>
+							<div class="cs-cell-stage">
+								<div class="cb-cost-link-wrapper">
+									<a
+										href="#"
+										class="cb-cost-link cb-cost-link-sm"
+										data-state="active"
+										tabindex="-1"
+										aria-label="$4.82 — View usage details"
+									>
+										<span class="cb-cost-link__text">$4.82</span>
+										<span class="cb-cost-link__icon" aria-hidden="true">
+											<svg
+												width="8"
+												height="8"
+												viewBox="0 0 8 8"
+												fill="none"
+												xmlns="http://www.w3.org/2000/svg"
+											>
+												<path
+													d="M1.5 6.5L6.5 1.5M6.5 1.5H2.5M6.5 1.5V5.5"
+													stroke="currentColor"
+													stroke-width="1.25"
+													stroke-linecap="round"
+													stroke-linejoin="round"
+												/>
+											</svg>
+										</span>
+									</a>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+
+				<!-- Section 2: Cost magnitudes -->
+				<div class="section">
+					<h2 class="gk-h3 section-title">Cost magnitudes — hover one to see icon</h2>
+
+					<div class="cs-cell" style="padding: 20px 18px">
+						<div class="magnitude-row">
+							<!-- $0.12 — micro session -->
+							<div class="magnitude-item">
+								<span class="magnitude-item__label">micro session</span>
+								<div class="cb-cost-link-wrapper">
+									<a
+										href="#"
+										class="cb-cost-link cb-cost-link-md"
+										aria-label="$0.12 — View usage details"
+									>
+										<span class="cb-cost-link__text">$0.12</span>
+										<span class="cb-cost-link__icon" aria-hidden="true">
+											<svg
+												width="8"
+												height="8"
+												viewBox="0 0 8 8"
+												fill="none"
+												xmlns="http://www.w3.org/2000/svg"
+											>
+												<path
+													d="M1.5 6.5L6.5 1.5M6.5 1.5H2.5M6.5 1.5V5.5"
+													stroke="currentColor"
+													stroke-width="1.25"
+													stroke-linecap="round"
+													stroke-linejoin="round"
+												/>
+											</svg>
+										</span>
+									</a>
+									<div class="cb-cost-link-tooltip">View usage details</div>
+								</div>
+							</div>
+
+							<!-- $4.82 — typical session -->
+							<div class="magnitude-item">
+								<span class="magnitude-item__label">typical session</span>
+								<div class="cb-cost-link-wrapper">
+									<a
+										href="#"
+										class="cb-cost-link cb-cost-link-md"
+										aria-label="$4.82 — View usage details"
+									>
+										<span class="cb-cost-link__text">$4.82</span>
+										<span class="cb-cost-link__icon" aria-hidden="true">
+											<svg
+												width="8"
+												height="8"
+												viewBox="0 0 8 8"
+												fill="none"
+												xmlns="http://www.w3.org/2000/svg"
+											>
+												<path
+													d="M1.5 6.5L6.5 1.5M6.5 1.5H2.5M6.5 1.5V5.5"
+													stroke="currentColor"
+													stroke-width="1.25"
+													stroke-linecap="round"
+													stroke-linejoin="round"
+												/>
+											</svg>
+										</span>
+									</a>
+									<div class="cb-cost-link-tooltip">View usage details</div>
+								</div>
+							</div>
+
+							<!-- $124.50 — heavy workspace -->
+							<div class="magnitude-item">
+								<span class="magnitude-item__label">heavy workspace</span>
+								<div class="cb-cost-link-wrapper">
+									<a
+										href="#"
+										class="cb-cost-link cb-cost-link-md"
+										aria-label="$124.50 — View usage details"
+									>
+										<span class="cb-cost-link__text">$124.50</span>
+										<span class="cb-cost-link__icon" aria-hidden="true">
+											<svg
+												width="8"
+												height="8"
+												viewBox="0 0 8 8"
+												fill="none"
+												xmlns="http://www.w3.org/2000/svg"
+											>
+												<path
+													d="M1.5 6.5L6.5 1.5M6.5 1.5H2.5M6.5 1.5V5.5"
+													stroke="currentColor"
+													stroke-width="1.25"
+													stroke-linecap="round"
+													stroke-linejoin="round"
+												/>
+											</svg>
+										</span>
+									</a>
+									<div class="cb-cost-link-tooltip">View usage details</div>
+								</div>
+							</div>
+
+							<!-- $0.12 sm -->
+							<div class="magnitude-item">
+								<span class="magnitude-item__label">micro · sm</span>
+								<div class="cb-cost-link-wrapper">
+									<a
+										href="#"
+										class="cb-cost-link cb-cost-link-sm"
+										aria-label="$0.12 — View usage details"
+									>
+										<span class="cb-cost-link__text">$0.12</span>
+										<span class="cb-cost-link__icon" aria-hidden="true">
+											<svg
+												width="8"
+												height="8"
+												viewBox="0 0 8 8"
+												fill="none"
+												xmlns="http://www.w3.org/2000/svg"
+											>
+												<path
+													d="M1.5 6.5L6.5 1.5M6.5 1.5H2.5M6.5 1.5V5.5"
+													stroke="currentColor"
+													stroke-width="1.25"
+													stroke-linecap="round"
+													stroke-linejoin="round"
+												/>
+											</svg>
+										</span>
+									</a>
+									<div class="cb-cost-link-tooltip">View usage details</div>
+								</div>
+							</div>
+
+							<!-- $124.50 sm -->
+							<div class="magnitude-item">
+								<span class="magnitude-item__label">heavy · sm</span>
+								<div class="cb-cost-link-wrapper">
+									<a
+										href="#"
+										class="cb-cost-link cb-cost-link-sm"
+										aria-label="$124.50 — View usage details"
+									>
+										<span class="cb-cost-link__text">$124.50</span>
+										<span class="cb-cost-link__icon" aria-hidden="true">
+											<svg
+												width="8"
+												height="8"
+												viewBox="0 0 8 8"
+												fill="none"
+												xmlns="http://www.w3.org/2000/svg"
+											>
+												<path
+													d="M1.5 6.5L6.5 1.5M6.5 1.5H2.5M6.5 1.5V5.5"
+													stroke="currentColor"
+													stroke-width="1.25"
+													stroke-linecap="round"
+													stroke-linejoin="round"
+												/>
+											</svg>
+										</span>
+									</a>
+									<div class="cb-cost-link-tooltip">View usage details</div>
+								</div>
+							</div>
+
+							<!-- Hover-pinned example -->
+							<div class="magnitude-item">
+								<span class="magnitude-item__label" style="color: var(--primary)"
+									>hover pinned ↓</span
+								>
+								<div class="cb-cost-link-wrapper">
+									<a
+										href="#"
+										class="cb-cost-link cb-cost-link-md"
+										data-state="hover"
+										tabindex="-1"
+										aria-label="$4.82 — View usage details"
+									>
+										<span class="cb-cost-link__text">$4.82</span>
+										<span class="cb-cost-link__icon" aria-hidden="true">
+											<svg
+												width="8"
+												height="8"
+												viewBox="0 0 8 8"
+												fill="none"
+												xmlns="http://www.w3.org/2000/svg"
+											>
+												<path
+													d="M1.5 6.5L6.5 1.5M6.5 1.5H2.5M6.5 1.5V5.5"
+													stroke="currentColor"
+													stroke-width="1.25"
+													stroke-linecap="round"
+													stroke-linejoin="round"
+												/>
+											</svg>
+										</span>
+									</a>
+									<div
+										class="cb-cost-link-tooltip"
+										style="
+											opacity: 1;
+											transform: translateX(-50%) translateY(0);
+										"
+									>
+										View usage details
+									</div>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+
+				<!-- Section 3: In-context demos -->
+				<div class="section">
+					<h2 class="gk-h3 section-title">In context</h2>
+
+					<div
+						class="context-demos"
+						style="display: flex; align-items: flex-start; gap: 16px; flex-wrap: wrap"
+					>
+						<!-- Workspace card -->
+						<div class="workspace-card">
+							<div class="workspace-card__header">
+								<div>
+									<div class="workspace-card__name">grovekeeper</div>
+									<div class="workspace-card__path">~/projects/grovekeeper</div>
+								</div>
+								<div class="workspace-card__status-dot"></div>
+							</div>
+							<div class="workspace-card__body">
+								<div class="workspace-card__task">
+									Implement session sidebar cost tracking with real-time token
+									usage updates
+								</div>
+							</div>
+							<div class="workspace-card__footer">
+								<div class="workspace-card__footer-meta">
+									<div class="workspace-card__footer-item">
+										<svg
+											width="10"
+											height="10"
+											viewBox="0 0 10 10"
+											fill="none"
+											style="opacity: 0.5"
+										>
+											<circle
+												cx="5"
+												cy="5"
+												r="4"
+												stroke="currentColor"
+												stroke-width="1.25"
+											/>
+											<path
+												d="M5 3V5.5L6.5 6.5"
+												stroke="currentColor"
+												stroke-width="1.25"
+												stroke-linecap="round"
+											/>
+										</svg>
+										<span>2h 14m</span>
+									</div>
+									<div class="workspace-card__footer-item">
+										<svg
+											width="10"
+											height="10"
+											viewBox="0 0 10 10"
+											fill="none"
+											style="opacity: 0.5"
+										>
+											<path
+												d="M2 7L4.5 3L7 5.5L8.5 3"
+												stroke="currentColor"
+												stroke-width="1.25"
+												stroke-linecap="round"
+												stroke-linejoin="round"
+											/>
+										</svg>
+										<span>84k tok</span>
+									</div>
+								</div>
+								<div style="display: flex; align-items: center; gap: 5px">
+									<span class="workspace-card__footer-label">cost</span>
+									<!-- CostLink sm in workspace card footer -->
+									<div class="cb-cost-link-wrapper">
+										<a
+											href="#"
+											class="cb-cost-link cb-cost-link-sm"
+											aria-label="$4.82 — View usage details"
+										>
+											<span class="cb-cost-link__text">$4.82</span>
+											<span class="cb-cost-link__icon" aria-hidden="true">
+												<svg
+													width="8"
+													height="8"
+													viewBox="0 0 8 8"
+													fill="none"
+													xmlns="http://www.w3.org/2000/svg"
+												>
+													<path
+														d="M1.5 6.5L6.5 1.5M6.5 1.5H2.5M6.5 1.5V5.5"
+														stroke="currentColor"
+														stroke-width="1.25"
+														stroke-linecap="round"
+														stroke-linejoin="round"
+													/>
+												</svg>
+											</span>
+										</a>
+										<div class="cb-cost-link-tooltip">View usage details</div>
+									</div>
+								</div>
+							</div>
+						</div>
+
+						<!-- Session sidebar -->
+						<div class="session-sidebar">
+							<div class="session-sidebar__header">
+								<span class="session-sidebar__title">Session</span>
+								<div class="session-sidebar__running-dot"></div>
+							</div>
+							<div class="session-sidebar__rows">
+								<div class="session-sidebar__row">
+									<span class="session-sidebar__row-label">Model</span>
+									<span class="session-sidebar__row-value"
+										>claude-sonnet-4-6</span
+									>
+								</div>
+								<div class="session-sidebar__row">
+									<span class="session-sidebar__row-label">Duration</span>
+									<span class="session-sidebar__row-value">47m 12s</span>
+								</div>
+								<div class="session-sidebar__row">
+									<span class="session-sidebar__row-label">Tokens in</span>
+									<span class="session-sidebar__row-value">192,840</span>
+								</div>
+								<div class="session-sidebar__row">
+									<span class="session-sidebar__row-label">Tokens out</span>
+									<span class="session-sidebar__row-value">38,220</span>
+								</div>
+								<div class="session-sidebar__divider"></div>
+								<div class="session-sidebar__row">
+									<span class="session-sidebar__row-label">Cost</span>
+									<!-- CostLink md in session sidebar -->
+									<div class="cb-cost-link-wrapper">
+										<a
+											href="#"
+											class="cb-cost-link cb-cost-link-md"
+											aria-label="$0.12 — View usage details"
+										>
+											<span class="cb-cost-link__text">$0.12</span>
+											<span class="cb-cost-link__icon" aria-hidden="true">
+												<svg
+													width="8"
+													height="8"
+													viewBox="0 0 8 8"
+													fill="none"
+													xmlns="http://www.w3.org/2000/svg"
+												>
+													<path
+														d="M1.5 6.5L6.5 1.5M6.5 1.5H2.5M6.5 1.5V5.5"
+														stroke="currentColor"
+														stroke-width="1.25"
+														stroke-linecap="round"
+														stroke-linejoin="round"
+													/>
+												</svg>
+											</span>
+										</a>
+										<div class="cb-cost-link-tooltip">View usage details</div>
+									</div>
+								</div>
+							</div>
+						</div>
+
+						<!-- Inline prose example -->
+						<div class="inline-usage-example" style="flex: 1; min-width: 220px">
+							<p
+								style="
+									margin: 0 0 10px 0;
+									font-size: 12px;
+									color: var(--foreground-subtle);
+									font-family: var(--font-mono);
+									letter-spacing: 0.04em;
+									text-transform: uppercase;
+								"
+							>
+								Inline prose usage
+							</p>
+							<div
+								style="
+									margin: 0;
+									font-size: 13px;
+									line-height: 1.65;
+									color: var(--foreground-muted);
+								"
+							>
+								Session
+								<span class="highlight-segment">feat/cost-tracking</span> completed
+								38 tool calls and consumed
+								<span class="highlight-segment">231k tokens</span> at a total cost
+								of
+								<!-- CostLink inline in text -->
+								<div class="cb-cost-link-wrapper" style="display: inline-flex">
+									<a
+										href="#"
+										class="cb-cost-link cb-cost-link-md"
+										aria-label="$124.50 — View usage details"
+									>
+										<span class="cb-cost-link__text">$124.50</span>
+										<span class="cb-cost-link__icon" aria-hidden="true">
+											<svg
+												width="8"
+												height="8"
+												viewBox="0 0 8 8"
+												fill="none"
+												xmlns="http://www.w3.org/2000/svg"
+											>
+												<path
+													d="M1.5 6.5L6.5 1.5M6.5 1.5H2.5M6.5 1.5V5.5"
+													stroke="currentColor"
+													stroke-width="1.25"
+													stroke-linecap="round"
+													stroke-linejoin="round"
+												/>
+											</svg>
+										</span>
+									</a>
+									<div class="cb-cost-link-tooltip">View usage details</div>
+								</div>
+								— well within the monthly budget of $200.
+							</div>
+							<p
+								style="
+									margin: 12px 0 0 0;
+									font-size: 12px;
+									color: var(--foreground-subtle);
+									font-style: italic;
+								"
+							>
+								Hover the cost value above to see the icon appear.
+							</p>
+						</div>
+					</div>
+				</div>
+
+				<!-- Section 4: Size comparison -->
+				<div class="section">
+					<h2 class="gk-h3 section-title">Size reference</h2>
+					<div class="cs-cell">
+						<table class="size-table">
+							<thead>
+								<tr>
+									<th>Size</th>
+									<th>Token</th>
+									<th>Font size</th>
+									<th>Use case</th>
+									<th>Example</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>sm</td>
+									<td>
+										<code
+											style="
+												font-family: var(--font-mono);
+												font-size: 10.5px;
+												color: var(--primary);
+											"
+											>cb-cost-link-sm</code
+										>
+									</td>
+									<td
+										style="
+											font-family: var(--font-mono);
+											font-size: 11px;
+											color: var(--foreground-muted);
+										"
+									>
+										10.5px / --text-2xs
+									</td>
+									<td style="font-size: 12px; color: var(--foreground-muted)">
+										Workspace card footer, compact rows
+									</td>
+									<td>
+										<div class="cb-cost-link-wrapper">
+											<a
+												href="#"
+												class="cb-cost-link cb-cost-link-sm"
+												aria-label="$4.82"
+											>
+												<span class="cb-cost-link__text">$4.82</span>
+												<span class="cb-cost-link__icon" aria-hidden="true">
+													<svg
+														width="8"
+														height="8"
+														viewBox="0 0 8 8"
+														fill="none"
+													>
+														<path
+															d="M1.5 6.5L6.5 1.5M6.5 1.5H2.5M6.5 1.5V5.5"
+															stroke="currentColor"
+															stroke-width="1.25"
+															stroke-linecap="round"
+															stroke-linejoin="round"
+														/>
+													</svg>
+												</span>
+											</a>
+											<div class="cb-cost-link-tooltip">
+												View usage details
+											</div>
+										</div>
+									</td>
+								</tr>
+								<tr>
+									<td>md</td>
+									<td>
+										<code
+											style="
+												font-family: var(--font-mono);
+												font-size: 10.5px;
+												color: var(--primary);
+											"
+											>cb-cost-link-md</code
+										>
+									</td>
+									<td
+										style="
+											font-family: var(--font-mono);
+											font-size: 11px;
+											color: var(--foreground-muted);
+										"
+									>
+										12px / --text-sm
+									</td>
+									<td style="font-size: 12px; color: var(--foreground-muted)">
+										Session sidebar, inline prose, summary rows
+									</td>
+									<td>
+										<div class="cb-cost-link-wrapper">
+											<a
+												href="#"
+												class="cb-cost-link cb-cost-link-md"
+												aria-label="$4.82"
+											>
+												<span class="cb-cost-link__text">$4.82</span>
+												<span class="cb-cost-link__icon" aria-hidden="true">
+													<svg
+														width="8"
+														height="8"
+														viewBox="0 0 8 8"
+														fill="none"
+													>
+														<path
+															d="M1.5 6.5L6.5 1.5M6.5 1.5H2.5M6.5 1.5V5.5"
+															stroke="currentColor"
+															stroke-width="1.25"
+															stroke-linecap="round"
+															stroke-linejoin="round"
+														/>
+													</svg>
+												</span>
+											</a>
+											<div class="cb-cost-link-tooltip">
+												View usage details
+											</div>
+										</div>
+									</td>
+								</tr>
+							</tbody>
+						</table>
+					</div>
+				</div>
+
+				<!-- Section 5: CodeBurn panel context -->
+				<div class="section">
+					<h2 class="gk-h3 section-title">CodeBurn panel context</h2>
+					<div class="cb-panel" style="max-width: 420px">
+						<div class="cb-panel-title">
+							Usage summary
+							<span class="cb-panel-sub">May 2026</span>
+						</div>
+						<div style="display: flex; flex-direction: column; gap: 6px">
+							<!-- Row 1 -->
+							<div
+								style="
+									display: grid;
+									grid-template-columns: 1fr auto auto;
+									align-items: center;
+									gap: 10px;
+									padding: 4px 0;
+									border-bottom: 1px solid
+										color-mix(in oklch, var(--border) 40%, transparent);
+								"
+							>
+								<span style="font-size: 12px; color: var(--foreground-muted)"
+									>grovekeeper</span
+								>
+								<span
+									style="
+										font-family: var(--font-mono);
+										font-size: 10.5px;
+										color: var(--foreground-subtle);
+									"
+									>842k tok</span
+								>
+								<div class="cb-cost-link-wrapper">
+									<a
+										href="#"
+										class="cb-cost-link cb-cost-link-sm"
+										aria-label="$124.50 — View usage details"
+									>
+										<span class="cb-cost-link__text">$124.50</span>
+										<span class="cb-cost-link__icon" aria-hidden="true">
+											<svg width="8" height="8" viewBox="0 0 8 8" fill="none">
+												<path
+													d="M1.5 6.5L6.5 1.5M6.5 1.5H2.5M6.5 1.5V5.5"
+													stroke="currentColor"
+													stroke-width="1.25"
+													stroke-linecap="round"
+													stroke-linejoin="round"
+												/>
+											</svg>
+										</span>
+									</a>
+									<div class="cb-cost-link-tooltip">View usage details</div>
+								</div>
+							</div>
+							<!-- Row 2 -->
+							<div
+								style="
+									display: grid;
+									grid-template-columns: 1fr auto auto;
+									align-items: center;
+									gap: 10px;
+									padding: 4px 0;
+									border-bottom: 1px solid
+										color-mix(in oklch, var(--border) 40%, transparent);
+								"
+							>
+								<span style="font-size: 12px; color: var(--foreground-muted)"
+									>low-poly-2d-trees</span
+								>
+								<span
+									style="
+										font-family: var(--font-mono);
+										font-size: 10.5px;
+										color: var(--foreground-subtle);
+									"
+									>31k tok</span
+								>
+								<div class="cb-cost-link-wrapper">
+									<a
+										href="#"
+										class="cb-cost-link cb-cost-link-sm"
+										aria-label="$4.82 — View usage details"
+									>
+										<span class="cb-cost-link__text">$4.82</span>
+										<span class="cb-cost-link__icon" aria-hidden="true">
+											<svg width="8" height="8" viewBox="0 0 8 8" fill="none">
+												<path
+													d="M1.5 6.5L6.5 1.5M6.5 1.5H2.5M6.5 1.5V5.5"
+													stroke="currentColor"
+													stroke-width="1.25"
+													stroke-linecap="round"
+													stroke-linejoin="round"
+												/>
+											</svg>
+										</span>
+									</a>
+									<div class="cb-cost-link-tooltip">View usage details</div>
+								</div>
+							</div>
+							<!-- Row 3 -->
+							<div
+								style="
+									display: grid;
+									grid-template-columns: 1fr auto auto;
+									align-items: center;
+									gap: 10px;
+									padding: 4px 0;
+								"
+							>
+								<span style="font-size: 12px; color: var(--foreground-muted)"
+									>dotfiles</span
+								>
+								<span
+									style="
+										font-family: var(--font-mono);
+										font-size: 10.5px;
+										color: var(--foreground-subtle);
+									"
+									>820 tok</span
+								>
+								<div class="cb-cost-link-wrapper">
+									<a
+										href="#"
+										class="cb-cost-link cb-cost-link-sm"
+										aria-label="$0.12 — View usage details"
+									>
+										<span class="cb-cost-link__text">$0.12</span>
+										<span class="cb-cost-link__icon" aria-hidden="true">
+											<svg width="8" height="8" viewBox="0 0 8 8" fill="none">
+												<path
+													d="M1.5 6.5L6.5 1.5M6.5 1.5H2.5M6.5 1.5V5.5"
+													stroke="currentColor"
+													stroke-width="1.25"
+													stroke-linecap="round"
+													stroke-linejoin="round"
+												/>
+											</svg>
+										</span>
+									</a>
+									<div class="cb-cost-link-tooltip">View usage details</div>
+								</div>
+							</div>
+						</div>
+						<!-- Total row -->
+						<div
+							style="
+								display: flex;
+								align-items: center;
+								justify-content: space-between;
+								padding-top: 8px;
+								border-top: 1px dashed var(--border);
+								margin-top: 2px;
+							"
+						>
+							<span
+								style="
+									font-family: var(--font-mono);
+									font-size: 10.5px;
+									color: var(--foreground-subtle);
+									text-transform: uppercase;
+									letter-spacing: 0.06em;
+								"
+								>Total</span
+							>
+							<div class="cb-cost-link-wrapper">
+								<a
+									href="#"
+									class="cb-cost-link cb-cost-link-md"
+									style="font-weight: 600; color: var(--foreground)"
+									aria-label="$129.44 — View usage details"
+								>
+									<span class="cb-cost-link__text">$129.44</span>
+									<span class="cb-cost-link__icon" aria-hidden="true">
+										<svg width="8" height="8" viewBox="0 0 8 8" fill="none">
+											<path
+												d="M1.5 6.5L6.5 1.5M6.5 1.5H2.5M6.5 1.5V5.5"
+												stroke="currentColor"
+												stroke-width="1.25"
+												stroke-linecap="round"
+												stroke-linejoin="round"
+											/>
+										</svg>
+									</span>
+								</a>
+								<div class="cb-cost-link-tooltip">View usage details</div>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</body>
 </html>

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -231,7 +231,6 @@
 	"assigned_title": "Assigned to me ({count})",
 	"assigned_load_more": "Load more",
 	"assigned_linked_heading": "Already in dashboard",
-	"assigned_deleted_heading": "Previously removed",
 	"assigned_wizard_open": "Add to dashboard",
 	"assigned_quick_worktree": "Quick add with worktree",
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -248,7 +248,6 @@
 	"assigned_title": "Assigned to me ({count})",
 	"assigned_load_more": "Load more",
 	"assigned_linked_heading": "Already in dashboard",
-	"assigned_deleted_heading": "Previously removed",
 	"assigned_wizard_open": "Add to dashboard",
 	"assigned_quick_worktree": "Quick add with worktree",
 

--- a/src-tauri/src/commands/github_commands.rs
+++ b/src-tauri/src/commands/github_commands.rs
@@ -355,7 +355,7 @@ pub async fn fetch_assigned_issues(
     repo: String,
     limit: Option<i64>,
 ) -> Result<AssignedIssuesResult, String> {
-    let effective_limit = limit.unwrap_or(10);
+    let effective_limit = limit.unwrap_or(50);
     let fetch_limit = (effective_limit + 1).to_string();
 
     let mut issues: Vec<AssignedIssue> = if github_client.is_oauth().await {
@@ -395,43 +395,6 @@ pub async fn fetch_assigned_issues(
     }
 
     Ok(AssignedIssuesResult { issues, has_more })
-}
-
-#[tauri::command]
-pub fn record_deleted_assigned_issue(
-    state: State<DatabaseState>,
-    dashboard_id: String,
-    github_issue_number: i64,
-) -> Result<(), String> {
-    let connection = state.write()?;
-    let id = uuid::Uuid::new_v4().to_string();
-    connection
-        .execute(
-            "INSERT OR IGNORE INTO deleted_assigned_issues (id, dashboard_id, github_issue_number) \
-             VALUES (?1, ?2, ?3)",
-            rusqlite::params![id, dashboard_id, github_issue_number],
-        )
-        .map_err(|error| format!("Failed to record deleted assigned issue: {error}"))?;
-    Ok(())
-}
-
-#[tauri::command]
-pub fn get_deleted_assigned_issue_numbers(
-    state: State<DatabaseState>,
-    dashboard_id: String,
-) -> Result<Vec<i64>, String> {
-    let connection = state.read()?;
-    let mut statement = connection
-        .prepare(
-            "SELECT github_issue_number FROM deleted_assigned_issues WHERE dashboard_id = ?1",
-        )
-        .map_err(|error| format!("Failed to prepare query: {error}"))?;
-    let numbers = statement
-        .query_map([&dashboard_id], |row| row.get(0))
-        .map_err(|error| format!("Failed to query deleted issues: {error}"))?
-        .collect::<Result<Vec<i64>, _>>()
-        .map_err(|error| format!("Failed to read row: {error}"))?;
-    Ok(numbers)
 }
 
 #[tauri::command]
@@ -666,12 +629,17 @@ fn parse_rest_assigned_issues(json: &str) -> Result<Vec<AssignedIssue>, String> 
                         .collect()
                 })
                 .unwrap_or_default();
+            let parent_issue_number = issue
+                .get("parent")
+                .and_then(|p| p.get("number"))
+                .and_then(|n| n.as_i64());
             Some(AssignedIssue {
                 number: issue.get("number")?.as_i64()?,
                 title: issue.get("title")?.as_str()?.to_string(),
                 state: issue.get("state")?.as_str()?.to_string(),
                 url: issue.get("html_url")?.as_str()?.to_string(),
                 labels,
+                parent_issue_number,
             })
         })
         .collect())
@@ -1253,82 +1221,6 @@ mod tests {
         let parsed: Vec<AssignedIssue> = serde_json::from_str(json).unwrap();
         assert_eq!(parsed.len(), 1);
         assert!(parsed[0].labels.is_empty(), "labels should default to empty vec");
-    }
-
-    #[test]
-    fn record_and_get_deleted_assigned_issue_numbers() {
-        let connection = setup_test_database();
-        insert_dashboard(&connection, "d1");
-        insert_dashboard(&connection, "d2");
-
-        let id1 = uuid::Uuid::new_v4().to_string();
-        connection
-            .execute(
-                "INSERT OR IGNORE INTO deleted_assigned_issues (id, dashboard_id, github_issue_number) VALUES (?1, ?2, ?3)",
-                rusqlite::params![id1, "d1", 42],
-            )
-            .unwrap();
-
-        let id2 = uuid::Uuid::new_v4().to_string();
-        connection
-            .execute(
-                "INSERT OR IGNORE INTO deleted_assigned_issues (id, dashboard_id, github_issue_number) VALUES (?1, ?2, ?3)",
-                rusqlite::params![id2, "d1", 99],
-            )
-            .unwrap();
-
-        let id3 = uuid::Uuid::new_v4().to_string();
-        connection
-            .execute(
-                "INSERT OR IGNORE INTO deleted_assigned_issues (id, dashboard_id, github_issue_number) VALUES (?1, ?2, ?3)",
-                rusqlite::params![id3, "d2", 50],
-            )
-            .unwrap();
-
-        // Query d1
-        let mut stmt = connection
-            .prepare("SELECT github_issue_number FROM deleted_assigned_issues WHERE dashboard_id = ?1")
-            .unwrap();
-        let d1_numbers: Vec<i64> = stmt.query_map(["d1"], |row| row.get(0)).unwrap().collect::<Result<Vec<_>, _>>().unwrap();
-        assert_eq!(d1_numbers.len(), 2);
-        assert!(d1_numbers.contains(&42));
-        assert!(d1_numbers.contains(&99));
-
-        // Query d2
-        let d2_numbers: Vec<i64> = stmt.query_map(["d2"], |row| row.get(0)).unwrap().collect::<Result<Vec<_>, _>>().unwrap();
-        assert_eq!(d2_numbers.len(), 1);
-        assert!(d2_numbers.contains(&50));
-    }
-
-    #[test]
-    fn deleted_assigned_issue_duplicate_is_ignored() {
-        let connection = setup_test_database();
-        insert_dashboard(&connection, "d1");
-
-        let id1 = uuid::Uuid::new_v4().to_string();
-        connection
-            .execute(
-                "INSERT OR IGNORE INTO deleted_assigned_issues (id, dashboard_id, github_issue_number) VALUES (?1, ?2, ?3)",
-                rusqlite::params![id1, "d1", 42],
-            )
-            .unwrap();
-
-        let id2 = uuid::Uuid::new_v4().to_string();
-        connection
-            .execute(
-                "INSERT OR IGNORE INTO deleted_assigned_issues (id, dashboard_id, github_issue_number) VALUES (?1, ?2, ?3)",
-                rusqlite::params![id2, "d1", 42],
-            )
-            .unwrap();
-
-        let count: i64 = connection
-            .query_row(
-                "SELECT COUNT(*) FROM deleted_assigned_issues WHERE dashboard_id = 'd1'",
-                [],
-                |row| row.get(0),
-            )
-            .unwrap();
-        assert_eq!(count, 1, "duplicate insert should be ignored");
     }
 
     // --- GraphQL query builder tests ---

--- a/src-tauri/src/commands/issue_commands.rs
+++ b/src-tauri/src/commands/issue_commands.rs
@@ -191,24 +191,6 @@ pub fn update_issue(
 pub fn delete_issue(state: State<DatabaseState>, id: String) -> Result<(), String> {
     let connection = state.write()?;
 
-    // Record deletion history for issues linked to GitHub
-    let deletion_info: Option<(String, i64)> = connection
-        .query_row(
-            "SELECT dashboard_id, github_issue_number FROM issues WHERE id = ?1 AND github_issue_number IS NOT NULL",
-            [&id],
-            |row| Ok((row.get(0)?, row.get(1)?)),
-        )
-        .ok();
-
-    if let Some((dashboard_id, github_issue_number)) = deletion_info {
-        let deletion_id = uuid::Uuid::new_v4().to_string();
-        let _ = connection.execute(
-            "INSERT OR IGNORE INTO deleted_assigned_issues (id, dashboard_id, github_issue_number) \
-             VALUES (?1, ?2, ?3)",
-            rusqlite::params![deletion_id, dashboard_id, github_issue_number],
-        );
-    }
-
     let rows_affected = connection
         .execute("DELETE FROM issues WHERE id = ?1", [&id])
         .map_err(|error| format!("Failed to delete issue: {error}"))?;
@@ -333,69 +315,4 @@ mod tests {
             .unwrap();
     }
 
-    #[test]
-    fn delete_issue_with_github_number_records_deletion_history() {
-        let connection = setup_test_database();
-        insert_dashboard(&connection, "d1");
-        insert_issue_with_github(&connection, "i1", "d1", Some(42));
-
-        // Simulate delete_issue logic (can't call Tauri command directly in tests)
-        let deletion_info: Option<(String, i64)> = connection
-            .query_row(
-                "SELECT dashboard_id, github_issue_number FROM issues WHERE id = ?1 AND github_issue_number IS NOT NULL",
-                ["i1"],
-                |row| Ok((row.get(0)?, row.get(1)?)),
-            )
-            .ok();
-
-        if let Some((dashboard_id, github_issue_number)) = deletion_info {
-            let deletion_id = uuid::Uuid::new_v4().to_string();
-            connection
-                .execute(
-                    "INSERT OR IGNORE INTO deleted_assigned_issues (id, dashboard_id, github_issue_number) VALUES (?1, ?2, ?3)",
-                    rusqlite::params![deletion_id, dashboard_id, github_issue_number],
-                )
-                .unwrap();
-        }
-
-        connection.execute("DELETE FROM issues WHERE id = 'i1'", []).unwrap();
-
-        let count: i64 = connection
-            .query_row("SELECT COUNT(*) FROM deleted_assigned_issues WHERE dashboard_id = 'd1'", [], |row| row.get(0))
-            .unwrap();
-        assert_eq!(count, 1);
-
-        let recorded_number: i64 = connection
-            .query_row(
-                "SELECT github_issue_number FROM deleted_assigned_issues WHERE dashboard_id = 'd1'",
-                [],
-                |row| row.get(0),
-            )
-            .unwrap();
-        assert_eq!(recorded_number, 42);
-    }
-
-    #[test]
-    fn delete_issue_without_github_number_does_not_record() {
-        let connection = setup_test_database();
-        insert_dashboard(&connection, "d1");
-        insert_issue_with_github(&connection, "i1", "d1", None);
-
-        let deletion_info: Option<(String, i64)> = connection
-            .query_row(
-                "SELECT dashboard_id, github_issue_number FROM issues WHERE id = ?1 AND github_issue_number IS NOT NULL",
-                ["i1"],
-                |row| Ok((row.get(0)?, row.get(1)?)),
-            )
-            .ok();
-
-        assert!(deletion_info.is_none(), "should not find github_issue_number");
-
-        connection.execute("DELETE FROM issues WHERE id = 'i1'", []).unwrap();
-
-        let count: i64 = connection
-            .query_row("SELECT COUNT(*) FROM deleted_assigned_issues", [], |row| row.get(0))
-            .unwrap();
-        assert_eq!(count, 0);
-    }
 }

--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -161,14 +161,6 @@ pub fn create_tables(connection: &Connection) -> Result<(), rusqlite::Error> {
             UNIQUE(blocker_issue_id, blocked_issue_id)
         );
 
-        CREATE TABLE IF NOT EXISTS deleted_assigned_issues (
-            id TEXT PRIMARY KEY,
-            dashboard_id TEXT NOT NULL REFERENCES dashboards(id) ON DELETE CASCADE,
-            github_issue_number INTEGER NOT NULL,
-            deleted_at TEXT NOT NULL DEFAULT (datetime('now')),
-            UNIQUE(dashboard_id, github_issue_number)
-        );
-
         CREATE TABLE IF NOT EXISTS session_metrics (
             session_id TEXT PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
             provider TEXT NOT NULL,
@@ -255,7 +247,6 @@ pub fn create_tables(connection: &Connection) -> Result<(), rusqlite::Error> {
         CREATE INDEX IF NOT EXISTS idx_sessions_issue_id ON sessions(issue_id);
         CREATE INDEX IF NOT EXISTS idx_issue_dependencies_blocker ON issue_dependencies(blocker_issue_id);
         CREATE INDEX IF NOT EXISTS idx_issue_dependencies_blocked ON issue_dependencies(blocked_issue_id);
-        CREATE INDEX IF NOT EXISTS idx_deleted_assigned_issues_dashboard ON deleted_assigned_issues(dashboard_id);
         CREATE INDEX IF NOT EXISTS idx_session_metrics_started_at ON session_metrics(started_at);
         CREATE INDEX IF NOT EXISTS idx_session_metrics_provider ON session_metrics(provider);
         CREATE INDEX IF NOT EXISTS idx_turn_metrics_session_id ON turn_metrics(session_id);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -177,8 +177,6 @@ pub fn run() {
             github_commands::fetch_assigned_issues,
             github_commands::search_github_issues,
             github_commands::sync_all_github_state,
-            github_commands::record_deleted_assigned_issue,
-            github_commands::get_deleted_assigned_issue_numbers,
             worktree_commands::setup_worktree,
             worktree_commands::remove_worktree,
             worktree_commands::refresh_worktree_state,

--- a/src-tauri/src/models/github.rs
+++ b/src-tauri/src/models/github.rs
@@ -88,6 +88,9 @@ pub struct AssignedIssue {
     pub url: String,
     #[serde(default)]
     pub labels: Vec<AssignedIssueLabel>,
+    #[serde(default)]
+    #[ts(type = "number | null")]
+    pub parent_issue_number: Option<i64>,
 }
 
 /// Paginated result from fetch_assigned_issues.

--- a/src/lib/components/AssignedIssuesPanel.svelte
+++ b/src/lib/components/AssignedIssuesPanel.svelte
@@ -599,6 +599,7 @@
 		.assigned-labels-col {
 			display: none;
 		}
+
 		.assigned-table-grid {
 			grid-template-columns: 28px 56px 54px 1fr 72px;
 		}
@@ -608,6 +609,7 @@
 		.assigned-prd-col {
 			display: none;
 		}
+
 		.assigned-table-grid {
 			grid-template-columns: 28px 54px 1fr 72px;
 		}

--- a/src/lib/components/AssignedIssuesPanel.svelte
+++ b/src/lib/components/AssignedIssuesPanel.svelte
@@ -200,6 +200,7 @@
 		toggleRowSelection(issueNumber);
 	}
 
+	// fallow-ignore-next-line complexity
 	function handleKeydown(event: KeyboardEvent) {
 		if (panelElement === null || !panelElement.contains(document.activeElement)) {
 			return;

--- a/src/lib/components/AssignedIssuesPanel.svelte
+++ b/src/lib/components/AssignedIssuesPanel.svelte
@@ -1,30 +1,43 @@
 <script lang="ts">
-	import * as m from '$lib/paraglide/messages.js';
 	import type { AssignedIssue } from '$lib/types/generated';
 	import type { Issue } from '$lib/modules/issues';
-	import { categorizeAssignedIssues } from './assigned_issues_utils.js';
-	import CircleDot from '@lucide/svelte/icons/circle-dot';
-	import CircleCheck from '@lucide/svelte/icons/circle-check';
+	import {
+		categorizeAssignedIssues,
+		filterAssignedIssues,
+		sortAssignedIssues,
+		sortLabelsByPriority,
+		type SortColumn,
+		type SortDirection,
+	} from './assigned_issues_utils.js';
 	import ChevronDown from '@lucide/svelte/icons/chevron-down';
 	import ChevronRight from '@lucide/svelte/icons/chevron-right';
+	import ArrowUpDown from '@lucide/svelte/icons/arrow-up-down';
+	import ArrowUp from '@lucide/svelte/icons/arrow-up';
+	import ArrowDown from '@lucide/svelte/icons/arrow-down';
 	import Plus from '@lucide/svelte/icons/plus';
 	import GitBranch from '@lucide/svelte/icons/git-branch';
+	import RefreshCw from '@lucide/svelte/icons/refresh-cw';
+	import Check from '@lucide/svelte/icons/check';
 	import { openUrl } from '$lib/opener.js';
 	import { Persisted, jsonSerde } from '$lib/reactivity/persisted.svelte.js';
 	import { Badge } from '$lib/components/ui/badge/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { SimpleTooltip } from '$lib/components/ui/tooltip/index.js';
+	import { Checkbox } from '$lib/components/ui/checkbox/index.js';
+	import { SearchField } from '$lib/components/ui/search-field/index.js';
 	import { cn } from '$lib/utils.js';
 
 	interface Props {
 		issues: AssignedIssue[];
 		dashboardIssues: readonly Issue[];
-		deletedIssueNumbers: readonly number[];
 		hasMore: boolean;
+		loading?: boolean;
+		lastSynced?: Date | null;
 		disabled?: boolean;
 		onWizardOpen?: (issue: AssignedIssue) => void;
 		onQuickAddWithWorktree?: (issue: AssignedIssue) => void;
 		onLoadMore?: () => void;
+		onRefresh?: () => void;
 	}
 
 	function isBoolean(value: unknown): value is boolean {
@@ -34,147 +47,561 @@
 	let {
 		issues,
 		dashboardIssues,
-		deletedIssueNumbers,
 		hasMore,
+		loading = false,
+		lastSynced = null,
 		disabled = false,
 		onWizardOpen,
 		onQuickAddWithWorktree,
 		onLoadMore,
+		onRefresh,
 	}: Props = $props();
 
-	const collapsed = new Persisted<boolean>({
-		key: 'grovekeeper_assigned_panel_collapsed',
+	// ─── Persisted section collapse state ────────────────────────────────────
+	const unlinkedCollapsed = new Persisted<boolean>({
+		key: 'grovekeeper_assigned_unlinked_collapsed',
 		serde: jsonSerde(isBoolean),
 		defaultValue: false,
 	});
+	const linkedCollapsed = new Persisted<boolean>({
+		key: 'grovekeeper_assigned_linked_collapsed',
+		serde: jsonSerde(isBoolean),
+		defaultValue: true,
+	});
 
-	const categorized = $derived(
-		categorizeAssignedIssues(issues, dashboardIssues, deletedIssueNumbers),
+	// ─── Search, sort, selection state ────────────────────────────────────────
+	let searchQuery = $state('');
+	let sortColumn = $state<SortColumn>('number');
+	let sortDirection = $state<SortDirection>('desc');
+	let selectedNumbers = $state(new Set<number>());
+	let panelElement = $state<HTMLDivElement | null>(null);
+
+	// ─── Derived data ────────────────────────────────────────────────────────
+	const categorized = $derived(categorizeAssignedIssues(issues, dashboardIssues));
+
+	const filteredUnlinked = $derived(
+		sortAssignedIssues(
+			filterAssignedIssues(categorized.unlinked, searchQuery),
+			sortColumn,
+			sortDirection,
+		),
+	);
+	const filteredLinked = $derived(
+		sortAssignedIssues(
+			filterAssignedIssues(categorized.linked, searchQuery),
+			sortColumn,
+			sortDirection,
+		),
+	);
+	const allFiltered = $derived([...filteredUnlinked, ...filteredLinked]);
+
+	const selectedCount = $derived(selectedNumbers.size);
+	const selectedUnlinkedCount = $derived(
+		filteredUnlinked.filter((issue) => selectedNumbers.has(issue.number)).length,
 	);
 
-	async function handleClick(url: string) {
-		if (!disabled) {
-			await openUrl(url);
+	const globalCheckboxState = $derived.by(() => {
+		if (selectedCount === 0) {
+			return { checked: false, indeterminate: false };
 		}
+		const allSelected = allFiltered.every((issue) => selectedNumbers.has(issue.number));
+		if (allSelected) {
+			return { checked: true, indeterminate: false };
+		}
+		return { checked: false, indeterminate: true };
+	});
+
+	const syncAgoText = $derived.by(() => {
+		if (lastSynced === null) {
+			return 'never synced';
+		}
+		const seconds = Math.floor((Date.now() - lastSynced.getTime()) / 1000);
+		if (seconds < 60) {
+			return `synced ${seconds}s ago`;
+		}
+		const minutes = Math.floor(seconds / 60);
+		return `synced ${minutes}m ago`;
+	});
+
+	// ─── Handlers ────────────────────────────────────────────────────────────
+	function toggleSort(column: SortColumn) {
+		if (sortColumn === column) {
+			sortDirection = sortDirection === 'asc' ? 'desc' : 'asc';
+		} else {
+			sortColumn = column;
+			sortDirection = 'asc';
+		}
+	}
+
+	function toggleGlobalCheckbox() {
+		if (globalCheckboxState.checked || globalCheckboxState.indeterminate) {
+			selectedNumbers = new Set();
+		} else {
+			selectedNumbers = new Set(allFiltered.map((issue) => issue.number));
+		}
+	}
+
+	function toggleRowSelection(issueNumber: number) {
+		const next = new Set(selectedNumbers);
+		if (next.has(issueNumber)) {
+			next.delete(issueNumber);
+		} else {
+			next.add(issueNumber);
+		}
+		selectedNumbers = next;
+	}
+
+	function selectAllUnlinked() {
+		const next = new Set(selectedNumbers);
+		for (const issue of filteredUnlinked) {
+			next.add(issue.number);
+		}
+		selectedNumbers = next;
+	}
+
+	function handleAddSelected() {
+		if (onWizardOpen === undefined) {
+			return;
+		}
+		for (const issue of filteredUnlinked) {
+			if (selectedNumbers.has(issue.number)) {
+				onWizardOpen(issue);
+			}
+		}
+		selectedNumbers = new Set();
+	}
+
+	function handleAddSelectedWithWorktree() {
+		if (onQuickAddWithWorktree === undefined) {
+			return;
+		}
+		for (const issue of filteredUnlinked) {
+			if (selectedNumbers.has(issue.number)) {
+				onQuickAddWithWorktree(issue);
+			}
+		}
+		selectedNumbers = new Set();
+	}
+
+	function handleRowClick(event: MouseEvent, issueNumber: number) {
+		const target = event.target as HTMLElement;
+		if (
+			target.closest('a') !== null ||
+			target.closest('button') !== null ||
+			target.closest('[data-slot="checkbox"]') !== null ||
+			target.closest('[data-no-select]') !== null
+		) {
+			return;
+		}
+		toggleRowSelection(issueNumber);
+	}
+
+	function handleKeydown(event: KeyboardEvent) {
+		if (panelElement === null || !panelElement.contains(document.activeElement)) {
+			return;
+		}
+		if ((event.ctrlKey || event.metaKey) && event.key === 'a') {
+			event.preventDefault();
+			selectedNumbers = new Set(allFiltered.map((issue) => issue.number));
+		}
+		if (event.key === 'Enter' && selectedUnlinkedCount > 0) {
+			event.preventDefault();
+			handleAddSelected();
+		}
+	}
+
+	function handleLinkClick(event: MouseEvent, url: string) {
+		event.preventDefault();
+		if (!disabled) {
+			void openUrl(url);
+		}
+	}
+
+	function sortIcon(column: SortColumn): typeof ArrowUpDown {
+		if (sortColumn !== column) {
+			return ArrowUpDown;
+		}
+		return sortDirection === 'asc' ? ArrowUp : ArrowDown;
 	}
 </script>
 
-{#snippet issueRow(issue: AssignedIssue, variant: 'unlinked' | 'linked' | 'deleted')}
-	<div class="group flex items-center gap-0.5">
-		<Button
-			variant="ghost"
-			size="sm"
-			onclick={() => handleClick(issue.url)}
-			class={cn(
-				'flex min-w-0 flex-1 justify-start rounded px-2 py-1 text-left text-xs',
-				disabled && 'cursor-not-allowed opacity-50',
-				variant !== 'deleted' ? 'text-muted-foreground' : 'text-status-warning',
-			)}
-			{disabled}
-		>
-			{#if issue.state === 'OPEN'}
-				<CircleDot size={12} class="shrink-0 text-gh-open" />
-			{:else}
-				<CircleCheck size={12} class="shrink-0 text-gh-closed" />
-			{/if}
-			<span class="min-w-0 truncate">#{issue.number} {issue.title}</span>
-			{#if issue.labels.length > 0}
-				<span class="flex shrink-0 items-center gap-1">
-					{#each issue.labels as label (label.name)}
-						<Badge
-							size="compact"
-							class="rounded-full"
-							style="background-color: {label.color}20; color: {label.color}; border-color: {label.color}40;"
-						>
-							{label.name}
-						</Badge>
-					{/each}
-				</span>
-			{/if}
-		</Button>
-		{#if variant === 'unlinked' || variant === 'deleted'}
-			{#if onWizardOpen}
-				<SimpleTooltip text={m.assigned_wizard_open()}>
-					<Button
-						variant="ghost"
-						size="icon-sm"
-						onclick={() => onWizardOpen(issue)}
-						class="shrink-0 opacity-0 group-hover:opacity-100"
-					>
-						<Plus size={12} />
-					</Button>
-				</SimpleTooltip>
-			{/if}
-			{#if onQuickAddWithWorktree}
-				<SimpleTooltip text={m.assigned_quick_worktree()}>
-					<Button
-						variant="ghost"
-						size="icon-sm"
-						onclick={() => onQuickAddWithWorktree(issue)}
-						class="shrink-0 opacity-0 group-hover:opacity-100"
-					>
-						<GitBranch size={12} />
-					</Button>
-				</SimpleTooltip>
-			{/if}
-		{/if}
-	</div>
+{#snippet sortIndicator(column: SortColumn)}
+	{@const Icon = sortIcon(column)}
+	<Icon size={10} />
 {/snippet}
 
-{#if issues.length > 0}
-	<div class="flex flex-col gap-1">
-		<Button
-			variant="ghost"
-			size="sm"
-			onclick={() => (collapsed.current = !collapsed.current)}
-			class="flex items-center gap-1 px-0 text-xs font-semibold uppercase tracking-wider text-muted-foreground/60 hover:bg-transparent hover:text-muted-foreground"
-		>
-			{#if collapsed.current}
-				<ChevronRight size={12} />
+<svelte:window onkeydown={handleKeydown} />
+
+<div bind:this={panelElement} class="flex h-full flex-col gap-0 px-3 pt-2 pb-3" tabindex="-1">
+	<!-- Toolbar: Search + Refresh -->
+	<div class="flex items-center gap-2 pb-2">
+		<SearchField
+			bind:value={searchQuery}
+			placeholder="Search issues..."
+			class="h-7 flex-1 text-xs"
+		/>
+		<div class="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+			<span class="whitespace-nowrap">{syncAgoText}</span>
+			<SimpleTooltip text="Refresh assigned issues">
+				<Button
+					variant="ghost"
+					size="icon-sm"
+					disabled={loading}
+					onclick={() => onRefresh?.()}
+				>
+					<RefreshCw size={13} class={loading ? 'animate-spin' : ''} />
+				</Button>
+			</SimpleTooltip>
+		</div>
+	</div>
+
+	<!-- Selection Bar -->
+	<div
+		class="flex min-h-[34px] items-center gap-2 rounded-[var(--radius-md)] border px-2 py-1 text-xs"
+		style="background: {selectedCount > 0
+			? 'color-mix(in oklch, var(--primary) 10%, var(--surface))'
+			: 'transparent'}; border-color: {selectedCount > 0
+			? 'color-mix(in oklch, var(--primary) 30%, var(--border))'
+			: 'var(--border)'};"
+	>
+		<Checkbox
+			checked={globalCheckboxState.checked}
+			indeterminate={globalCheckboxState.indeterminate}
+			onCheckedChange={toggleGlobalCheckbox}
+		/>
+		<span class="text-muted-foreground">
+			{#if selectedCount > 0}
+				{selectedCount} selected
 			{:else}
-				<ChevronDown size={12} />
+				No issues selected
 			{/if}
-			{m.assigned_title({ count: issues.length })}
-		</Button>
+		</span>
+		{#if selectedCount > 0 && selectedCount < filteredUnlinked.length}
+			<button
+				class="text-primary underline-offset-2 hover:underline"
+				onclick={selectAllUnlinked}
+			>
+				Select all {filteredUnlinked.length} unlinked
+			</button>
+		{/if}
+		<div class="flex-1"></div>
+		{#if selectedUnlinkedCount > 0}
+			<Button variant="primary" size="sm" class="h-6 text-xs" onclick={handleAddSelected}>
+				<Plus size={12} />
+				Add Selected
+			</Button>
+			<Button
+				variant="secondary"
+				size="sm"
+				class="h-6 text-xs"
+				onclick={handleAddSelectedWithWorktree}
+			>
+				<GitBranch size={12} />
+				Add + Worktree
+			</Button>
+		{/if}
+	</div>
 
-		{#if !collapsed.current}
-			<div class="flex flex-col gap-0.5">
-				{#each categorized.unlinked as issue (issue.number)}
-					{@render issueRow(issue, 'unlinked')}
+	<!-- Table -->
+	<div class="mt-1 flex-1 overflow-auto">
+		<!-- Table Header -->
+		<div
+			class="assigned-table-grid sticky top-0 z-10 border-b border-border bg-surface text-[11px] font-medium uppercase tracking-wider text-muted-foreground"
+		>
+			<div class="flex items-center justify-center py-1"></div>
+			<button
+				class="flex items-center gap-0.5 py-1 hover:text-foreground"
+				onclick={() => toggleSort('prd')}
+			>
+				PRD
+				{@render sortIndicator('prd')}
+			</button>
+			<button
+				class="flex items-center gap-0.5 py-1 hover:text-foreground"
+				onclick={() => toggleSort('number')}
+			>
+				Issue
+				{@render sortIndicator('number')}
+			</button>
+			<button
+				class="flex items-center gap-0.5 py-1 hover:text-foreground"
+				onclick={() => toggleSort('title')}
+			>
+				Title
+				{@render sortIndicator('title')}
+			</button>
+			<button
+				class="assigned-labels-col flex items-center gap-0.5 py-1 hover:text-foreground"
+				onclick={() => toggleSort('labels')}
+			>
+				Labels
+				{@render sortIndicator('labels')}
+			</button>
+			<div class="py-1 text-right">Actions</div>
+		</div>
+
+		<!-- Unlinked Section -->
+		<div class="mt-1">
+			<button
+				class="flex w-full items-center gap-1 px-1 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60 hover:text-muted-foreground"
+				onclick={() => (unlinkedCollapsed.current = !unlinkedCollapsed.current)}
+			>
+				{#if unlinkedCollapsed.current}
+					<ChevronRight size={12} />
+				{:else}
+					<ChevronDown size={12} />
+				{/if}
+				Unlinked ({filteredUnlinked.length})
+			</button>
+
+			{#if !unlinkedCollapsed.current}
+				{#each filteredUnlinked as issue (issue.number)}
+					<div
+						class={cn(
+							'assigned-table-grid cursor-pointer items-center border-b border-border/40 text-xs transition-colors hover:bg-accent/40',
+							selectedNumbers.has(issue.number) && 'bg-primary/5',
+						)}
+						style="height: 38px;"
+						onclick={(event) => handleRowClick(event, issue.number)}
+						role="row"
+						tabindex="0"
+						onkeydown={(event) => {
+							if (event.key === ' ') {
+								event.preventDefault();
+								toggleRowSelection(issue.number);
+							}
+						}}
+					>
+						<div class="flex items-center justify-center">
+							<Checkbox
+								checked={selectedNumbers.has(issue.number)}
+								onCheckedChange={() => toggleRowSelection(issue.number)}
+							/>
+						</div>
+						<div class="assigned-prd-col font-mono text-muted-foreground">
+							{#if issue.parent_issue_number !== null}
+								<a
+									href={issue.url.replace(
+										/\/issues\/\d+$/,
+										`/issues/${issue.parent_issue_number}`,
+									)}
+									data-no-select
+									class="hover:text-primary hover:underline"
+									onclick={(event) =>
+										handleLinkClick(
+											event,
+											issue.url.replace(
+												/\/issues\/\d+$/,
+												`/issues/${issue.parent_issue_number}`,
+											),
+										)}
+								>
+									#{issue.parent_issue_number}
+								</a>
+							{:else}
+								<span class="text-muted-foreground/40">—</span>
+							{/if}
+						</div>
+						<div class="font-mono">
+							<a
+								href={issue.url}
+								data-no-select
+								class="text-foreground hover:text-primary hover:underline"
+								onclick={(event) => handleLinkClick(event, issue.url)}
+							>
+								#{issue.number}
+							</a>
+						</div>
+						<div class="min-w-0 truncate" data-no-select>
+							{issue.title}
+						</div>
+						<div class="assigned-labels-col flex items-center gap-1 overflow-hidden">
+							{#each sortLabelsByPriority(issue.labels) as label (label.name)}
+								<Badge
+									size="compact"
+									class="shrink-0 rounded-full"
+									style="background-color: #{label.color}20; color: #{label.color}; border-color: #{label.color}40;"
+								>
+									{label.name}
+								</Badge>
+							{/each}
+						</div>
+						<div class="flex items-center justify-end gap-0.5">
+							{#if onWizardOpen}
+								<SimpleTooltip text="Add to dashboard">
+									<Button
+										variant="ghost"
+										size="icon-sm"
+										onclick={(event) => {
+											event.stopPropagation();
+											onWizardOpen(issue);
+										}}
+									>
+										<Plus size={12} />
+									</Button>
+								</SimpleTooltip>
+							{/if}
+							{#if onQuickAddWithWorktree}
+								<SimpleTooltip text="Add with worktree">
+									<Button
+										variant="ghost"
+										size="icon-sm"
+										onclick={(event) => {
+											event.stopPropagation();
+											onQuickAddWithWorktree(issue);
+										}}
+									>
+										<GitBranch size={12} />
+									</Button>
+								</SimpleTooltip>
+							{/if}
+						</div>
+					</div>
 				{/each}
+			{/if}
+		</div>
 
-				{#if categorized.deleted.length > 0}
-					{#each categorized.deleted as issue (issue.number)}
-						{@render issueRow(issue, 'deleted')}
+		<!-- Linked Section -->
+		{#if filteredLinked.length > 0}
+			<div class="mt-2">
+				<button
+					class="flex w-full items-center gap-1 px-1 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60 hover:text-muted-foreground"
+					onclick={() => (linkedCollapsed.current = !linkedCollapsed.current)}
+				>
+					{#if linkedCollapsed.current}
+						<ChevronRight size={12} />
+					{:else}
+						<ChevronDown size={12} />
+					{/if}
+					Linked ({filteredLinked.length})
+				</button>
+
+				{#if !linkedCollapsed.current}
+					{#each filteredLinked as issue (issue.number)}
+						<div
+							class="assigned-table-grid items-center border-b border-border/40 text-xs opacity-45"
+							style="height: 38px;"
+							role="row"
+						>
+							<div class="flex items-center justify-center">
+								<Checkbox
+									checked={selectedNumbers.has(issue.number)}
+									onCheckedChange={() => toggleRowSelection(issue.number)}
+								/>
+							</div>
+							<div class="assigned-prd-col font-mono text-muted-foreground">
+								{#if issue.parent_issue_number !== null}
+									<a
+										href={issue.url.replace(
+											/\/issues\/\d+$/,
+											`/issues/${issue.parent_issue_number}`,
+										)}
+										class="hover:text-primary hover:underline"
+										onclick={(event) =>
+											handleLinkClick(
+												event,
+												issue.url.replace(
+													/\/issues\/\d+$/,
+													`/issues/${issue.parent_issue_number}`,
+												),
+											)}
+									>
+										#{issue.parent_issue_number}
+									</a>
+								{:else}
+									<span class="text-muted-foreground/40">—</span>
+								{/if}
+							</div>
+							<div class="font-mono">
+								<a
+									href={issue.url}
+									class="text-foreground hover:text-primary hover:underline"
+									onclick={(event) => handleLinkClick(event, issue.url)}
+								>
+									#{issue.number}
+								</a>
+							</div>
+							<div class="min-w-0 truncate">
+								{issue.title}
+							</div>
+							<div
+								class="assigned-labels-col flex items-center gap-1 overflow-hidden"
+							>
+								{#each sortLabelsByPriority(issue.labels) as label (label.name)}
+									<Badge
+										size="compact"
+										class="shrink-0 rounded-full"
+										style="background-color: #{label.color}20; color: #{label.color}; border-color: #{label.color}40;"
+									>
+										{label.name}
+									</Badge>
+								{/each}
+							</div>
+							<div class="flex items-center justify-end">
+								<SimpleTooltip text="Already linked">
+									<span class="text-muted-foreground">
+										<Check size={14} />
+									</span>
+								</SimpleTooltip>
+							</div>
+						</div>
 					{/each}
 				{/if}
 			</div>
+		{/if}
 
-			{#if categorized.linked.length > 0}
-				<div class="border-t border-border pt-1">
-					<p
-						class="px-2 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/40"
-					>
-						{m.assigned_linked_heading()}
-					</p>
-					<div class="flex flex-col gap-0.5">
-						{#each categorized.linked as issue (issue.number)}
-							{@render issueRow(issue, 'linked')}
-						{/each}
-					</div>
-				</div>
-			{/if}
-
-			{#if hasMore && onLoadMore}
+		<!-- Load More -->
+		{#if hasMore && onLoadMore}
+			<div class="mt-2 text-center">
 				<Button
 					variant="ghost"
 					size="sm"
 					onclick={onLoadMore}
 					class="text-muted-foreground/60"
 				>
-					{m.assigned_load_more()}
+					Load more
 				</Button>
-			{/if}
+			</div>
+		{/if}
+
+		<!-- Empty State -->
+		{#if issues.length === 0 && !loading}
+			<div
+				class="flex flex-col items-center justify-center gap-2 py-12 text-muted-foreground"
+			>
+				<p class="text-sm">No assigned issues found</p>
+				<p class="text-xs text-muted-foreground/60">
+					Issues assigned to you on GitHub will appear here
+				</p>
+			</div>
 		{/if}
 	</div>
-{/if}
+</div>
+
+<style>
+	.assigned-table-grid {
+		display: grid;
+		grid-template-columns: 28px 56px 54px 1fr 200px 72px;
+		gap: 0;
+		padding-inline: 4px;
+		align-items: center;
+	}
+
+	@container (max-width: 600px) {
+		.assigned-labels-col {
+			display: none;
+		}
+		.assigned-table-grid {
+			grid-template-columns: 28px 56px 54px 1fr 72px;
+		}
+	}
+
+	@container (max-width: 400px) {
+		.assigned-prd-col {
+			display: none;
+		}
+		.assigned-table-grid {
+			grid-template-columns: 28px 54px 1fr 72px;
+		}
+	}
+</style>

--- a/src/lib/components/AssignedIssuesPanel.svelte
+++ b/src/lib/components/AssignedIssuesPanel.svelte
@@ -18,6 +18,7 @@
 	import GitBranch from '@lucide/svelte/icons/git-branch';
 	import RefreshCw from '@lucide/svelte/icons/refresh-cw';
 	import Check from '@lucide/svelte/icons/check';
+	import { SvelteSet } from 'svelte/reactivity';
 	import { openUrl } from '$lib/opener.js';
 	import { Persisted, jsonSerde } from '$lib/reactivity/persisted.svelte.js';
 	import { Badge } from '$lib/components/ui/badge/index.js';
@@ -73,7 +74,7 @@
 	let searchQuery = $state('');
 	let sortColumn = $state<SortColumn>('number');
 	let sortDirection = $state<SortDirection>('desc');
-	let selectedNumbers = $state(new Set<number>());
+	const selectedNumbers = new SvelteSet<number>();
 	let panelElement = $state<HTMLDivElement | null>(null);
 
 	// ─── Derived data ────────────────────────────────────────────────────────
@@ -133,30 +134,33 @@
 		}
 	}
 
+	function replaceSelectedWith(numbers: number[]) {
+		selectedNumbers.clear();
+		for (const n of numbers) {
+			selectedNumbers.add(n);
+		}
+	}
+
 	function toggleGlobalCheckbox() {
 		if (globalCheckboxState.checked || globalCheckboxState.indeterminate) {
-			selectedNumbers = new Set();
+			selectedNumbers.clear();
 		} else {
-			selectedNumbers = new Set(allFiltered.map((issue) => issue.number));
+			replaceSelectedWith(allFiltered.map((issue) => issue.number));
 		}
 	}
 
 	function toggleRowSelection(issueNumber: number) {
-		const next = new Set(selectedNumbers);
-		if (next.has(issueNumber)) {
-			next.delete(issueNumber);
+		if (selectedNumbers.has(issueNumber)) {
+			selectedNumbers.delete(issueNumber);
 		} else {
-			next.add(issueNumber);
+			selectedNumbers.add(issueNumber);
 		}
-		selectedNumbers = next;
 	}
 
 	function selectAllUnlinked() {
-		const next = new Set(selectedNumbers);
 		for (const issue of filteredUnlinked) {
-			next.add(issue.number);
+			selectedNumbers.add(issue.number);
 		}
-		selectedNumbers = next;
 	}
 
 	function handleAddSelected() {
@@ -168,7 +172,7 @@
 				onWizardOpen(issue);
 			}
 		}
-		selectedNumbers = new Set();
+		selectedNumbers.clear();
 	}
 
 	function handleAddSelectedWithWorktree() {
@@ -180,7 +184,7 @@
 				onQuickAddWithWorktree(issue);
 			}
 		}
-		selectedNumbers = new Set();
+		selectedNumbers.clear();
 	}
 
 	function handleRowClick(event: MouseEvent, issueNumber: number) {
@@ -202,7 +206,7 @@
 		}
 		if ((event.ctrlKey || event.metaKey) && event.key === 'a') {
 			event.preventDefault();
-			selectedNumbers = new Set(allFiltered.map((issue) => issue.number));
+			replaceSelectedWith(allFiltered.map((issue) => issue.number));
 		}
 		if (event.key === 'Enter' && selectedUnlinkedCount > 0) {
 			event.preventDefault();
@@ -378,6 +382,7 @@
 								onCheckedChange={() => toggleRowSelection(issue.number)}
 							/>
 						</div>
+						<!-- eslint-disable svelte/no-navigation-without-resolve -- external GitHub links -->
 						<div class="assigned-prd-col font-mono text-muted-foreground">
 							{#if issue.parent_issue_number !== null}
 								<a
@@ -412,6 +417,7 @@
 								#{issue.number}
 							</a>
 						</div>
+						<!-- eslint-enable svelte/no-navigation-without-resolve -->
 						<div class="min-w-0 truncate" data-no-select>
 							{issue.title}
 						</div>
@@ -489,6 +495,7 @@
 									onCheckedChange={() => toggleRowSelection(issue.number)}
 								/>
 							</div>
+							<!-- eslint-disable svelte/no-navigation-without-resolve -- external GitHub links -->
 							<div class="assigned-prd-col font-mono text-muted-foreground">
 								{#if issue.parent_issue_number !== null}
 									<a
@@ -521,6 +528,7 @@
 									#{issue.number}
 								</a>
 							</div>
+							<!-- eslint-enable svelte/no-navigation-without-resolve -->
 							<div class="min-w-0 truncate">
 								{issue.title}
 							</div>

--- a/src/lib/components/WorkspaceBottomPanel.svelte
+++ b/src/lib/components/WorkspaceBottomPanel.svelte
@@ -22,6 +22,7 @@
 	import IssueDetail from './IssueDetail.svelte';
 	import GhSetupBanner from './GhSetupBanner.svelte';
 	import AssignedIssuesPanel from './AssignedIssuesPanel.svelte';
+	import { categorizeAssignedIssues } from './assigned_issues_utils.js';
 
 	// fallow-ignore-next-line code-duplication
 	interface Props extends IssueCardCallbacks {
@@ -40,13 +41,15 @@
 		onconnect?: () => void;
 		assignedIssues?: AssignedIssue[];
 		assignedIssuesHasMore?: boolean;
-		deletedAssignedIssueNumbers?: readonly number[];
+		assignedIssuesLoading?: boolean;
+		assignedIssuesLastSynced?: Date | null;
 		getVisualization: (issueId: string) => TreeVisualization | undefined;
 		getChildren: (parentId: string) => Issue[];
 		getNotificationDotColor?: (issueId: string) => string | null;
 		onWizardOpen?: (issue: AssignedIssue) => void;
 		onQuickAddWithWorktree?: (issue: AssignedIssue) => void;
 		onLoadMoreAssignedIssues?: () => void;
+		onRefreshAssignedIssues?: () => void;
 		onPrune?: () => void;
 	}
 
@@ -66,7 +69,8 @@
 		onconnect,
 		assignedIssues = [],
 		assignedIssuesHasMore = false,
-		deletedAssignedIssueNumbers = [],
+		assignedIssuesLoading = false,
+		assignedIssuesLastSynced = null,
 		getVisualization,
 		getChildren,
 		getNotificationDotColor,
@@ -83,6 +87,7 @@
 		onWizardOpen,
 		onQuickAddWithWorktree,
 		onLoadMoreAssignedIssues,
+		onRefreshAssignedIssues,
 		onPrune,
 	}: Props = $props();
 
@@ -121,6 +126,12 @@
 		return computeStageCounts(visualizations);
 	});
 
+	const unlinkedCount = $derived(
+		categorizeAssignedIssues(assignedIssues, issues).unlinked.filter(
+			(issue) => issue.state !== 'CLOSED',
+		).length,
+	);
+
 	function handleTabClick(tab: BottomPanelTab) {
 		if (selection.activeTab === tab) {
 			selection.setActiveTab(null);
@@ -140,7 +151,8 @@
 	const shouldShowPrdOverview = $derived(
 		selection.showPrdOverview &&
 			defaultTab !== BOTTOM_PANEL_TABS.issues &&
-			defaultTab !== BOTTOM_PANEL_TABS.kanban,
+			defaultTab !== BOTTOM_PANEL_TABS.kanban &&
+			defaultTab !== BOTTOM_PANEL_TABS.assignedIssues,
 	);
 </script>
 
@@ -150,6 +162,13 @@
 			{#each tabValues as tab (tab)}
 				<Tabs.Tab active={defaultTab === tab} onclick={() => handleTabClick(tab)}>
 					{BOTTOM_PANEL_TAB_LABELS[tab]}
+					{#if tab === BOTTOM_PANEL_TABS.assignedIssues && unlinkedCount > 0}
+						<span
+							class="ml-0.5 inline-flex min-w-[18px] items-center justify-center rounded-full bg-primary px-1.5 py-0 font-mono text-[10px] leading-[16px] text-primary-foreground"
+						>
+							{unlinkedCount}
+						</span>
+					{/if}
 				</Tabs.Tab>
 			{/each}
 		</Tabs.Root>
@@ -192,19 +211,6 @@
 					{onChangeColor}
 					onBatchPrune={onPrune ? () => onPrune!() : undefined}
 				/>
-
-				{#if assignedIssues.length > 0}
-					<AssignedIssuesPanel
-						issues={assignedIssues}
-						dashboardIssues={issues}
-						deletedIssueNumbers={deletedAssignedIssueNumbers}
-						hasMore={assignedIssuesHasMore}
-						disabled={!ghAvailable}
-						{onWizardOpen}
-						{onQuickAddWithWorktree}
-						onLoadMore={onLoadMoreAssignedIssues}
-					/>
-				{/if}
 			</div>
 		{:else if defaultTab === BOTTOM_PANEL_TABS.kanban}
 			<div class="p-4">
@@ -243,6 +249,19 @@
 			<div class="p-4">
 				<p class="text-sm text-muted-foreground">Session view coming soon</p>
 			</div>
+		{:else if defaultTab === BOTTOM_PANEL_TABS.assignedIssues}
+			<AssignedIssuesPanel
+				issues={assignedIssues}
+				dashboardIssues={issues}
+				hasMore={assignedIssuesHasMore}
+				loading={assignedIssuesLoading}
+				lastSynced={assignedIssuesLastSynced}
+				disabled={!ghAvailable}
+				{onWizardOpen}
+				{onQuickAddWithWorktree}
+				onLoadMore={onLoadMoreAssignedIssues}
+				onRefresh={onRefreshAssignedIssues}
+			/>
 		{/if}
 	</div>
 </div>

--- a/src/lib/components/assigned_issues_utils.test.ts
+++ b/src/lib/components/assigned_issues_utils.test.ts
@@ -1,15 +1,22 @@
 import { describe, it, expect } from 'vitest';
-import { categorizeAssignedIssues } from './assigned_issues_utils.js';
+import {
+	categorizeAssignedIssues,
+	filterAssignedIssues,
+	sortAssignedIssues,
+	sortLabelsByPriority,
+} from './assigned_issues_utils.js';
 import type { AssignedIssue } from '$lib/types/generated';
 import type { Issue } from '$lib/modules/issues';
 
-function makeAssignedIssue(number: number): AssignedIssue {
+function makeAssignedIssue(number: number, overrides?: Partial<AssignedIssue>): AssignedIssue {
 	return {
 		number,
 		title: `Issue #${number}`,
 		state: 'OPEN',
 		url: `https://github.com/o/r/issues/${number}`,
 		labels: [],
+		parent_issue_number: null,
+		...overrides,
 	};
 }
 
@@ -45,44 +52,27 @@ function makeDashboardIssue(githubNumber: number | null): Issue {
 
 describe('categorizeAssignedIssues', () => {
 	it('returns all empty arrays for empty inputs', () => {
-		const result = categorizeAssignedIssues([], [], []);
-		expect(result).toEqual({ unlinked: [], linked: [], deleted: [] });
+		const result = categorizeAssignedIssues([], []);
+		expect(result).toEqual({ unlinked: [], linked: [] });
 	});
 
 	it('categorizes issue matching dashboard as linked', () => {
 		const assigned = [makeAssignedIssue(42)];
 		const dashboard = [makeDashboardIssue(42)];
-		const result = categorizeAssignedIssues(assigned, dashboard, []);
+		const result = categorizeAssignedIssues(assigned, dashboard);
 		expect(result.linked).toHaveLength(1);
 		expect(result.linked[0].number).toBe(42);
 		expect(result.unlinked).toHaveLength(0);
-		expect(result.deleted).toHaveLength(0);
-	});
-
-	it('categorizes issue in deletedNumbers as deleted', () => {
-		const assigned = [makeAssignedIssue(10)];
-		const result = categorizeAssignedIssues(assigned, [], [10]);
-		expect(result.deleted).toHaveLength(1);
-		expect(result.deleted[0].number).toBe(10);
-		expect(result.unlinked).toHaveLength(0);
-	});
-
-	it('linked takes priority over deleted', () => {
-		const assigned = [makeAssignedIssue(5)];
-		const dashboard = [makeDashboardIssue(5)];
-		const result = categorizeAssignedIssues(assigned, dashboard, [5]);
-		expect(result.linked).toHaveLength(1);
-		expect(result.deleted).toHaveLength(0);
 	});
 
 	it('categorizes unmatched issue as unlinked', () => {
 		const assigned = [makeAssignedIssue(99)];
-		const result = categorizeAssignedIssues(assigned, [], []);
+		const result = categorizeAssignedIssues(assigned, []);
 		expect(result.unlinked).toHaveLength(1);
 		expect(result.unlinked[0].number).toBe(99);
 	});
 
-	it('handles multiple issues across all categories', () => {
+	it('handles multiple issues across both categories', () => {
 		const assigned = [
 			makeAssignedIssue(1),
 			makeAssignedIssue(2),
@@ -90,9 +80,80 @@ describe('categorizeAssignedIssues', () => {
 			makeAssignedIssue(4),
 		];
 		const dashboard = [makeDashboardIssue(1), makeDashboardIssue(3)];
-		const result = categorizeAssignedIssues(assigned, dashboard, [2]);
+		const result = categorizeAssignedIssues(assigned, dashboard);
 		expect(result.linked.map((i) => i.number)).toEqual([1, 3]);
-		expect(result.deleted.map((i) => i.number)).toEqual([2]);
-		expect(result.unlinked.map((i) => i.number)).toEqual([4]);
+		expect(result.unlinked.map((i) => i.number)).toEqual([2, 4]);
+	});
+});
+
+describe('filterAssignedIssues', () => {
+	const issues = [
+		makeAssignedIssue(42, { title: 'Auth middleware', parent_issue_number: 89 }),
+		makeAssignedIssue(55, { title: 'Dark mode toggle', parent_issue_number: null }),
+		makeAssignedIssue(78, { title: 'Onboarding wizard', parent_issue_number: 254 }),
+	];
+
+	it('returns all issues for empty query', () => {
+		expect(filterAssignedIssues(issues, '')).toHaveLength(3);
+	});
+
+	it('filters by issue number', () => {
+		const result = filterAssignedIssues(issues, '42');
+		expect(result).toHaveLength(1);
+		expect(result[0].number).toBe(42);
+	});
+
+	it('filters by title substring', () => {
+		const result = filterAssignedIssues(issues, 'dark');
+		expect(result).toHaveLength(1);
+		expect(result[0].number).toBe(55);
+	});
+
+	it('filters by PRD number', () => {
+		const result = filterAssignedIssues(issues, '#89');
+		expect(result).toHaveLength(1);
+		expect(result[0].number).toBe(42);
+	});
+});
+
+describe('sortAssignedIssues', () => {
+	const issues = [
+		makeAssignedIssue(10, { title: 'Zebra', parent_issue_number: 5 }),
+		makeAssignedIssue(5, { title: 'Apple', parent_issue_number: null }),
+		makeAssignedIssue(20, { title: 'Mango', parent_issue_number: 3 }),
+	];
+
+	it('sorts by number ascending', () => {
+		const sorted = sortAssignedIssues(issues, 'number', 'asc');
+		expect(sorted.map((i) => i.number)).toEqual([5, 10, 20]);
+	});
+
+	it('sorts by number descending', () => {
+		const sorted = sortAssignedIssues(issues, 'number', 'desc');
+		expect(sorted.map((i) => i.number)).toEqual([20, 10, 5]);
+	});
+
+	it('sorts by title ascending', () => {
+		const sorted = sortAssignedIssues(issues, 'title', 'asc');
+		expect(sorted.map((i) => i.title)).toEqual(['Apple', 'Mango', 'Zebra']);
+	});
+
+	it('sorts by PRD ascending with nulls last', () => {
+		const sorted = sortAssignedIssues(issues, 'prd', 'asc');
+		expect(sorted.map((i) => i.parent_issue_number)).toEqual([3, 5, null]);
+	});
+});
+
+describe('sortLabelsByPriority', () => {
+	it('puts AFK/HITL labels first', () => {
+		const labels = [
+			{ name: 'bug', color: 'd73a4a' },
+			{ name: 'AFK', color: '1D76DB' },
+			{ name: 'design-needed', color: 'E8820C' },
+		];
+		const sorted = sortLabelsByPriority(labels);
+		expect(sorted[0].name).toBe('AFK');
+		expect(sorted[1].name).toBe('design-needed');
+		expect(sorted[2].name).toBe('bug');
 	});
 });

--- a/src/lib/components/assigned_issues_utils.ts
+++ b/src/lib/components/assigned_issues_utils.ts
@@ -5,13 +5,11 @@ import type { Issue } from '$lib/modules/issues';
 export interface CategorizedAssignedIssues {
 	unlinked: AssignedIssue[];
 	linked: AssignedIssue[];
-	deleted: AssignedIssue[];
 }
 
 export function categorizeAssignedIssues(
 	assignedIssues: readonly AssignedIssue[],
 	dashboardIssues: readonly Issue[],
-	deletedIssueNumbers: readonly number[],
 ): CategorizedAssignedIssues {
 	const linkedNumbers = new Set<number>();
 	for (const issue of dashboardIssues) {
@@ -20,21 +18,90 @@ export function categorizeAssignedIssues(
 		}
 	}
 
-	const deletedSet = new Set(deletedIssueNumbers);
-
 	const unlinked: AssignedIssue[] = [];
 	const linked: AssignedIssue[] = [];
-	const deleted: AssignedIssue[] = [];
 
 	for (const assignedIssue of assignedIssues) {
 		if (linkedNumbers.has(assignedIssue.number)) {
 			linked.push(assignedIssue);
-		} else if (deletedSet.has(assignedIssue.number)) {
-			deleted.push(assignedIssue);
 		} else {
 			unlinked.push(assignedIssue);
 		}
 	}
 
-	return { unlinked, linked, deleted };
+	return { unlinked, linked };
+}
+
+const PRIORITY_LABEL_NAMES = new Set(['afk', 'hitl', 'AFK', 'HITL']);
+const SECONDARY_LABEL_NAMES = new Set(['design-needed']);
+
+export function sortLabelsByPriority(
+	labels: readonly { name: string; color: string }[],
+): { name: string; color: string }[] {
+	return [...labels].sort((a, b) => {
+		const aPriority = PRIORITY_LABEL_NAMES.has(a.name)
+			? 0
+			: SECONDARY_LABEL_NAMES.has(a.name)
+				? 1
+				: 2;
+		const bPriority = PRIORITY_LABEL_NAMES.has(b.name)
+			? 0
+			: SECONDARY_LABEL_NAMES.has(b.name)
+				? 1
+				: 2;
+		return aPriority - bPriority;
+	});
+}
+
+export type SortColumn = 'prd' | 'number' | 'title' | 'labels';
+export type SortDirection = 'asc' | 'desc';
+
+export function sortAssignedIssues(
+	issues: readonly AssignedIssue[],
+	column: SortColumn,
+	direction: SortDirection,
+): AssignedIssue[] {
+	const sorted = [...issues];
+	const multiplier = direction === 'asc' ? 1 : -1;
+
+	sorted.sort((a, b) => {
+		switch (column) {
+			case 'prd': {
+				const aPrd = a.parent_issue_number ?? Infinity;
+				const bPrd = b.parent_issue_number ?? Infinity;
+				return (aPrd - bPrd) * multiplier;
+			}
+			case 'number':
+				return (a.number - b.number) * multiplier;
+			case 'title':
+				return a.title.localeCompare(b.title) * multiplier;
+			case 'labels': {
+				const aCount = a.labels.length;
+				const bCount = b.labels.length;
+				return (aCount - bCount) * multiplier;
+			}
+		}
+	});
+
+	return sorted;
+}
+
+export function filterAssignedIssues(
+	issues: readonly AssignedIssue[],
+	query: string,
+): AssignedIssue[] {
+	const trimmed = query.trim().toLowerCase();
+	if (trimmed === '') {
+		return [...issues];
+	}
+	return issues.filter((issue) => {
+		const numberStr = `#${issue.number}`;
+		const prdStr = issue.parent_issue_number !== null ? `#${issue.parent_issue_number}` : '';
+		return (
+			numberStr.includes(trimmed) ||
+			prdStr.includes(trimmed) ||
+			issue.title.toLowerCase().includes(trimmed) ||
+			issue.number.toString().includes(trimmed)
+		);
+	});
 }

--- a/src/lib/modules/board/selection.test.ts
+++ b/src/lib/modules/board/selection.test.ts
@@ -9,7 +9,7 @@ import {
 } from './selection.js';
 
 describe('BOTTOM_PANEL_TABS', () => {
-	it('has exactly 6 entries with correct values', () => {
+	it('has exactly 7 entries with correct values', () => {
 		expect(BOTTOM_PANEL_TABS).toEqual({
 			issues: 'issues',
 			kanban: 'kanban',
@@ -17,8 +17,9 @@ describe('BOTTOM_PANEL_TABS', () => {
 			dependencies: 'dependencies',
 			activity: 'activity',
 			session: 'session',
+			assignedIssues: 'assigned-issues',
 		});
-		expect(Object.keys(BOTTOM_PANEL_TABS)).toHaveLength(6);
+		expect(Object.keys(BOTTOM_PANEL_TABS)).toHaveLength(7);
 	});
 });
 

--- a/src/lib/modules/board/selection.ts
+++ b/src/lib/modules/board/selection.ts
@@ -7,6 +7,7 @@ export const BOTTOM_PANEL_TABS = {
 	dependencies: 'dependencies',
 	activity: 'activity',
 	session: 'session',
+	assignedIssues: 'assigned-issues',
 } as const;
 
 export type BottomPanelTab = (typeof BOTTOM_PANEL_TABS)[keyof typeof BOTTOM_PANEL_TABS];
@@ -22,6 +23,7 @@ export const TAB_BEHAVIOR_MAP = {
 	dependencies: 'highlight',
 	activity: 'filter',
 	session: 'replace',
+	'assigned-issues': 'replace',
 } as const satisfies Record<BottomPanelTab, TabBehavior>;
 
 // ─── Tab Labels ──────────────────────────────────────────────────────────
@@ -33,6 +35,7 @@ export const BOTTOM_PANEL_TAB_LABELS = {
 	dependencies: 'Dependencies',
 	activity: 'Activity',
 	session: 'Session',
+	'assigned-issues': 'Assigned Issues',
 } as const satisfies Record<BottomPanelTab, string>;
 
 // ─── PRD Overview Logic ──────────────────────────────────────────────────

--- a/src/lib/modules/version-control/version_control.context.svelte.ts
+++ b/src/lib/modules/version-control/version_control.context.svelte.ts
@@ -68,6 +68,25 @@ function createVersionControlContext() {
 		}
 	}
 
+	async function fetchAssignedIssuesBatch(owner: string, repo: string) {
+		try {
+			assignedIssuesLoading = true;
+			const result = await invoke<AssignedIssuesResult>('fetch_assigned_issues', {
+				owner,
+				repo,
+				limit: assignedIssuesLimit,
+			});
+			assignedIssues = result.issues;
+			assignedIssuesHasMore = result.has_more;
+			assignedIssuesLastSynced = new Date();
+		} catch (err) {
+			error = String(err);
+			console.error('Failed to load assigned issues:', err);
+		} finally {
+			assignedIssuesLoading = false;
+		}
+	}
+
 	return {
 		get stateMap() {
 			return stateMap;
@@ -205,43 +224,13 @@ function createVersionControlContext() {
 		},
 
 		async loadAssignedIssues(owner: string, repo: string) {
-			try {
-				assignedIssuesLoading = true;
-				assignedIssuesLimit = 50;
-				const result = await invoke<AssignedIssuesResult>('fetch_assigned_issues', {
-					owner,
-					repo,
-					limit: assignedIssuesLimit,
-				});
-				assignedIssues = result.issues;
-				assignedIssuesHasMore = result.has_more;
-				assignedIssuesLastSynced = new Date();
-			} catch (err) {
-				error = String(err);
-				console.error('Failed to load assigned issues:', err);
-			} finally {
-				assignedIssuesLoading = false;
-			}
+			assignedIssuesLimit = 50;
+			await fetchAssignedIssuesBatch(owner, repo);
 		},
 
 		async loadMoreAssignedIssues(owner: string, repo: string) {
-			try {
-				assignedIssuesLoading = true;
-				assignedIssuesLimit += 50;
-				const result = await invoke<AssignedIssuesResult>('fetch_assigned_issues', {
-					owner,
-					repo,
-					limit: assignedIssuesLimit,
-				});
-				assignedIssues = result.issues;
-				assignedIssuesHasMore = result.has_more;
-				assignedIssuesLastSynced = new Date();
-			} catch (err) {
-				error = String(err);
-				console.error('Failed to load more assigned issues:', err);
-			} finally {
-				assignedIssuesLoading = false;
-			}
+			assignedIssuesLimit += 50;
+			await fetchAssignedIssuesBatch(owner, repo);
 		},
 
 		clear() {

--- a/src/lib/modules/version-control/version_control.context.svelte.ts
+++ b/src/lib/modules/version-control/version_control.context.svelte.ts
@@ -48,8 +48,9 @@ function createVersionControlContext() {
 	let syncError = $state<string | null>(null);
 	let assignedIssues = $state<AssignedIssue[]>([]);
 	let assignedIssuesHasMore = $state(false);
-	let assignedIssuesLimit = $state(10);
-	let deletedAssignedIssueNumbers = $state<number[]>([]);
+	let assignedIssuesLimit = $state(50);
+	let assignedIssuesLastSynced = $state<Date | null>(null);
+	let assignedIssuesLoading = $state(false);
 	let loading = $state(false);
 	let error = $state<string | null>(null);
 
@@ -92,8 +93,11 @@ function createVersionControlContext() {
 		get assignedIssuesHasMore() {
 			return assignedIssuesHasMore;
 		},
-		get deletedAssignedIssueNumbers() {
-			return deletedAssignedIssueNumbers;
+		get assignedIssuesLastSynced() {
+			return assignedIssuesLastSynced;
+		},
+		get assignedIssuesLoading() {
+			return assignedIssuesLoading;
 		},
 		get loading() {
 			return loading;
@@ -202,7 +206,8 @@ function createVersionControlContext() {
 
 		async loadAssignedIssues(owner: string, repo: string) {
 			try {
-				assignedIssuesLimit = 10;
+				assignedIssuesLoading = true;
+				assignedIssuesLimit = 50;
 				const result = await invoke<AssignedIssuesResult>('fetch_assigned_issues', {
 					owner,
 					repo,
@@ -210,15 +215,19 @@ function createVersionControlContext() {
 				});
 				assignedIssues = result.issues;
 				assignedIssuesHasMore = result.has_more;
+				assignedIssuesLastSynced = new Date();
 			} catch (err) {
 				error = String(err);
 				console.error('Failed to load assigned issues:', err);
+			} finally {
+				assignedIssuesLoading = false;
 			}
 		},
 
 		async loadMoreAssignedIssues(owner: string, repo: string) {
 			try {
-				assignedIssuesLimit += 10;
+				assignedIssuesLoading = true;
+				assignedIssuesLimit += 50;
 				const result = await invoke<AssignedIssuesResult>('fetch_assigned_issues', {
 					owner,
 					repo,
@@ -226,20 +235,12 @@ function createVersionControlContext() {
 				});
 				assignedIssues = result.issues;
 				assignedIssuesHasMore = result.has_more;
+				assignedIssuesLastSynced = new Date();
 			} catch (err) {
 				error = String(err);
 				console.error('Failed to load more assigned issues:', err);
-			}
-		},
-
-		async loadDeletedAssignedIssueNumbers(dashboardId: string) {
-			try {
-				deletedAssignedIssueNumbers = await invoke<number[]>(
-					'get_deleted_assigned_issue_numbers',
-					{ dashboardId },
-				);
-			} catch (err) {
-				console.error('Failed to load deleted assigned issue numbers:', err);
+			} finally {
+				assignedIssuesLoading = false;
 			}
 		},
 

--- a/src/lib/tauri_mock.ts
+++ b/src/lib/tauri_mock.ts
@@ -123,7 +123,6 @@ const MOCK_COMMAND_HANDLERS: Record<string, MockHandler> = {
 	github_auth_status: () => ({ status: 'not-connected' }),
 	github_logout: () => null,
 	fetch_assigned_issues: () => MOCK_ASSIGNED_ISSUES_RESULT,
-	get_deleted_assigned_issue_numbers: () => [],
 	sync_all_github_state: () => MOCK_SYNC_RESULT,
 
 	// ─── Notifications reads ──────────────────────────────────────────────────

--- a/src/lib/tauri_mock_data.ts
+++ b/src/lib/tauri_mock_data.ts
@@ -789,6 +789,7 @@ const MOCK_ASSIGNED_ISSUES: AssignedIssue[] = [
 		state: 'open',
 		url: 'https://github.com/MartinoPolo/Grovekeeper/issues/42',
 		labels: [{ name: 'auth', color: 'ef4444' }],
+		parent_issue_number: 89,
 	},
 	{
 		number: 55,
@@ -799,6 +800,7 @@ const MOCK_ASSIGNED_ISSUES: AssignedIssue[] = [
 			{ name: 'ui', color: '8b5cf6' },
 			{ name: 'theme', color: '6366f1' },
 		],
+		parent_issue_number: 254,
 	},
 	{
 		number: 78,
@@ -806,6 +808,37 @@ const MOCK_ASSIGNED_ISSUES: AssignedIssue[] = [
 		state: 'open',
 		url: 'https://github.com/MartinoPolo/Grovekeeper/issues/78',
 		labels: [{ name: 'ui', color: '8b5cf6' }],
+		parent_issue_number: null,
+	},
+	{
+		number: 101,
+		title: 'Wire notification event triggers from source points',
+		state: 'open',
+		url: 'https://github.com/MartinoPolo/Grovekeeper/issues/101',
+		labels: [
+			{ name: 'AFK', color: '1D76DB' },
+			{ name: 'task', color: '0E8A16' },
+		],
+		parent_issue_number: 95,
+	},
+	{
+		number: 135,
+		title: 'Build character pack creator with sound assignment',
+		state: 'open',
+		url: 'https://github.com/MartinoPolo/Grovekeeper/issues/135',
+		labels: [
+			{ name: 'design-needed', color: 'E8820C' },
+			{ name: 'HITL', color: 'FBCA04' },
+		],
+		parent_issue_number: 95,
+	},
+	{
+		number: 200,
+		title: 'Fix sound engine: Tokio crash and MP3 support',
+		state: 'open',
+		url: 'https://github.com/MartinoPolo/Grovekeeper/issues/200',
+		labels: [{ name: 'bug', color: 'd73a4a' }],
+		parent_issue_number: null,
 	},
 ];
 

--- a/src/lib/types/generated/AssignedIssue.ts
+++ b/src/lib/types/generated/AssignedIssue.ts
@@ -4,4 +4,4 @@ import type { AssignedIssueLabel } from "./AssignedIssueLabel";
 /**
  * A GitHub issue assigned to the current user, returned by `gh issue list --assignee @me`.
  */
-export type AssignedIssue = { number: number, title: string, state: string, url: string, labels: Array<AssignedIssueLabel>, };
+export type AssignedIssue = { number: number, title: string, state: string, url: string, labels: Array<AssignedIssueLabel>, parent_issue_number: number | null, };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -138,7 +138,6 @@
 			if (githubRepoParts) {
 				versionControlStore.loadAssignedIssues(githubRepoParts.owner, githubRepoParts.repo);
 			}
-			versionControlStore.loadDeletedAssignedIssueNumbers(dashboardId);
 		});
 	});
 
@@ -309,6 +308,13 @@
 			githubRepoParts.owner,
 			githubRepoParts.repo,
 		);
+	}
+
+	function handleRefreshAssignedIssues() {
+		if (githubRepoParts === null) {
+			return;
+		}
+		void versionControlStore.loadAssignedIssues(githubRepoParts.owner, githubRepoParts.repo);
 	}
 
 	async function handleUnarchiveIssue(id: string) {
@@ -577,7 +583,8 @@
 						onconnect={() => (authWizardOpen = true)}
 						assignedIssues={versionControlStore.assignedIssues}
 						assignedIssuesHasMore={versionControlStore.assignedIssuesHasMore}
-						deletedAssignedIssueNumbers={versionControlStore.deletedAssignedIssueNumbers}
+						assignedIssuesLoading={versionControlStore.assignedIssuesLoading}
+						assignedIssuesLastSynced={versionControlStore.assignedIssuesLastSynced}
 						{getVisualization}
 						getChildren={issueStore.getChildren}
 						{getNotificationDotColor}
@@ -598,6 +605,7 @@
 						onWizardOpen={handleWizardOpenWithIssue}
 						onQuickAddWithWorktree={handleQuickAddWithWorktree}
 						onLoadMoreAssignedIssues={handleLoadMoreAssignedIssues}
+						onRefreshAssignedIssues={handleRefreshAssignedIssues}
 					/>
 				{/snippet}
 			</WorkspaceDashboardLayout>


### PR DESCRIPTION
## Summary

- Promote Assigned Issues from subsection of Issues tab to **dedicated bottom panel tab** with count badge
- Complete redesign: search toolbar, refresh indicator ("synced Xs ago"), tri-state global checkbox, sortable CSS grid table (PRD/Issue#/Title/Labels/Actions), collapsible Unlinked/Linked sections, batch add with/without worktree
- **Rust backend**: add `parent_issue_number` to `AssignedIssue`, bump default limit 10→50, remove `deleted_assigned_issues` table and tracking commands
- Keyboard shortcuts: Ctrl+A (select all), Space (toggle row), Enter (add selected)
- Responsive: Labels column hides first, then PRD column on narrow widths
- Updated tests, mock data, i18n messages

Fixes #269

## Test plan

- [x] Unit tests updated for new categorization (2 categories, no deleted)
- [x] New tests for `filterAssignedIssues`, `sortAssignedIssues`, `sortLabelsByPriority`
- [x] Selection test updated for 7 tabs
- [x] svelte-check: 0 errors, 0 warnings
- [x] oxlint: 0 errors
- [x] fallow regression: passed (baseline: 2, delta: +0)
- [ ] Visual verification in browser mock mode (`pnpm dev`)
- [ ] Tauri native app verification (`pnpm tauri dev`)