### PR TITLE
#263 feat(github-auth): OAuth and CLI status card

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2299,8 +2299,10 @@ version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
 dependencies = [
+ "byteorder",
  "dbus-secret-service",
  "log",
+ "windows-sys 0.60.2",
  "zeroize",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -44,7 +44,7 @@ futures-util = "0.3"
 portpicker = "0.1"
 regex = "1"
 walkdir = "2"
-keyring = { version = "3", features = ["sync-secret-service"] }
+keyring = { version = "3", features = ["sync-secret-service", "windows-native"] }
 
 [target."cfg(any(target_os = \"macos\", windows, target_os = \"linux\"))".dependencies]
 tauri-plugin-single-instance = "2"

--- a/src-tauri/src/commands/dashboard_commands.rs
+++ b/src-tauri/src/commands/dashboard_commands.rs
@@ -133,11 +133,13 @@ pub fn update_dashboard(
         .query_row(&query, [&request.id], |row| row_to_dashboard(row))
         .map_err(|_| "ERR_DASHBOARD_NOT_FOUND".to_string())?;
 
+    let resolved_github_repo = resolve_nullable_field(request.github_repo, existing.github_repo.clone());
+
     let updated = Dashboard {
         id: existing.id,
         name: request.name.unwrap_or(existing.name),
         dashboard_type: request.dashboard_type.unwrap_or(existing.dashboard_type),
-        github_repo: resolve_nullable_field(request.github_repo, existing.github_repo),
+        github_repo: resolved_github_repo,
         local_folder: resolve_nullable_field(request.local_folder, existing.local_folder),
         default_base_branch: resolve_nullable_field(
             request.default_base_branch,

--- a/src-tauri/src/commands/github_auth_commands.rs
+++ b/src-tauri/src/commands/github_auth_commands.rs
@@ -12,39 +12,78 @@ const GITHUB_CLIENT_ID: &str = match option_env!("GROVEKEEPER_GITHUB_CLIENT_ID")
 const GITHUB_DEVICE_FLOW_SCOPES: &str = "repo read:org read:user";
 const KEYRING_SERVICE: &str = "grovekeeper";
 const KEYRING_USERNAME: &str = "github-oauth-token";
+const KEYRING_USER_INFO: &str = "github-oauth-user";
 
 // ─── Keyring helpers ────────────────────────────────────────────────────────
 
-fn store_token(token: &str) -> Result<(), String> {
-    let entry = keyring::Entry::new(KEYRING_SERVICE, KEYRING_USERNAME)
+fn store_credentials(token: &str, user: &GitHubUser) -> Result<(), String> {
+    let token_entry = keyring::Entry::new(KEYRING_SERVICE, KEYRING_USERNAME)
         .map_err(|error| format!("Failed to create keyring entry: {error}"))?;
-    entry
+    token_entry
         .set_password(token)
-        .map_err(|error| format!("Failed to store token in keychain: {error}"))
+        .map_err(|error| format!("Failed to store token in keychain: {error}"))?;
+
+    let user_json = serde_json::to_string(user)
+        .map_err(|error| format!("Failed to serialize user: {error}"))?;
+    let user_entry = keyring::Entry::new(KEYRING_SERVICE, KEYRING_USER_INFO)
+        .map_err(|error| format!("Failed to create keyring entry: {error}"))?;
+    user_entry
+        .set_password(&user_json)
+        .map_err(|error| format!("Failed to store user info in keychain: {error}"))?;
+
+    Ok(())
 }
 
-fn get_stored_token() -> Result<Option<String>, String> {
-    let entry = keyring::Entry::new(KEYRING_SERVICE, KEYRING_USERNAME)
+fn get_stored_credentials() -> Result<Option<(String, GitHubUser)>, String> {
+    let token_entry = keyring::Entry::new(KEYRING_SERVICE, KEYRING_USERNAME)
         .map_err(|error| format!("Failed to create keyring entry: {error}"))?;
-    match entry.get_password() {
-        Ok(token) => Ok(Some(token)),
-        Err(keyring::Error::NoEntry) => Ok(None),
-        Err(error) => Err(format!("Failed to read token from keychain: {error}")),
+    let token = match token_entry.get_password() {
+        Ok(token) => token,
+        Err(keyring::Error::NoEntry) => return Ok(None),
+        Err(error) => return Err(format!("Failed to read token from keychain: {error}")),
+    };
+
+    let user_entry = keyring::Entry::new(KEYRING_SERVICE, KEYRING_USER_INFO)
+        .map_err(|error| format!("Failed to create keyring entry: {error}"))?;
+    match user_entry.get_password() {
+        Ok(json) => {
+            if let Ok(user) = serde_json::from_str::<GitHubUser>(&json) {
+                Ok(Some((token, user)))
+            } else {
+                Ok(Some((token, GitHubUser { login: "unknown".to_string(), avatar_url: String::new() })))
+            }
+        }
+        Err(_) => {
+            Ok(Some((token, GitHubUser { login: "unknown".to_string(), avatar_url: String::new() })))
+        }
     }
 }
 
-fn delete_stored_token() -> Result<(), String> {
-    let entry = keyring::Entry::new(KEYRING_SERVICE, KEYRING_USERNAME)
-        .map_err(|error| format!("Failed to create keyring entry: {error}"))?;
-    match entry.delete_credential() {
-        Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
-        Err(error) => Err(format!("Failed to delete token from keychain: {error}")),
+fn delete_stored_credentials() -> Result<(), String> {
+    for username in [KEYRING_USERNAME, KEYRING_USER_INFO] {
+        let entry = keyring::Entry::new(KEYRING_SERVICE, username)
+            .map_err(|error| format!("Failed to create keyring entry: {error}"))?;
+        match entry.delete_credential() {
+            Ok(()) | Err(keyring::Error::NoEntry) => {}
+            Err(error) => return Err(format!("Failed to delete from keychain: {error}")),
+        }
     }
+    Ok(())
 }
 
 // ─── GitHub API helpers ─────────────────────────────────────────────────────
 
-async fn fetch_github_user(http: &reqwest::Client, token: &str) -> Result<GitHubUser, String> {
+enum FetchUserError {
+    /// Token is invalid/revoked (401/403) — should delete stored token
+    AuthRejected(String),
+    /// Network/transient error — token may still be valid
+    Transient(String),
+}
+
+async fn fetch_github_user(
+    http: &reqwest::Client,
+    token: &str,
+) -> Result<GitHubUser, FetchUserError> {
     let response = http
         .get("https://api.github.com/user")
         .header("Authorization", format!("Bearer {token}"))
@@ -52,16 +91,24 @@ async fn fetch_github_user(http: &reqwest::Client, token: &str) -> Result<GitHub
         .header("User-Agent", "Grovekeeper")
         .send()
         .await
-        .map_err(|error| format!("Failed to fetch GitHub user: {error}"))?;
+        .map_err(|error| FetchUserError::Transient(format!("Network error: {error}")))?;
 
-    if !response.status().is_success() {
-        return Err(format!("GitHub API error: {}", response.status()));
+    let status = response.status();
+    if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+        return Err(FetchUserError::AuthRejected(format!(
+            "Token rejected: {status}"
+        )));
+    }
+    if !status.is_success() {
+        return Err(FetchUserError::Transient(format!(
+            "GitHub API error: {status}"
+        )));
     }
 
     response
         .json::<GitHubUser>()
         .await
-        .map_err(|error| format!("Failed to parse user response: {error}"))
+        .map_err(|error| FetchUserError::Transient(format!("Parse error: {error}")))
 }
 
 // ─── Tauri commands ─────────────────────────────────────────────────────────
@@ -127,9 +174,13 @@ pub async fn github_device_flow_poll(
         .ok_or("Missing access_token in response")?
         .to_string();
 
-    let user = fetch_github_user(github_client.http_client(), &token).await?;
+    let user = fetch_github_user(github_client.http_client(), &token)
+        .await
+        .map_err(|error| match error {
+            FetchUserError::AuthRejected(message) | FetchUserError::Transient(message) => message,
+        })?;
 
-    store_token(&token)?;
+    store_credentials(&token, &user)?;
 
     github_client
         .set_auth_mode(AuthMode::OAuth {
@@ -145,33 +196,27 @@ pub async fn github_device_flow_poll(
 pub async fn github_auth_status(
     github_client: State<'_, GitHubClient>,
 ) -> Result<GhAuthStatus, String> {
-    // Fast path: already initialized this session
     let current = github_client.auth_mode().await;
     match current {
-        AuthMode::OAuth { user, .. } => return Ok(GhAuthStatus::OAuthConnected { user }),
-        AuthMode::Cli => return Ok(GhAuthStatus::CliConnected),
+        AuthMode::OAuth { ref user, .. } => {
+            return Ok(GhAuthStatus::OAuthConnected { user: user.clone() });
+        }
+        AuthMode::Cli => {
+            return Ok(GhAuthStatus::CliConnected);
+        }
         AuthMode::NotConnected => {}
     }
 
-    // Try stored OAuth token
-    if let Some(token) = get_stored_token()? {
-        match fetch_github_user(github_client.http_client(), &token).await {
-            Ok(user) => {
-                github_client
-                    .set_auth_mode(AuthMode::OAuth {
-                        token,
-                        user: user.clone(),
-                    })
-                    .await;
-                return Ok(GhAuthStatus::OAuthConnected { user });
-            }
-            Err(_) => {
-                let _ = delete_stored_token();
-            }
-        }
+    if let Some((token, user)) = get_stored_credentials()? {
+        github_client
+            .set_auth_mode(AuthMode::OAuth {
+                token,
+                user: user.clone(),
+            })
+            .await;
+        return Ok(GhAuthStatus::OAuthConnected { user });
     }
 
-    // Try gh CLI
     if run_gh_command(&["auth", "status"]).await.is_ok() {
         github_client.set_auth_mode(AuthMode::Cli).await;
         return Ok(GhAuthStatus::CliConnected);
@@ -184,7 +229,7 @@ pub async fn github_auth_status(
 pub async fn github_logout(
     github_client: State<'_, GitHubClient>,
 ) -> Result<(), String> {
-    delete_stored_token()?;
+    delete_stored_credentials()?;
     github_client.set_auth_mode(AuthMode::NotConnected).await;
     Ok(())
 }

--- a/src-tauri/src/commands/github_commands.rs
+++ b/src-tauri/src/commands/github_commands.rs
@@ -511,12 +511,19 @@ pub async fn list_user_repos(
     github_client: State<'_, GitHubClient>,
 ) -> Result<Vec<UserRepo>, String> {
     if github_client.is_oauth().await {
-        let response = github_client
+        match github_client
             .api_get("/user/repos?per_page=100&sort=pushed&direction=desc")
-            .await?;
-        let json_str = serde_json::to_string(&response)
-            .map_err(|error| format!("Failed to serialize repos response: {error}"))?;
-        return parse_rest_user_repos(&json_str);
+            .await
+        {
+            Ok(response) => {
+                let json_str = serde_json::to_string(&response)
+                    .map_err(|error| format!("Failed to serialize repos response: {error}"))?;
+                return parse_rest_user_repos(&json_str);
+            }
+            Err(error) => {
+                log::warn!("OAuth repo list failed, falling back to gh CLI: {error}");
+            }
+        }
     }
 
     let stdout = run_gh_command(&[
@@ -553,12 +560,19 @@ pub async fn search_github_repos(
     }
 
     if github_client.is_oauth().await {
-        let response = github_client
+        match github_client
             .api_get(&format!("/search/repositories?q={}&per_page=20", urlencoded(trimmed)))
-            .await?;
-        let json_str = serde_json::to_string(&response)
-            .map_err(|error| format!("Failed to serialize search output: {error}"))?;
-        return parse_rest_repo_search(&json_str);
+            .await
+        {
+            Ok(response) => {
+                let json_str = serde_json::to_string(&response)
+                    .map_err(|error| format!("Failed to serialize search output: {error}"))?;
+                return parse_rest_repo_search(&json_str);
+            }
+            Err(error) => {
+                log::warn!("OAuth repo search failed, falling back to gh CLI: {error}");
+            }
+        }
     }
 
     let stdout = run_gh_command(&[

--- a/src-tauri/src/commands/github_commands.rs
+++ b/src-tauri/src/commands/github_commands.rs
@@ -203,12 +203,7 @@ pub fn get_all_github_status_caches(
 }
 
 #[tauri::command]
-pub async fn check_gh_availability(
-    github_client: State<'_, GitHubClient>,
-) -> Result<GhCliAvailability, String> {
-    if github_client.is_oauth().await {
-        return Ok(GhCliAvailability::Available);
-    }
+pub async fn check_gh_availability() -> Result<GhCliAvailability, String> {
     match run_gh_command(&["auth", "status"]).await {
         Ok(_) => Ok(GhCliAvailability::Available),
         Err(error) => {

--- a/src/lib/components/GitHubAuthWizard.svelte
+++ b/src/lib/components/GitHubAuthWizard.svelte
@@ -139,21 +139,21 @@
 		} catch (error) {
 			const errorMessage = String(error);
 
-			if (errorMessage === 'authorization_pending') {
+			if (errorMessage.includes('authorization_pending')) {
 				schedulePoll();
 				return;
 			}
-			if (errorMessage === 'slow_down') {
+			if (errorMessage.includes('slow_down')) {
 				pollInterval += 5;
 				schedulePoll();
 				return;
 			}
-			if (errorMessage === 'expired_token') {
+			if (errorMessage.includes('expired_token')) {
 				clearAllTimers();
 				phase = { kind: 'expired' };
 				return;
 			}
-			if (errorMessage === 'access_denied') {
+			if (errorMessage.includes('access_denied')) {
 				clearAllTimers();
 				phase = {
 					kind: 'error',
@@ -163,6 +163,7 @@
 				return;
 			}
 
+			console.error('[GitHubAuthWizard] poll error:', error, '| stringified:', errorMessage);
 			clearAllTimers();
 			phase = {
 				kind: 'error',

--- a/src/lib/components/GitHubAuthWizard.svelte
+++ b/src/lib/components/GitHubAuthWizard.svelte
@@ -63,10 +63,11 @@
 	async function startDeviceFlow() {
 		try {
 			const result = await invoke<DeviceFlowStartResult>('github_device_flow_start');
-			phase = { kind: 'initial', data: result };
+			phase = { kind: 'polling', data: result };
 			remainingSeconds = result.expires_in;
 			pollInterval = result.interval;
 			startCountdown();
+			schedulePoll();
 		} catch (error) {
 			if (error instanceof MockDesktopOnlyError) {
 				handleClose();
@@ -95,12 +96,10 @@
 	}
 
 	async function handleOpenGitHub() {
-		if (phase === null || (phase.kind !== 'initial' && phase.kind !== 'polling')) {
+		if (phase === null || phase.kind !== 'polling') {
 			return;
 		}
 		await openUrl(phase.data.verification_uri);
-		phase = { kind: 'polling', data: phase.data };
-		schedulePoll();
 	}
 
 	function schedulePoll() {
@@ -129,7 +128,6 @@
 				phase = { kind: 'success', user: result.user };
 				onconnected?.(result.user);
 			} else {
-				// Unexpected success status — treat as connected
 				phase = {
 					kind: 'error',
 					errorType: 'network_error',
@@ -163,7 +161,6 @@
 				return;
 			}
 
-			console.error('[GitHubAuthWizard] poll error:', error, '| stringified:', errorMessage);
 			clearAllTimers();
 			phase = {
 				kind: 'error',
@@ -174,7 +171,7 @@
 	}
 
 	async function handleCopyCode() {
-		if (phase === null || (phase.kind !== 'initial' && phase.kind !== 'polling')) {
+		if (phase === null || phase.kind !== 'polling') {
 			return;
 		}
 		try {
@@ -235,13 +232,9 @@
 				<div class="flex items-center justify-center py-8">
 					<Loader2 size={24} class="animate-spin text-muted-foreground" />
 				</div>
-			{:else if phase.kind === 'initial' || phase.kind === 'polling'}
+			{:else if phase.kind === 'polling'}
 				<p class="text-center text-sm text-muted-foreground">
-					{#if phase.kind === 'initial'}
-						Copy this code and enter it on GitHub to connect your account.
-					{:else}
-						Waiting for authorization...
-					{/if}
+					Copy this code and enter it on GitHub to connect your account.
 				</p>
 
 				<!-- User code display -->
@@ -288,12 +281,10 @@
 				</a>
 				<!-- eslint-enable svelte/no-navigation-without-resolve -->
 
-				{#if phase.kind === 'polling'}
-					<div class="flex items-center gap-2 text-sm text-muted-foreground">
-						<Loader2 size={14} class="animate-spin" />
-						<span>Polling for authorization...</span>
-					</div>
-				{/if}
+				<div class="flex items-center gap-2 text-sm text-muted-foreground">
+					<Loader2 size={14} class="animate-spin" />
+					<span>Waiting for authorization...</span>
+				</div>
 			{:else if phase.kind === 'expired'}
 				<div class="flex flex-col items-center gap-3 py-4">
 					<Clock size={32} class="text-status-warning" />
@@ -333,14 +324,12 @@
 		<Dialog.Footer>
 			{#if phase === null}
 				<Button variant="ghost" onclick={handleClose}>Cancel</Button>
-			{:else if phase.kind === 'initial'}
+			{:else if phase.kind === 'polling'}
 				<Button variant="ghost" onclick={handleClose}>Cancel</Button>
 				<Button onclick={handleOpenGitHub}>
 					<ExternalLink size={14} />
 					Open GitHub
 				</Button>
-			{:else if phase.kind === 'polling'}
-				<Button variant="ghost" onclick={handleClose}>Cancel</Button>
 			{:else if phase.kind === 'expired'}
 				<Button variant="ghost" onclick={handleClose}>Cancel</Button>
 				<Button onclick={handleGetNewCode}>Get New Code</Button>

--- a/src/lib/components/GitHubStatusCard.svelte
+++ b/src/lib/components/GitHubStatusCard.svelte
@@ -1,0 +1,94 @@
+<script lang="ts">
+	import type { GhAuthStatus, GhCliAvailability } from '$lib/types/generated';
+	import { Badge } from '$lib/components/ui/badge/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import GithubIcon from './icons/GithubIcon.svelte';
+	import CircleCheckBig from '@lucide/svelte/icons/circle-check-big';
+	import CircleAlert from '@lucide/svelte/icons/circle-alert';
+	import Terminal from '@lucide/svelte/icons/terminal';
+	import KeyRound from '@lucide/svelte/icons/key-round';
+
+	interface Props {
+		authStatus: GhAuthStatus;
+		ghAvailability: GhCliAvailability;
+		onconnect?: () => void;
+		ondisconnect?: () => void;
+	}
+
+	let { authStatus, ghAvailability, onconnect, ondisconnect }: Props = $props();
+
+	const oauthConnected = $derived(authStatus.status === 'oauth-connected');
+	const cliConnected = $derived(
+		authStatus.status === 'cli-connected' || ghAvailability === 'available',
+	);
+	const fullyDisconnected = $derived(!oauthConnected && !cliConnected);
+</script>
+
+<div class="rounded-lg border bg-surface-1 p-4">
+	<div class="mb-3 flex items-center justify-between">
+		<div class="flex items-center gap-2">
+			<GithubIcon size={18} />
+			<span class="text-sm font-medium">GitHub</span>
+		</div>
+		{#if fullyDisconnected}
+			<Badge variant="danger" size="compact">Not connected</Badge>
+		{:else if oauthConnected}
+			<Badge variant="success" size="compact">Connected</Badge>
+		{:else}
+			<Badge variant="warning" size="compact">CLI only</Badge>
+		{/if}
+	</div>
+
+	<div class="flex flex-col gap-2">
+		<!-- OAuth status row -->
+		<div class="flex items-center justify-between gap-2 text-xs">
+			<div class="flex items-center gap-2">
+				<KeyRound size={13} class="text-muted-foreground" />
+				{#if oauthConnected && authStatus.status === 'oauth-connected'}
+					<div class="flex items-center gap-2">
+						<img
+							src={authStatus.user.avatar_url}
+							alt="{authStatus.user.login}'s avatar"
+							class="size-5 rounded-full border"
+						/>
+						<span class="font-medium">{authStatus.user.login}</span>
+						<Badge variant="moss" size="compact">OAuth</Badge>
+					</div>
+				{:else}
+					<span class="text-muted-foreground">OAuth not connected</span>
+				{/if}
+			</div>
+			{#if oauthConnected && ondisconnect}
+				<Button variant="ghost" size="sm" class="h-6 text-xs" onclick={ondisconnect}>
+					Disconnect
+				</Button>
+			{:else if !oauthConnected && onconnect}
+				<Button variant="secondary" size="sm" class="h-6 text-xs" onclick={onconnect}>
+					Connect
+				</Button>
+			{/if}
+		</div>
+
+		<!-- CLI status row -->
+		<div class="flex items-center gap-2 text-xs">
+			<Terminal size={13} class="text-muted-foreground" />
+			{#if ghAvailability === 'available'}
+				<div class="flex items-center gap-1.5">
+					<CircleCheckBig size={12} class="text-status-success" />
+					<span>gh CLI authenticated</span>
+				</div>
+			{:else if ghAvailability === 'not-authenticated'}
+				<div class="flex items-center gap-1.5">
+					<CircleAlert size={12} class="text-status-warning" />
+					<span class="text-muted-foreground">gh CLI installed but not authenticated</span
+					>
+				</div>
+			{:else}
+				<div class="flex items-center gap-1.5">
+					<CircleAlert size={12} class="text-muted-foreground" />
+					<span class="text-muted-foreground">gh CLI not installed</span>
+				</div>
+			{/if}
+		</div>
+	</div>
+</div>

--- a/src/lib/components/GitHubStatusCard.svelte
+++ b/src/lib/components/GitHubStatusCard.svelte
@@ -13,9 +13,16 @@
 		ghAvailability: GhCliAvailability;
 		onconnect?: () => void;
 		ondisconnect?: () => void;
+		borderless?: boolean;
 	}
 
-	let { authStatus, ghAvailability, onconnect, ondisconnect }: Props = $props();
+	let {
+		authStatus,
+		ghAvailability,
+		onconnect,
+		ondisconnect,
+		borderless = false,
+	}: Props = $props();
 
 	const oauthConnected = $derived(authStatus.status === 'oauth-connected');
 	const cliConnected = $derived(
@@ -24,7 +31,7 @@
 	const fullyDisconnected = $derived(!oauthConnected && !cliConnected);
 </script>
 
-<div class="rounded-lg border bg-surface-1 p-4">
+<div class={borderless ? '' : 'rounded-lg border bg-surface-1 p-4'}>
 	<div class="mb-3 flex items-center justify-between">
 		<div class="flex items-center gap-2">
 			<GithubIcon size={18} />

--- a/src/lib/components/RepoCombobox.svelte
+++ b/src/lib/components/RepoCombobox.svelte
@@ -64,6 +64,12 @@
 		}
 	}
 
+	function syncInputDisplay() {
+		if (inputRef) {
+			inputRef.value = value;
+		}
+	}
+
 	function handleOpenChange(isOpen: boolean) {
 		open = isOpen;
 		if (isOpen) {
@@ -109,8 +115,16 @@
 			}
 			searchValue = '';
 			searchResults = [];
+			syncInputDisplay();
 		}
 	}
+
+	$effect(() => {
+		value;
+		if (!open) {
+			syncInputDisplay();
+		}
+	});
 </script>
 
 <Combobox.Root

--- a/src/lib/components/RepoCombobox.svelte
+++ b/src/lib/components/RepoCombobox.svelte
@@ -120,7 +120,7 @@
 	}
 
 	$effect(() => {
-		value;
+		void value;
 		if (!open) {
 			syncInputDisplay();
 		}

--- a/src/lib/components/RepoCombobox.svelte
+++ b/src/lib/components/RepoCombobox.svelte
@@ -136,7 +136,7 @@
 
 	<Combobox.Portal>
 		<Combobox.Content
-			class="z-[var(--z-popover)] mt-1 max-h-[240px] w-[var(--bits-combobox-anchor-width)] overflow-y-auto rounded-md border border-border bg-surface-3 shadow-md"
+			class="z-[var(--z-tooltip)] mt-1 max-h-[240px] w-[var(--bits-combobox-anchor-width)] overflow-y-auto rounded-md border border-border bg-surface-3 shadow-md"
 			sideOffset={4}
 		>
 			{#if loadingUserRepos || searchingRemote}

--- a/src/lib/components/github_auth_wizard.svelte.ts
+++ b/src/lib/components/github_auth_wizard.svelte.ts
@@ -2,7 +2,6 @@ import type { DeviceFlowStartResult, GitHubUser } from '$lib/types/generated';
 
 // Wizard phase state machine
 export type WizardPhase =
-	| { kind: 'initial'; data: DeviceFlowStartResult }
 	| { kind: 'polling'; data: DeviceFlowStartResult }
 	| { kind: 'success'; user: GitHubUser }
 	| { kind: 'expired' }

--- a/src/lib/modules/board/board.context.svelte.ts
+++ b/src/lib/modules/board/board.context.svelte.ts
@@ -186,7 +186,7 @@ function createBoardContext() {
 		},
 
 		async updateDashboard(request: UpdateDashboardRequest): Promise<Dashboard> {
-			return invoke('update_dashboard', { request });
+			return invoke<Dashboard>('update_dashboard', { request });
 		},
 
 		async archiveDashboard(id: string): Promise<void> {

--- a/src/lib/tauri_mock.ts
+++ b/src/lib/tauri_mock.ts
@@ -120,7 +120,10 @@ const MOCK_COMMAND_HANDLERS: Record<string, MockHandler> = {
 			fetched_at: null,
 		},
 	check_gh_availability: () => 'available',
-	github_auth_status: () => ({ status: 'not-connected' }),
+	github_auth_status: () => ({
+		status: 'oauth-connected',
+		user: { login: 'MockUser', avatar_url: 'https://avatars.githubusercontent.com/u/0?v=4' },
+	}),
 	github_logout: () => null,
 	fetch_assigned_issues: () => MOCK_ASSIGNED_ISSUES_RESULT,
 	get_deleted_assigned_issue_numbers: () => [],

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -64,7 +64,7 @@
 		void preloadCode(resolve('/quick-ideas'));
 		void preloadCode(resolve('/ai-config'));
 		void shortcutsCtx.loadCustomBindings();
-		void versionControlCtx.checkAuthStatus();
+		void versionControlCtx.checkAvailability();
 
 		shortcutsCtx.registerShortcut({
 			id: 'command-palette',

--- a/src/routes/overview/+page.svelte
+++ b/src/routes/overview/+page.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
 	import { openPath } from '$lib/opener.js';
+	import { invoke } from '$lib/tauri.js';
 	import { useBoard } from '$lib/modules/board';
 	import { useVersionControl } from '$lib/modules/version-control';
 	import { getOverviewData, openWorkspaceWindow } from '$lib/modules/window';
 	import WorkspaceCard from '$lib/components/WorkspaceCard.svelte';
 	import AddWorkspaceCard from '$lib/components/AddWorkspaceCard.svelte';
-	import GhSetupBanner from '$lib/components/GhSetupBanner.svelte';
+	import GitHubStatusCard from '$lib/components/GitHubStatusCard.svelte';
 	import GitHubAuthWizard from '$lib/components/GitHubAuthWizard.svelte';
 	import { Switch } from '$lib/components/ui/switch/index.js';
 	import { Label } from '$lib/components/ui/label/index.js';
@@ -72,9 +73,14 @@
 		</div>
 	</div>
 
-	<GhSetupBanner
+	<GitHubStatusCard
 		authStatus={versionControl.authStatus}
+		ghAvailability={versionControl.ghAvailability}
 		onconnect={() => (authWizardOpen = true)}
+		ondisconnect={async () => {
+			await invoke('github_logout');
+			await versionControl.checkAvailability();
+		}}
 	/>
 
 	{#if loading}
@@ -105,6 +111,6 @@
 {#if authWizardOpen}
 	<GitHubAuthWizard
 		bind:open={authWizardOpen}
-		onconnected={() => void versionControl.checkAuthStatus()}
+		onconnected={() => void versionControl.checkAvailability()}
 	/>
 {/if}

--- a/src/routes/overview/+page.svelte
+++ b/src/routes/overview/+page.svelte
@@ -9,8 +9,10 @@
 	import AddWorkspaceCard from '$lib/components/AddWorkspaceCard.svelte';
 	import GitHubStatusCard from '$lib/components/GitHubStatusCard.svelte';
 	import GitHubAuthWizard from '$lib/components/GitHubAuthWizard.svelte';
-	import { Switch } from '$lib/components/ui/switch/index.js';
-	import { Label } from '$lib/components/ui/label/index.js';
+	import * as Popover from '$lib/components/ui/popover/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import GithubIcon from '$lib/components/icons/GithubIcon.svelte';
+	import ArchiveIcon from '@lucide/svelte/icons/archive';
 	import type { OverviewWorkspaceData } from '$lib/types/generated';
 
 	const boardStore = useBoard();
@@ -68,20 +70,38 @@
 			<p class="text-sm text-muted-foreground">{m.overview_subtitle()}</p>
 		</div>
 		<div class="flex items-center gap-2">
-			<Switch id="show-archived" bind:checked={showArchived} />
-			<Label for="show-archived" class="text-sm text-muted-foreground">Show archived</Label>
+			<Button
+				variant={showArchived ? 'primary' : 'secondary'}
+				size="icon"
+				onclick={() => (showArchived = !showArchived)}
+				aria-label="Toggle archived workspaces"
+				aria-pressed={showArchived}
+			>
+				<ArchiveIcon size={16} />
+			</Button>
+			<Popover.Root>
+				<Popover.Trigger>
+					{#snippet child({ props })}
+						<Button {...props} variant="secondary" size="icon">
+							<GithubIcon size={16} />
+						</Button>
+					{/snippet}
+				</Popover.Trigger>
+				<Popover.Content class="w-80" align="end">
+					<GitHubStatusCard
+						borderless
+						authStatus={versionControl.authStatus}
+						ghAvailability={versionControl.ghAvailability}
+						onconnect={() => (authWizardOpen = true)}
+						ondisconnect={async () => {
+							await invoke('github_logout');
+							await versionControl.checkAvailability();
+						}}
+					/>
+				</Popover.Content>
+			</Popover.Root>
 		</div>
 	</div>
-
-	<GitHubStatusCard
-		authStatus={versionControl.authStatus}
-		ghAvailability={versionControl.ghAvailability}
-		onconnect={() => (authWizardOpen = true)}
-		ondisconnect={async () => {
-			await invoke('github_logout');
-			await versionControl.checkAvailability();
-		}}
-	/>
 
 	{#if loading}
 		<p class="text-muted-foreground">{m.overview_loading()}</p>

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -8,9 +8,8 @@
 	import { Input } from '$lib/components/ui/input/index.js';
 	import { Textarea } from '$lib/components/ui/textarea/index.js';
 	import { Label } from '$lib/components/ui/label/index.js';
-	import { Badge } from '$lib/components/ui/badge/index.js';
+	import GitHubStatusCard from '$lib/components/GitHubStatusCard.svelte';
 	import GitHubAuthWizard from '$lib/components/GitHubAuthWizard.svelte';
-	import GithubIcon from '$lib/components/icons/GithubIcon.svelte';
 	import type { ColorPalette } from '$lib/types/generated';
 	import { invoke } from '$lib/tauri.js';
 
@@ -170,59 +169,27 @@
 			Connect your GitHub account to sync issues, pull requests, and branches.
 		</p>
 
-		{#if versionControl.authStatus.status === 'oauth-connected'}
-			<div class="flex items-center justify-between rounded border bg-muted/30 px-4 py-3">
-				<div class="flex items-center gap-3">
-					<img
-						src={versionControl.authStatus.user.avatar_url}
-						alt="{versionControl.authStatus.user.login}'s avatar"
-						class="size-10 rounded-full border"
-					/>
-					<div>
-						<p class="text-sm font-medium">{versionControl.authStatus.user.login}</p>
-						<Badge variant="moss" class="text-2xs">Connected via OAuth</Badge>
-					</div>
-				</div>
-				<Button
-					variant="danger"
-					size="sm"
-					onclick={async () => {
-						await invoke('github_logout');
-						await versionControl.checkAuthStatus();
-					}}
-				>
-					Disconnect
-				</Button>
-			</div>
-		{:else if versionControl.authStatus.status === 'cli-connected'}
-			<div class="flex items-center justify-between rounded border bg-muted/30 px-4 py-3">
-				<div class="flex items-center gap-3">
-					<GithubIcon size={24} />
-					<div>
-						<p class="text-sm font-medium">Connected via gh CLI</p>
-						<Badge variant="moss" class="text-2xs">gh auth</Badge>
-					</div>
-				</div>
-				<Button variant="secondary" size="sm" onclick={() => (authWizardOpen = true)}>
-					<GithubIcon size={14} />
-					Connect via OAuth
-				</Button>
-			</div>
+		<GitHubStatusCard
+			authStatus={versionControl.authStatus}
+			ghAvailability={versionControl.ghAvailability}
+			onconnect={() => (authWizardOpen = true)}
+			ondisconnect={async () => {
+				await invoke('github_logout');
+				await versionControl.checkAvailability();
+			}}
+		/>
+
+		{#if !versionControl.authStatus.status.startsWith('oauth') && versionControl.ghAvailability === 'available'}
 			<p class="text-xs text-muted-foreground">
 				Using the gh CLI for GitHub access. Connect via OAuth for a richer experience
 				without the CLI dependency.
 			</p>
-		{:else}
-			<Button onclick={() => (authWizardOpen = true)}>
-				<GithubIcon size={14} />
-				Connect to GitHub
-			</Button>
 		{/if}
 	</section>
 
 	<GitHubAuthWizard
 		bind:open={authWizardOpen}
-		onconnected={() => void versionControl.checkAuthStatus()}
+		onconnected={() => void versionControl.checkAvailability()}
 	/>
 
 	<NotificationSettingsPanel />


### PR DESCRIPTION
## Description
- Fixed check_gh_availability backend bug that short-circuited on OAuth — now always verifies actual gh CLI status
- Updated layout to call checkAvailability() on mount instead of just checkAuthStatus() for comprehensive auth checks
- Added new GitHubStatusCard component showing OAuth and CLI authentication status independently and always-visible
- Replaced GhSetupBanner with GitHubStatusCard on overview dashboard and settings page
- Improved browser mock mode to return oauth-connected state for authenticated UI preview

## Resolves
Closes #263

## Testing
- [ ] Manual: verify GitHubStatusCard displays correct auth state (both OAuth and CLI) in overview and settings
- [ ] Manual: test browser mode shows oauth-connected state in mock
- [ ] Manual: verify check_gh_availability correctly detects gh CLI regardless of OAuth status