### PR TITLE
test(storybook): Phase 2 block component stories

### DIFF
--- a/.mpx/testing-framework/README.md
+++ b/.mpx/testing-framework/README.md
@@ -4,14 +4,14 @@ This folder contains stand-alone agent prompt documents for each phase of the Gr
 
 ## Execution Order
 
-| Phase | File                                                               | Description                                                                      | Est. Sub-Agents | Priority    |
-| ----- | ------------------------------------------------------------------ | -------------------------------------------------------------------------------- | --------------- | ----------- |
-| 1     | [phase-1-storybook-primitives.md](phase-1-storybook-primitives.md) | Storybook stories for shadcn/base/derived components missing stories             | 14              | High        |
-| 2     | [phase-2-storybook-blocks.md](phase-2-storybook-blocks.md)         | Storybook stories for block components (issue, workspace, session, layout, etc.) | 18              | High        |
-| 3     | [phase-3-storybook-play-tests.md](phase-3-storybook-play-tests.md) | Add `play()` interaction tests to existing + new stories; enable a11y CI         | 18              | Highest ROI |
-| 4     | [phase-4-vitest-logic.md](phase-4-vitest-logic.md)                 | Fill Vitest unit test gaps for business logic modules                            | 6               | Critical    |
-| 5     | [phase-5-rust-tests.md](phase-5-rust-tests.md)                     | Rust `#[cfg(test)]` tests for backend commands and logic                         | 6               | Critical    |
-| 6     | [phase-6-playwright-e2e.md](phase-6-playwright-e2e.md)             | Playwright E2E tests: navigation, URL state, keyboard, workflows                 | 4               | Important   |
+| Phase | File                                                               | Description                                                                      | Est. Sub-Agents | Status       |
+| ----- | ------------------------------------------------------------------ | -------------------------------------------------------------------------------- | --------------- | ------------ |
+| 1     | [phase-1-storybook-primitives.md](phase-1-storybook-primitives.md) | Storybook stories for shadcn/base/derived components missing stories             | 14              | ✅ Complete  |
+| 2     | [phase-2-storybook-blocks.md](phase-2-storybook-blocks.md)         | Storybook stories for block components (issue, workspace, session, layout, etc.) | 20              | ✅ Complete  |
+| 3     | [phase-3-storybook-play-tests.md](phase-3-storybook-play-tests.md) | Add `play()` interaction tests to existing + new stories; enable a11y CI         | 18              | ⏳ Blocked/2 |
+| 4     | [phase-4-vitest-logic.md](phase-4-vitest-logic.md)                 | Fill Vitest unit test gaps for business logic modules                            | 6               | ⏳ Parallel  |
+| 5     | [phase-5-rust-tests.md](phase-5-rust-tests.md)                     | Rust `#[cfg(test)]` tests for backend commands and logic                         | 6               | ⏳ Parallel  |
+| 6     | [phase-6-playwright-e2e.md](phase-6-playwright-e2e.md)             | Playwright E2E tests: navigation, URL state, keyboard, workflows                 | 4               | ⏳ Parallel  |
 
 ## Shared Conventions
 

--- a/.mpx/testing-framework/phase-2-storybook-blocks.md
+++ b/.mpx/testing-framework/phase-2-storybook-blocks.md
@@ -1,8 +1,8 @@
 # Phase 2 — Storybook Stories: Block Components
 
-**Status**: Not started
-**Pre-requisite**: Phase 1 complete (CONVENTIONS.md written, pattern established)
-**Estimated sub-agents**: 18 (one per component or tightly-related group)
+**Status**: Ready to execute
+**Pre-requisite**: Phase 1 complete ✅
+**Estimated sub-agents**: 20 (18 components + 2 story splits)
 **Run after**: Phase 1
 **Run before**: Phase 3
 
@@ -12,148 +12,385 @@
 
 Read `.mpx/testing-framework/CONVENTIONS.md` in full before starting.
 
-This phase creates Storybook stories for block-level components — the complex composed components that form the actual UI: issue cards, workspace cards, session panels, layout shells, dependency graph, forest view, creation wizard, and GitHub auth flows.
+This phase creates dedicated Storybook stories for block-level components — the composed UI that forms the actual app. It also splits existing combined stories into per-component files.
 
-Many of these components depend on context stores (`useIssues()`, `useSessions()`) or call `invoke()` for Tauri commands. Refer to CONVENTIONS.md §3 (Context Dependencies) for the correct approach for each tier.
+**Key principles:**
 
-**Key principle**: Prefer prop-driven isolation wherever possible. If a component accepts all data as props and only calls `invoke()` for mutations, it can be rendered standalone (Tauri calls are auto-mocked). If it calls context hooks to pull data, create a minimal wrapper.
+- Every component gets its own `.stories.svelte` file (one component = one Storybook page).
+- Composition demos (showing how components work together) are separate stories.
+- Prefer prop-driven isolation. Components that accept data as props and only call `invoke()` for mutations work standalone (Tauri calls are auto-mocked).
+- Components calling context hooks (`useIssues()`, `useSelection()`, etc.) need a co-located `*StoryWrapper.svelte`.
+
+---
+
+## Pre-Flight: Split Existing Combined Stories
+
+Before spawning component sub-agents, the orchestrator (or sub-agents 1–2) must split these combined story files:
+
+### Split 1 — ChatComponents → CodeBlock
+
+**Current**: `src/lib/components/blocks/chat/ChatComponents.stories.svelte` bundles CodeBlock + StreamingCaret + InlineImage.
+
+**Action**:
+
+- Create `src/lib/components/blocks/chat/CodeBlock.stories.svelte` — dedicated CodeBlock stories.
+- Keep `ChatComponents.stories.svelte` as a composition demo (`Blocks/Chat/ChatComponents`) showing StreamingCaret and InlineImage together.
+
+### Split 2 — SessionLayout → SessionSidebar + SessionChatView
+
+**Current**: `src/lib/components/blocks/session/SessionLayout.stories.svelte` bundles SessionTopBar, SessionSidebar, and full layout.
+
+**Action**:
+
+- Create `src/lib/components/blocks/session/SessionSidebar.stories.svelte` — dedicated sidebar stories (move the 3 sidebar variants from SessionLayout).
+- Create `src/lib/components/blocks/session/SessionChatView.stories.svelte` — dedicated chat view stories.
+- Keep `SessionLayout.stories.svelte` as a composition demo (`Blocks/Session/Layout`) showing the full assembled layout.
+
+---
+
+## Execution Waves
+
+All sub-agents within a wave can run in parallel.
+
+### Wave 1 — Tier 1: No Context, No Wrappers (8 sub-agents)
+
+These components accept all data as props. No context hooks. Simplest to story.
+
+| #   | Component             | Storybook Title                          |
+| --- | --------------------- | ---------------------------------------- |
+| 1   | CodeBlock             | `Blocks/Chat/CodeBlock`                  |
+| 2   | SessionSidebar        | `Blocks/Session/SessionSidebar`          |
+| 3   | IssueDetail           | `Blocks/Issue/IssueDetail`               |
+| 4   | AssignedIssuesPanel   | `Blocks/Issue/AssignedIssuesPanel`       |
+| 5   | TopBar                | `Blocks/Layout/TopBar`                   |
+| 6   | DiscoveredSessionCard | `Blocks/Workspace/DiscoveredSessionCard` |
+| 7   | GhSetupBanner         | `Blocks/GitHub/GhSetupBanner`            |
+| 8   | WorkspaceCard         | `Blocks/Workspace/WorkspaceCard`         |
+
+### Wave 2 — Tier 2: Single Context Wrapper (7 sub-agents)
+
+Each needs one context hook. Create a co-located `*StoryWrapper.svelte` that provides the missing context.
+
+| #   | Component            | Context needed           | Storybook Title                              |
+| --- | -------------------- | ------------------------ | -------------------------------------------- |
+| 9   | IssueCardList        | `useSelection()`         | `Blocks/Issue/IssueCardList`                 |
+| 10  | SessionCard          | `useNotifications()`     | `Blocks/Workspace/SessionCard`               |
+| 11  | NoteCard             | `useRawRequirements()`   | `Blocks/Workspace/NoteCard`                  |
+| 12  | DependencyGraphView  | `useSelection()`         | `Blocks/DependencyGraph/DependencyGraphView` |
+| 13  | WorkspaceBottomPanel | `useSelection()`         | `Blocks/Layout/WorkspaceBottomPanel`         |
+| 14  | ForestView           | `useSelection()`         | `Blocks/Forest/ForestView`                   |
+| 15  | DashboardSidebar     | `useKeyboardShortcuts()` | `Blocks/Layout/DashboardSidebar`             |
+
+### Wave 3 — Tier 3/4: Complex Wrappers or Tauri-Only (5 sub-agents)
+
+These need multi-store wrappers, Tauri event listeners, or have Tauri-only commands.
+
+| #   | Component        | Context needed                 | Storybook Title                        |
+| --- | ---------------- | ------------------------------ | -------------------------------------- |
+| 16  | IssueCard        | `useIssues()` (hard dep)       | `Blocks/Issue/IssueCard`               |
+| 17  | SessionChatView  | `useSessions()` + Tauri events | `Blocks/Session/SessionChatView`       |
+| 18  | CreationWizard   | `useCreationWizard()`          | `Blocks/CreationWizard/CreationWizard` |
+| 19  | GitHubAuthWizard | Tauri-only commands            | `Blocks/GitHub/GitHubAuthWizard`       |
+| 20  | _(orchestrator)_ | Split + composition stories    | —                                      |
 
 ---
 
 ## Project Context
 
-- Mock data source: `src/lib/tauri_mock_data.ts` — use `MOCK_SESSIONS`, `MOCK_ISSUES`, `MOCK_DASHBOARDS`, etc.
-- Context wrapper pattern: see `src/lib/components/blocks/command-palette/CommandPaletteStoryWrapper.svelte`
-- Tauri commands: auto-intercepted by `src/lib/tauri_mock.ts` in Storybook (no setup needed)
-- Session layout pattern: see existing `src/lib/components/blocks/session/SessionLayout.stories.svelte` as a reference for mock data factories and multi-variant stories
-- **bits-ui docs**: use Context7 MCP for any component using bits-ui primitives
+- Mock data: `src/lib/tauri_mock_data.ts` — exports `MOCK_SESSIONS`, `MOCK_ISSUES`, `MOCK_DASHBOARDS`, `MOCK_OVERVIEW_DATA`, `MOCK_ISSUE_DEPENDENCIES`, `MOCK_ASSIGNED_ISSUES_RESULT`, etc.
+- Wrapper reference: `src/lib/components/blocks/command-palette/CommandPaletteStoryWrapper.svelte`
+- Tauri commands: auto-intercepted by `src/lib/tauri_mock.ts` in Storybook
+- bits-ui docs: use Context7 MCP for any component using bits-ui primitives
+- Session layout reference: existing `SessionLayout.stories.svelte` has good `makeMockSession()` factory pattern
 
 ---
 
-## Components to Cover
+## Sub-Agent Specs
 
-### Sub-agent 1 — `CodeBlock` (chat)
+### Sub-agent 1 — `CodeBlock` (chat) — Tier 1
 
 - **File**: `src/lib/components/blocks/chat/CodeBlock.svelte`
-- **Dependencies**: None (pure display + clipboard API)
-- **Variants**: Short snippet (JS), Long multi-line code (Rust), No language specified, Very long single line, Copy button interaction (show copied state)
-- **Event propagation**: Copy button click must not bubble up. Verify `stopPropagation()` is present or add it.
+- **Props**: `code: string`, `language?: string`
+- **Context**: None
+- **Invoke**: None
+- **Create**: `CodeBlock.stories.svelte`
+- **Also**: Update `ChatComponents.stories.svelte` to remove CodeBlock story (keep StreamingCaret + InlineImage as composition demo)
+- **Variants**: Short snippet (JS), Long multi-line (Rust), No language specified, Very long single line, Copy button interaction (show copied state)
+- **Event propagation**: Copy button click must not bubble. Verify `stopPropagation()`.
 
-### Sub-agent 2 — `SessionChatView` (session)
-
-- **File**: `src/lib/components/blocks/session/SessionChatView.svelte`
-- **Dependencies**: Calls `useSessions()` context + Tauri `listen()` events
-- **Approach**: Read the component. Create a `SessionChatViewStoryWrapper.svelte` that calls `setSessionsContext(noopNotifications)` (note: `setSessionsContext` **requires** a `NotificationsApi` argument — pass `{ addPending: () => {}, clearPending: () => {} }`). Messages arrive via Tauri event listeners, not via direct prop/context injection, so stories should pass different `session` prop objects rather than trying to pre-populate messages directly.
-- **Variants**: Running session (pass `session` prop with `state: 'running'`), Empty session (no messages yet), Needs-input state (`state: 'needs-input'`), Error state (`state: 'errored'`)
-- **Event propagation**: Chat input Escape should clear the input field only, NOT dismiss any parent dialog.
-
-### Sub-agent 3 — `SessionSidebar` (session)
+### Sub-agent 2 — `SessionSidebar` (session) — Tier 1
 
 - **File**: `src/lib/components/blocks/session/SessionSidebar.svelte`
-- **Dependencies**: Likely props-driven (read the source first)
-- **Variants**: With session data, Without session (idle), With cost displayed, Collapsed state
+- **Props**: `session: Session`, `contextPercent?: number`, `quota5hPercent?: number`, `quota7dPercent?: number`, `subAgentCount?: number`, `subAgentTree?: Snippet`
+- **Context**: None
+- **Invoke**: None
+- **Create**: `SessionSidebar.stories.svelte`
+- **Also**: Remove sidebar stories from `SessionLayout.stories.svelte` (keep only the "Full Layout" composition story)
+- **Variants**: With session data (running), Idle session, With quota warning (quota5hPercent > 80), Errored session, With sub-agents, Collapsed state (if applicable)
+- **Mock data**: Use `makeMockSession()` factory from existing SessionLayout stories
 
-### Sub-agent 4 — `IssueCard` (issue)
-
-- **File**: `src/lib/components/blocks/issue/IssueCard.svelte`
-- **Dependencies**: `useIssues()` is a **hard dependency** (called unconditionally). You must create an `IssueCardStoryWrapper.svelte` that calls `setIssuesContext()` and loads mock issues. See CONVENTIONS.md §3 for the correct way to populate issues context (use `issuesCtx.loadIssues(dashboardId)` from `onMount`). The `toggle_issue_sound_mute` Tauri command is auto-mocked.
-- **Variants**: Active issue (default), Selected/active state, Batch-selected state, High priority, Low priority, No priority, With worktree active, With GitHub PR linked, Archived issue, With notification dot, Loading/submitting state
-- **⚠️ Event propagation**: IssueCard has action buttons (GitHub link, terminal, VS Code). Each must stop click propagation so the card's main `onclick` is not triggered by button clicks. Verify `stopPropagation()` on all nested interactive elements. Report any missing guards.
-
-### Sub-agent 5 — `IssueCardList` (issue)
-
-- **File**: `src/lib/components/blocks/issue/IssueCardList.svelte`
-- **Dependencies**: Read source — probably accepts `issues` as a prop
-- **Variants**: Full list (use `MOCK_ISSUES`), Empty list, Single issue, Mixed priorities, All archived
-
-### Sub-agent 6 — `IssueDetail` (issue)
+### Sub-agent 3 — `IssueDetail` (issue) — Tier 1
 
 - **File**: `src/lib/components/blocks/issue/IssueDetail.svelte`
-- **Dependencies**: Read source to understand data flow
-- **Variants**: Full detail view, Minimal info (no PR, no worktree), With sub-issues, With dependency chain, Edit mode (if applicable)
-- **Event propagation**: Any dialog/overlay opened from IssueDetail (rename, edit, delete confirmation) must contain Escape properly. Check each dialog child.
+- **Props**: `issue: Issue`, `cache?: GitStatusCache | null`, `ghAvailable?: boolean`, `paletteColors?: string[]`, `usedColors?: string[]` + `IssueCardCallbacks` interface
+- **Context**: None
+- **Invoke**: None
+- **Variants**: Full detail view (all fields populated), Minimal info (no PR, no worktree), With sub-issues, With GitHub PR linked, With worktree active, Edit mode (if applicable)
+- **Mock data**: Use `MOCK_ISSUES[0]` as base, spread overrides for variants
+- **Event propagation**: Any dialog/overlay opened from IssueDetail must contain Escape properly.
 
-### Sub-agent 7 — `AssignedIssuesPanel` (issue)
+### Sub-agent 4 — `AssignedIssuesPanel` (issue) — Tier 1
 
 - **File**: `src/lib/components/blocks/issue/AssignedIssuesPanel.svelte`
-- **Dependencies**: Likely fetches via Tauri (auto-mocked) or receives props
-- **Variants**: With assigned issues, Empty state, Loading, With action buttons
+- **Props**: `issues: AssignedIssue[]`, `dashboardIssues: readonly Issue[]`, `hasMore: boolean`, `loading?: boolean`, `lastSynced?: Date | null`, `disabled?: boolean` + callbacks (`onWizardOpen?`, `onQuickAddWithWorktree?`, `onLoadMore?`, `onRefresh?`)
+- **Context**: None
+- **Invoke**: None
+- **Variants**: With assigned issues, Empty state (no issues), Loading state, With "has more" (load more button visible), Disabled state, Recently synced vs stale sync
+- **Mock data**: Use `MOCK_ASSIGNED_ISSUES_RESULT` and `MOCK_ISSUES`
 
-### Sub-agent 8 — `WorkspaceCard` (workspace)
-
-- **File**: `src/lib/components/blocks/workspace/WorkspaceCard.svelte`
-- **Dependencies**: Read source — mostly prop-driven with callbacks
-- **Variants**: Active workspace (full data), Dormant (no active sessions), Busy (multiple sessions), Empty workspace (no issues), With AFK loop, With attention badge, With GitHub PR open, With merge conflicts, Dark accent color, Light accent color
-- **⚠️ Event propagation**: WorkspaceCard has multiple icon buttons. Each must `stopPropagation()` to prevent triggering the card's main click. The source already has some `stopPropagation()` calls — verify ALL interactive children are covered.
-- **Mock data**: `WorkspaceCard` takes `workspace: OverviewWorkspaceData`, **not** a `Dashboard` object. Use `MOCK_OVERVIEW_DATA[0]` as the base fixture (not `MOCK_DASHBOARDS[0]`). Field names are snake_case: `active_session_count`, `open_issue_count`, `hitl_count`, etc. Example: `{ ...MOCK_OVERVIEW_DATA[0], active_session_count: 3 }`.
-
-### Sub-agent 9 — `SessionCard` (workspace)
-
-- **File**: `src/lib/components/blocks/workspace/SessionCard.svelte`
-- **Dependencies**: Read source — mostly prop-driven
-- **Variants**: Running session, Needs-input session, Errored session, Finished session, With cost displayed, With issue linked, Without issue (orphan)
-- **Event propagation**: Session card likely has action buttons. Verify same pattern as WorkspaceCard.
-
-### Sub-agent 10 — `NoteCard` (workspace)
-
-- **File**: `src/lib/components/blocks/workspace/NoteCard.svelte`
-- **Dependencies**: Read source — inline editing behavior
-- **Variants**: View mode, Edit mode, Empty note, Long note (overflow), Saving/submitting
-
-### Sub-agent 11 — `DiscoveredSessionCard` (workspace)
-
-- **File**: `src/lib/components/blocks/workspace/DiscoveredSessionCard.svelte`
-- **Dependencies**: Read source
-- **Variants**: Default discovered session, With cost info, With process ID
-
-### Sub-agent 12 — `DashboardSidebar` (layout)
-
-- **File**: `src/lib/components/blocks/layout/DashboardSidebar.svelte`
-- **Dependencies**: Read source carefully before writing anything. `DashboardSidebar` does NOT use `useBoard()` or `useSelection()` — it reads the active route directly from SvelteKit's `$app/state` (`page.url.pathname`). Its only external context is `useKeyboardShortcuts()`. The global ThemeDecorator is sufficient; no additional wrapper is needed for most stories.
-- **Variants**: Expanded (default), Collapsed icon-only mode, Active route = '/', Active route = '/sessions', Active route = '/settings', With notification badge, Dark mode
-
-### Sub-agent 13 — `TopBar` (layout)
+### Sub-agent 5 — `TopBar` (layout) — Tier 1
 
 - **File**: `src/lib/components/blocks/layout/TopBar.svelte`
-- **Dependencies**: Read source — likely uses board/selection context
-- **Variants**: Default state, With issue selected, With sync indicator running, With notifications
+- **Props**: `title: string`, `subtitle?: string`, `hasNotifications?: boolean`, `syncing?: boolean`, `forestCollapsed?: boolean` + callbacks (`onSync?`, `onQuickIdeas?`, `onCreateIssue?`, `onToggleForest?`) + `children?: Snippet`
+- **Context**: None
+- **Invoke**: None
+- **Variants**: Default (title only), With subtitle, With notifications badge, Syncing state, Forest collapsed, With all actions visible
+- **Event propagation**: Action buttons must not interfere with each other.
 
-### Sub-agent 14 — `WorkspaceBottomPanel` (layout)
+### Sub-agent 6 — `DiscoveredSessionCard` (workspace) — Tier 1
 
-- **File**: `src/lib/components/blocks/layout/WorkspaceBottomPanel.svelte`
-- **Dependencies**: Read source — likely takes active tab + content as props or slot
-- **Variants**: Issues tab active, Kanban tab active, Dependencies tab active, Collapsed/hidden state, With tab badge
+- **File**: `src/lib/components/blocks/workspace/DiscoveredSessionCard.svelte`
+- **Props**: `session: DiscoveredSession`, `onAdopt: (session: DiscoveredSession) => void`
+- **Context**: None
+- **Invoke**: None
+- **Variants**: Default discovered session, With cost info, With process ID, Multiple providers
+- **Mock data**: Create `makeMockDiscoveredSession()` factory
 
-### Sub-agent 15 — `CreationWizard` (creation-wizard)
+### Sub-agent 7 — `GhSetupBanner` (github) — Tier 1
 
-- **File**: `src/lib/components/blocks/creation-wizard/CreationWizard.svelte`
-- **Dependencies**: This is the main issue creation dialog. It uses `wizard` state internally and accepts callbacks (`onCreate`, `onUpdate`, `onSetupWorktree`). Calls `invoke('search_github_issues')` etc. (all auto-mocked).
-- **Variants**: Closed state, Open — Step 1 (GitHub Search), Open — Step 2 (Issue Name), Open — Step 3 (Color Selection), Open — Step 4 (Worktree Choice, if localFolder set), Submitting state
-- **⚠️ Event propagation — CRITICAL**: `CreationWizard.svelte` uses `svelte:window onkeydown` to handle Escape and uses `onEscapeKeydown={(e) => e.preventDefault()}` on `Dialog.Content`. This pattern suppresses bits-ui's built-in Escape close and delegates to the window handler instead. The window handler calls both `preventDefault()` AND `stopPropagation()`. Verify: (1) Escape correctly closes the wizard, (2) Escape does NOT reach any other `svelte:window onkeydown` listener on the page, (3) Escape inside a text input navigates the wizard back rather than typing "Escape".
-- **Story mock**: Provide mock `assignedIssues` array from `MOCK_ISSUES`
+- **File**: `src/lib/components/blocks/github/GhSetupBanner.svelte`
+- **Props**: `authStatus: GhAuthStatus`, `onconnect?: () => void`
+- **Context**: None
+- **Invoke**: None
+- **Variants**: GitHub not configured (default), With repo configured but no auth, Authenticated (if banner renders differently or hides)
 
-### Sub-agent 16 — `DependencyGraphView` (dependency-graph)
+### Sub-agent 8 — `WorkspaceCard` (workspace) — Tier 1
+
+- **File**: `src/lib/components/blocks/workspace/WorkspaceCard.svelte`
+- **Props**: `workspace: OverviewWorkspaceData`, `onclick: () => void` + 10 optional click handlers (`onGithubClick`, `onFolderClick`, `onGithubRightClick`, `onFolderRightClick`, `onIssuesClick`, `onPrsClick`, `onAttnClick`, `onHitlClick`, `onPrdClick`, `onAfkClick`)
+- **Context**: None
+- **Invoke**: None
+- **Variants**: Active workspace (full data), Dormant (no active sessions), Busy (multiple sessions), Empty workspace (no issues), With AFK loop, With attention badge, With open PRs, With merge conflicts, Dark accent color, Light accent color
+- **⚠️ Event propagation**: Multiple icon buttons — each must `stopPropagation()` to prevent triggering card's main `onclick`. Verify ALL interactive children are covered.
+- **Mock data**: Use `MOCK_OVERVIEW_DATA[0]` as base. Field names are **snake_case**: `active_session_count`, `open_issue_count`, `hitl_count`. Override for variants: `{ ...MOCK_OVERVIEW_DATA[0], active_session_count: 3 }`.
+
+### Sub-agent 9 — `IssueCardList` (issue) — Tier 2
+
+- **File**: `src/lib/components/blocks/issue/IssueCardList.svelte`
+- **Props**: `IssueCardCallbacks` interface + `parentIssues: Issue[]`, `archivedIssues: Issue[]`, `showArchived: boolean`, `isPortfolio: boolean`, `cacheMap?: Map<string, GitStatusCache>`, `ghAvailable?: boolean`, `prioritiesEnabled?: boolean` + batch callbacks + getters (`getChildren`, `getNotificationDotColor?`, `getVisualization?`)
+- **Context**: `useSelection()` from `$lib/modules/board/selection.context.svelte.ts`
+- **Wrapper needed**: `IssueCardListStoryWrapper.svelte` — must call `setSelectionContext()`. Check if `setBoardContext()` is also required (ThemeDecorator may already provide it). Also needs `setIssuesContext()` because child `IssueCard` calls `useIssues()`.
+- **Invoke**: None
+- **Variants**: Full list (use `MOCK_ISSUES`), Empty list, Single issue, Mixed priorities, All archived (with `showArchived: true`), Batch selection mode
+- **Mock data**: `MOCK_ISSUES` for parentIssues, empty array for archivedIssues in most variants
+
+### Sub-agent 10 — `SessionCard` (workspace) — Tier 2
+
+- **File**: `src/lib/components/blocks/workspace/SessionCard.svelte`
+- **Props**: `session: Session`, `onClick: (session: Session) => void`, `onTerminate: (id: string) => void`
+- **Context**: `useNotifications()` from notifications module
+- **Wrapper needed**: `SessionCardStoryWrapper.svelte` — calls `setNotificationsContext()` with no-op handlers
+- **Invoke**: None
+- **Variants**: Running session, Needs-input session, Errored session, Finished session, With cost displayed, With issue linked, Without issue (orphan)
+- **Event propagation**: Action buttons (terminate) must not trigger card's `onClick`.
+- **Mock data**: Use `MOCK_SESSIONS`, override `state` for variants
+
+### Sub-agent 11 — `NoteCard` (workspace) — Tier 2
+
+- **File**: `src/lib/components/blocks/workspace/NoteCard.svelte`
+- **Props**: `note: RawRequirementNote`, `index: number`, `showToggleProcessed?: boolean`
+- **Context**: `useRawRequirements()` from raw requirements module
+- **Wrapper needed**: `NoteCardStoryWrapper.svelte` — calls `setRawRequirementsContext()` with mock data
+- **Invoke**: None
+- **Variants**: View mode, Edit mode, Empty note, Long note (overflow), With toggle processed visible
+- **Mock data**: Create `makeMockNote()` factory
+
+### Sub-agent 12 — `DependencyGraphView` (dependency-graph) — Tier 2
 
 - **File**: `src/lib/components/blocks/dependency-graph/DependencyGraphView.svelte`
-- **Also cover**: `DependencyGraphCanvas.svelte`
-- **Dependencies**: `DependencyGraphView` is **fully prop-driven** — it accepts `issues: readonly Issue[]` and `dependencies: readonly IssueDependency[]` as props, not from context. However it calls `useSelection()` from `$lib/modules/board` internally, so a wrapper that calls `setBoardContext()` and `setSelectionContext()` (or equivalent) is needed. Read the source to identify the exact context setup required. There is no `useDependencyGraph()` function.
-- **Variants**: With issues and dependencies (use `MOCK_ISSUES`), Empty graph, Filtered view (only AFK issues), Graph with a long chain
+- **Props**: `issues: readonly Issue[]`, `dependencies: readonly IssueDependency[]`, `onhitlquickstart?: (issueId: string) => void`
+- **Context**: `useSelection()` from `$lib/modules/board/selection.context.svelte.ts`
+- **Wrapper needed**: `DependencyGraphStoryWrapper.svelte` — calls `setSelectionContext()`. Check if `setBoardContext()` is also required.
+- **Invoke**: None
+- **Variants**: With issues and dependencies (use `MOCK_ISSUES` + `MOCK_ISSUE_DEPENDENCIES`), Empty graph (no issues), Filtered view (subset of issues), Long dependency chain, Single isolated node
+- **Canvas note**: Uses SVG/canvas-based rendering. Wrap in a `div` with explicit dimensions (`min-h-[400px] w-full`).
 
-### Sub-agent 17 — `ForestView` (forest)
+### Sub-agent 13 — `WorkspaceBottomPanel` (layout) — Tier 2
+
+- **File**: `src/lib/components/blocks/layout/WorkspaceBottomPanel.svelte`
+- **Props**: Extensive — `IssueCardCallbacks` + `issues`, `parentIssues`, `archivedIssues`, `showArchived`, `isPortfolio`, `cacheMap`, `ghAvailable`, `prioritiesEnabled`, `paletteColors`, `usedColors`, `dependencies`, `authStatus` + assigned issues props + getters + callbacks
+- **Context**: `useSelection()` from `$lib/modules/board/selection.context.svelte.ts`
+- **Wrapper needed**: `WorkspaceBottomPanelStoryWrapper.svelte` — calls `setSelectionContext()`. Also needs `setIssuesContext()` because child components (IssueCardList → IssueCard) call `useIssues()`.
+- **Invoke**: None
+- **Variants**: Issues tab active (default), Dependencies tab active, With issue selected (detail panel visible), Empty state (no issues), With GitHub setup banner, With assigned issues panel
+- **Note**: This is a container component — test that tab switching works and content renders. Detailed component testing happens in the individual component stories.
+
+### Sub-agent 14 — `ForestView` (forest) — Tier 2
 
 - **File**: `src/lib/components/blocks/forest/ForestView.svelte`
-- **Note**: ForestView uses the `low-poly-2d-trees` canvas library for 2D tree rendering. It likely accepts issues/dashboards as data props.
-- **Dependencies**: Read source carefully. Use `MOCK_ISSUES` and `MOCK_DASHBOARDS` as fixtures.
-- **Variants**: With full issue tree, Empty forest, Single issue, Many issues (performance view)
-- **Canvas note**: The canvas element should render visibly in Storybook. If it requires a minimum size, wrap in a `div` with explicit dimensions.
+- **Props**: `issues: readonly Issue[]`, `allIssues: readonly Issue[]`, `dependencies: readonly IssueDependency[]`, `getGitStatus: (issueId: string) => GitStatusCache | undefined`, `getSessionsForIssue: (issueId: string) => readonly SessionForMapping[]` + callbacks (`onAddIssue?`, `onArchiveIssue?`, `onChangeIssueColor?`)
+- **Context**: `useSelection()` from `$lib/modules/board/selection.context.svelte.ts`
+- **Wrapper needed**: `ForestViewStoryWrapper.svelte` — calls `setSelectionContext()`.
+- **Invoke**: None
+- **Variants**: Full forest (multiple issues/trees), Empty forest (no issues), Single issue/tree, Many issues (performance test), With active session on a tree
+- **Canvas note**: Uses `low-poly-2d-trees` canvas library. Wrap in a `div` with explicit dimensions (`min-h-[500px] w-full`). The canvas must have visible space to render.
+- **Mock data**: `MOCK_ISSUES` for issues, `MOCK_ISSUE_DEPENDENCIES` for dependencies. Pass stub functions for `getGitStatus` and `getSessionsForIssue`.
 
-### Sub-agent 18 — `GhSetupBanner` + `GitHubAuthWizard` (github)
+### Sub-agent 15 — `DashboardSidebar` (layout) — Tier 2
 
-- **Files**: `src/lib/components/blocks/github/GhSetupBanner.svelte` and `src/lib/components/blocks/github-auth/GitHubAuthWizard.svelte`
-- **Dependencies**: Auth wizard calls `invoke('github_device_flow_start')`. **Important**: this command is in `TAURI_ONLY_COMMANDS` — in browser/Storybook mode it fires a "GitHub authentication requires the desktop app" warning toast and is a no-op. Stories for `GitHubAuthWizard` can only show static initial states; the live device-flow polling will not work in Storybook.
-- **Variants for GhSetupBanner**: Default (GitHub not configured), With repo configured but no auth
-- **Variants for GitHubAuthWizard**: Initial state (show the UI with device code), Error state (simulate error via props if supported)
-- **⚠️ Event propagation**: GitHubAuthWizard is a dialog. Check `onEscapeKeydown` on its `Dialog.Content`.
+- **File**: `src/lib/components/blocks/layout/DashboardSidebar.svelte`
+- **Props**: `workspaceName: string`, `username: string`, `userInitials: string`, `activeSessionCount?: number`, `collapsed: boolean`, `onToggleSidebar: () => void`, `onEditWorkspace?: () => void`
+- **Context**: `useKeyboardShortcuts()` from `$lib/modules/keyboard-shortcuts/keyboard_shortcuts.context.svelte.ts`
+- **Wrapper needed**: `DashboardSidebarStoryWrapper.svelte` — calls `setKeyboardShortcutsContext()`. ThemeDecorator already provides board context.
+- **Invoke**: None
+- **Variants**: Expanded (default), Collapsed icon-only mode, With active sessions badge, With notification badge, Dark mode (handled by ThemeDecorator controls)
+- **Navigation**: Contains links to `/`, `/sessions`, `/ai-config`, `/usage`, `/workspace-settings`, `/settings`. In Storybook these links won't navigate — that's fine, they're visual.
+- **Internal components**: WorkspaceSelector, UserAvatar, ThemeToggle, LanguageSwitcher, SidebarNavItem, BrandMark
+
+### Sub-agent 16 — `IssueCard` (issue) — Tier 3
+
+- **File**: `src/lib/components/blocks/issue/IssueCard.svelte`
+- **Props**: `issue: Issue` + `cache?`, `ghAvailable?`, `notificationDotColor?`, `childCount?`, `prdParent?`, `prioritiesEnabled?`, `sessionState?`, `visualization?`, `isActive?`, `isHovered?`, `isBatchSelected?`, `isModifierHeld?` + 7 callback handlers (`onCardClick`, `onTitleClick`, `onMouseEnter`, `onMouseLeave`, `onExecuteAction`, `onPriorityClick`, `onQuickActionAssignFolder`)
+- **Context**: `useIssues()` — **hard dependency**, called unconditionally
+- **Invoke**: `invoke('toggle_issue_sound_mute')` (auto-mocked)
+- **Wrapper needed**: `IssueCardStoryWrapper.svelte` — must call `setIssuesContext()` and load mock issues via `issuesCtx.loadIssues(MOCK_DASHBOARDS[0].id)` from `onMount`. See CONVENTIONS.md §3 for the exact pattern. **Do NOT assign to `issuesCtx.issues` directly — it is a read-only getter.**
+- **Variants**: Active issue (default), Selected/active state, Batch-selected state, High priority, Low priority, No priority, With worktree active, With GitHub PR linked, Archived issue, With notification dot, With session state chip (running/hitl/error)
+- **⚠️ Event propagation — CRITICAL**: Action buttons (GitHub link, terminal, VS Code) must stop click propagation. Right-click on quick-action buttons must call `stopPropagation()` on `contextmenu` event. Verify all nested interactive elements.
+- **Mock data**: `MOCK_ISSUES[0]` as base, spread overrides
+
+### Sub-agent 17 — `SessionChatView` (session) — Tier 3
+
+- **File**: `src/lib/components/blocks/session/SessionChatView.svelte`
+- **Props**: `session: Session`, `onBack?: () => void`
+- **Context**: `useSessions()` — requires session store context
+- **Invoke**: `listen<SessionEventPayload>('session-event', ...)` (Tauri event listener)
+- **Wrapper needed**: `SessionChatViewStoryWrapper.svelte` — must call `setSessionsContext(noopNotifications)` where `noopNotifications = { addPending: () => {}, clearPending: () => {} }`. Messages arrive via Tauri event listeners (not direct prop/context injection), so stories should pass different `session` prop objects to show different states rather than trying to pre-populate messages.
+- **Variants**: Running session, Empty session (no messages yet), Needs-input state, Error state, With back button
+- **Event propagation**: Chat input Escape should clear the input field only, NOT dismiss any parent dialog.
+- **Mock data**: Use `makeMockSession()` factory, override `state` field
+
+### Sub-agent 18 — `CreationWizard` (creation-wizard) — Tier 3
+
+- **File**: `src/lib/components/blocks/creation-wizard/CreationWizard.svelte`
+- **Props**: `assignedIssues: AssignedIssue[]`, `onCreate: (request: CreateIssueRequest) => Promise<Issue>`, `onUpdate: (request: UpdateIssueRequest) => Promise<Issue>`, `onSetupWorktree: (issue: Issue) => Promise<void>`
+- **Context**: `useCreationWizard()` — provides full wizard state and step management
+- **Invoke**: `search_github_issues` (via context, auto-mocked)
+- **Wrapper needed**: `CreationWizardStoryWrapper.svelte` — must call `setCreationWizardContext()`. Check the context's dependencies — it may need board context (already provided by ThemeDecorator) or additional contexts.
+- **Variants**: Closed state, Open — Step 1 (GitHub Search), Open — Step 2 (Issue Name), Open — Step 3 (Color Selection), Open — Step 4 (Worktree Choice), Submitting state
+- **⚠️ Event propagation — CRITICAL**: Uses `svelte:window onkeydown` for Escape with explicit `stopPropagation()`. Uses `onEscapeKeydown={(e) => e.preventDefault()}` on `Dialog.Content` to suppress bits-ui's built-in close. Verify: (1) Escape correctly closes the wizard, (2) Escape does NOT reach other `svelte:window` listeners, (3) Escape inside text input navigates back rather than typing "Escape".
+- **Keyboard**: Arrow keys for step navigation, Enter for confirm, Backspace for back
+- **Mock data**: `MOCK_ASSIGNED_ISSUES_RESULT` for assignedIssues, return mock `Issue` from `onCreate`/`onUpdate` callbacks
+
+### Sub-agent 19 — `GitHubAuthWizard` (github-auth) — Tier 4
+
+- **File**: `src/lib/components/blocks/github-auth/GitHubAuthWizard.svelte`
+- **Props**: `open = $bindable()`, `onconnected?: (user: GitHubUser) => void`
+- **Context**: None
+- **Invoke**: `invoke('github_device_flow_start')`, `invoke('github_device_flow_poll')` — **both are in `TAURI_ONLY_COMMANDS`**. In Storybook they fire a "Desktop app required" warning toast and are no-ops.
+- **Wrapper needed**: None (props-driven dialog)
+- **Variants**: Initial state (dialog open, showing UI before device code), Error state (if supported via props)
+- **Limitation**: Live device-flow polling will not work in Storybook. Stories can only show static initial states.
+- **⚠️ Event propagation**: This is a Dialog. Check `onEscapeKeydown` on `Dialog.Content`.
+
+### Sub-agent 20 — Story Splits & Composition (orchestrator task)
+
+This is not a component sub-agent — it's cleanup by the orchestrator after Waves 1-3:
+
+1. **Verify splits**: Confirm `CodeBlock.stories.svelte` and `SessionSidebar.stories.svelte` were created by sub-agents 1 and 2.
+2. **Update ChatComponents.stories.svelte**: Remove CodeBlock story if sub-agent 1 didn't already. Keep StreamingCaret + InlineImage stories. Update title to `Blocks/Chat/ChatComponents`.
+3. **Update SessionLayout.stories.svelte**: Remove SessionSidebar variants if sub-agent 2 didn't already. Keep the "Full Layout" composition story. Ensure it imports SessionChatView and SessionSidebar to show them composed together.
+4. **Verify title taxonomy**: Every new story file must use the correct Storybook title prefix per CONVENTIONS.md §2.
+
+---
+
+## Context Wrapper Patterns
+
+### Selection context (used by 4 components: IssueCardList, DependencyGraphView, WorkspaceBottomPanel, ForestView)
+
+```svelte
+<!-- Example: DependencyGraphStoryWrapper.svelte -->
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import { setSelectionContext } from '$lib/modules/board/selection.context.svelte.js';
+
+	const { children }: { children: Snippet } = $props();
+
+	setSelectionContext();
+</script>
+
+{@render children()}
+```
+
+> **Note**: Check whether `setSelectionContext()` requires `setBoardContext()` to have been called first. ThemeDecorator calls `setBoardContext()` globally, so this may already be available. If `setSelectionContext()` calls `useBoard()` internally, it will work. If it requires an explicit parameter, read the source and adjust.
+
+### Issues context (used by IssueCard, and transitively by IssueCardList/WorkspaceBottomPanel)
+
+```svelte
+<!-- IssueCardStoryWrapper.svelte -->
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import type { Snippet } from 'svelte';
+	import { setIssuesContext } from '$lib/modules/issues/index.js';
+	import { MOCK_DASHBOARDS } from '$lib/tauri_mock_data.js';
+
+	const { children }: { children: Snippet } = $props();
+
+	const issuesCtx = setIssuesContext();
+	onMount(() => issuesCtx.loadIssues(MOCK_DASHBOARDS[0].id));
+</script>
+
+{@render children()}
+```
+
+### Sessions context (used by SessionChatView)
+
+```svelte
+<!-- SessionChatViewStoryWrapper.svelte -->
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import { setSessionsContext } from '$lib/modules/sessions/index.js';
+
+	const { children }: { children: Snippet } = $props();
+
+	const noopNotifications = { addPending: () => {}, clearPending: () => {} };
+	setSessionsContext(noopNotifications);
+</script>
+
+{@render children()}
+```
+
+### Composite wrappers (for components needing multiple contexts)
+
+Components like `IssueCardList` and `WorkspaceBottomPanel` need **both** `useSelection()` and child `IssueCard`s need `useIssues()`. Their wrappers must set up both:
+
+```svelte
+<!-- IssueCardListStoryWrapper.svelte -->
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import type { Snippet } from 'svelte';
+	import { setSelectionContext } from '$lib/modules/board/selection.context.svelte.js';
+	import { setIssuesContext } from '$lib/modules/issues/index.js';
+	import { MOCK_DASHBOARDS } from '$lib/tauri_mock_data.js';
+
+	const { children }: { children: Snippet } = $props();
+
+	setSelectionContext();
+	const issuesCtx = setIssuesContext();
+	onMount(() => issuesCtx.loadIssues(MOCK_DASHBOARDS[0].id));
+</script>
+
+{@render children()}
+```
 
 ---
 
@@ -164,7 +401,10 @@ You are implementing a Storybook story for a specific block component in the Gro
 
 1. Read ALL source files for this component completely before writing anything.
 2. Determine context tier (see CONVENTIONS.md §3): Does it need a wrapper?
-3. If it calls context hooks, read the context module to understand what data it needs.
+3. If it calls context hooks, read the context module to understand:
+   - What the set*Context() function signature is
+   - What parameters it requires
+   - Whether it depends on other contexts being set first
 4. Import mock data from 'src/lib/tauri_mock_data.ts' — do NOT hardcode fixture data.
 5. If a wrapper is needed, create `MyComponentStoryWrapper.svelte` alongside the story.
 6. Create the story file following the exact format in CONVENTIONS.md §2.
@@ -173,70 +413,39 @@ You are implementing a Storybook story for a specific block component in the Gro
    - For every nested button/link: verify stopPropagation() exists.
    - For every dialog/popover child: verify onEscapeKeydown guard exists.
    - If violations found: fix the source file AND document in Findings Report.
-9. Use Context7 MCP for bits-ui API reference if needed:
-   - mcp_context7_resolve-library-id({ libraryName: "bits-ui" })
-   - mcp_context7_get-library-docs({ id: "<result>", topic: "<relevant feature>" })
-10. Return a Findings Report (format in CONVENTIONS.md §4).
+9. Use Context7 MCP for bits-ui API reference if needed.
+10. Run svelte-autofixer on any .svelte files you create or modify.
+11. Return a Findings Report (format in CONVENTIONS.md §4).
+```
+
+---
+
+## Mock Data Quick Reference
+
+```ts
+import {
+	MOCK_SESSIONS, // Session[]
+	MOCK_ISSUES, // Issue[]
+	MOCK_DASHBOARDS, // Dashboard[]
+	MOCK_OVERVIEW_DATA, // OverviewWorkspaceData[]
+	MOCK_ISSUE_DEPENDENCIES, // IssueDependency[]
+	MOCK_GIT_STATUSES, // GitStatusCache[]
+	MOCK_ASSIGNED_ISSUES_RESULT, // { issues: AssignedIssue[], has_more: boolean }
+	MOCK_COLOR_PALETTES, // ColorPalette[]
+} from '$lib/tauri_mock_data.js';
 ```
 
 ---
 
 ## Completion Criteria
 
-- All 18 story files (or story+wrapper pairs) exist and render without errors
+- All 18 component story files (or story+wrapper pairs) exist and render without errors
+- Combined stories split: CodeBlock and SessionSidebar have dedicated story files
+- SessionLayout.stories.svelte and ChatComponents.stories.svelte are composition-only demos
+- Every story uses the correct title prefix from the taxonomy table
 - `pnpm test -- --project=storybook` passes
 - `pnpm check:all` passes with no new errors
-- Consolidated Findings Report listing all event propagation violations found and whether they were fixed or deferred
-
----
-
-## Example: Context Wrapper Pattern (reference)
-
-If `IssueCard` needs `useIssues()` context, create `IssueCardStoryWrapper.svelte`:
-
-```svelte
-<!-- src/lib/components/blocks/issue/IssueCardStoryWrapper.svelte -->
-<script lang="ts">
-	import { onMount } from 'svelte';
-	import { setIssuesContext } from '$lib/modules/issues/index.js';
-	import { MOCK_DASHBOARDS } from '$lib/tauri_mock_data.js';
-	import type { Snippet } from 'svelte';
-
-	const { children }: { children: Snippet } = $props();
-
-	const issuesCtx = setIssuesContext();
-	// Load mock issues via the auto-mocked Tauri handler
-	// Do NOT assign to issuesCtx.issues directly — it is a read-only getter.
-	onMount(() => issuesCtx.loadIssues(MOCK_DASHBOARDS[0].id));
-</script>
-
-{@render children()}
-```
-
-Then in the story:
-
-```svelte
-<script module lang="ts">
-	import { defineMeta } from '@storybook/addon-svelte-csf';
-	import IssueCardStoryWrapper from './IssueCardStoryWrapper.svelte';
-
-	const { Story } = defineMeta({
-		title: 'Blocks/Issue/IssueCard',
-		component: IssueCardStoryWrapper,
-		tags: ['autodocs'],
-	});
-</script>
-
-<script lang="ts">
-	import IssueCard from './IssueCard.svelte';
-	import { MOCK_ISSUES } from '$lib/tauri_mock_data.js';
-</script>
-
-<Story name="Active Issue">
-	{#snippet template()}
-		<IssueCardStoryWrapper>
-			<IssueCard issue={MOCK_ISSUES[0]} isActive={false} />
-		</IssueCardStoryWrapper>
-	{/snippet}
-</Story>
-```
+- Consolidated Findings Report listing:
+    - All event propagation violations found and whether they were fixed or deferred
+    - All context setup issues encountered
+    - Any components that could not be rendered in Storybook (with reason)

--- a/src/lib/components/base/stat-cell/StatCell.svelte
+++ b/src/lib/components/base/stat-cell/StatCell.svelte
@@ -64,11 +64,17 @@
 	class={cn(statCellVariants({ tone: effectiveTone }), onclick && 'cursor-pointer', className)}
 	role={onclick ? 'button' : undefined}
 	tabindex={onclick ? 0 : undefined}
-	{onclick}
+	onclick={onclick
+		? (event: MouseEvent) => {
+				event.stopPropagation();
+				onclick();
+			}
+		: undefined}
 	onkeydown={onclick
-		? (event) => {
+		? (event: KeyboardEvent) => {
 				if (event.key === 'Enter' || event.key === ' ') {
 					event.preventDefault();
+					event.stopPropagation();
 					onclick();
 				}
 			}

--- a/src/lib/components/base/status-row/StatusRow.svelte
+++ b/src/lib/components/base/status-row/StatusRow.svelte
@@ -27,11 +27,17 @@
 		: 'var(--border)'}
 	role={onclick ? 'button' : undefined}
 	tabindex={onclick ? 0 : undefined}
-	{onclick}
+	onclick={onclick
+		? (event: MouseEvent) => {
+				event.stopPropagation();
+				onclick();
+			}
+		: undefined}
 	onkeydown={onclick
-		? (event) => {
+		? (event: KeyboardEvent) => {
 				if (event.key === 'Enter' || event.key === ' ') {
 					event.preventDefault();
+					event.stopPropagation();
 					onclick();
 				}
 			}

--- a/src/lib/components/blocks/chat/ChatComponents.stories.svelte
+++ b/src/lib/components/blocks/chat/ChatComponents.stories.svelte
@@ -1,40 +1,17 @@
 <script module lang="ts">
 	import { defineMeta } from '@storybook/addon-svelte-csf';
-	import CodeBlock from './CodeBlock.svelte';
+	import StreamingCaret from './StreamingCaret.svelte';
 
 	const { Story } = defineMeta({
-		title: 'Blocks/Chat/Components',
-		component: CodeBlock,
+		title: 'Blocks/Chat/ChatComponents',
+		component: StreamingCaret,
 		tags: ['autodocs'],
 	});
 </script>
 
 <script lang="ts">
-	import StreamingCaret from './StreamingCaret.svelte';
 	import InlineImage from './InlineImage.svelte';
-
-	const typescriptCode = `export interface Provider {
-  spawn(): Promise<Session>;
-  sendMessage(msg: string): Promise<void>;
-  handleToolResult(id: string, result: unknown): Promise<void>;
-}`;
-
-	const bashCode = `$ cargo test --workspace
-   Compiling grovekeeper v0.8.0
-running 24 tests...
-test providers::claude_code::tests::test_spawn ... ok
-test providers::opencode::tests::test_auth ... ok`;
 </script>
-
-<Story name="CodeBlock with Language">
-	{#snippet template()}
-		<div class="mx-auto max-w-225 space-y-4">
-			<CodeBlock language="typescript" code={typescriptCode} />
-			<CodeBlock language="bash" code={bashCode} />
-			<CodeBlock code="plain text without language label" />
-		</div>
-	{/snippet}
-</Story>
 
 <Story name="Streaming Caret">
 	{#snippet template()}

--- a/src/lib/components/blocks/chat/CodeBlock.stories.svelte
+++ b/src/lib/components/blocks/chat/CodeBlock.stories.svelte
@@ -1,0 +1,101 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import CodeBlock from './CodeBlock.svelte';
+
+	const { Story } = defineMeta({
+		title: 'Blocks/Chat/CodeBlock',
+		component: CodeBlock,
+		tags: ['autodocs'],
+	});
+</script>
+
+<script lang="ts">
+	const typescriptSnippet = `export interface Provider {
+  spawn(): Promise<Session>;
+  sendMessage(msg: string): Promise<void>;
+  handleToolResult(id: string, result: unknown): Promise<void>;
+}`;
+
+	const rustMultiline = `use anyhow::Result;
+use rusqlite::Connection;
+use std::path::PathBuf;
+
+pub struct Database {
+    connection: Connection,
+    path: PathBuf,
+}
+
+impl Database {
+    pub fn open(path: impl Into<PathBuf>) -> Result<Self> {
+        let path = path.into();
+        let connection = Connection::open(&path)?;
+        connection.execute_batch("
+            PRAGMA journal_mode = WAL;
+            PRAGMA synchronous = NORMAL;
+            PRAGMA foreign_keys = ON;
+        ")?;
+        Ok(Self { connection, path })
+    }
+
+    pub fn execute(&self, sql: &str) -> Result<usize> {
+        Ok(self.connection.execute(sql, [])?)
+    }
+
+    pub fn query_row<T, F>(&self, sql: &str, f: F) -> Result<T>
+    where
+        F: FnOnce(&rusqlite::Row<'_>) -> rusqlite::Result<T>,
+    {
+        Ok(self.connection.query_row(sql, [], f)?)
+    }
+}`;
+
+	const noLanguageCode = `Some plain text output without any language specified.
+It could be log output, a configuration snippet, or anything else.
+Line 3 of the output.`;
+
+	const longSingleLine =
+		'const veryLongVariableName = performSomeComplexCalculation(firstArgument, secondArgument, thirdArgument, fourthArgument, fifthArgument, sixthArgument, seventhArgument, eighthArgument);';
+</script>
+
+<Story name="Short Snippet">
+	{#snippet template()}
+		<div class="mx-auto max-w-225">
+			<CodeBlock language="typescript" code={typescriptSnippet} />
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Long Multiline">
+	{#snippet template()}
+		<div class="mx-auto max-w-225">
+			<CodeBlock language="rust" code={rustMultiline} />
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="No Language">
+	{#snippet template()}
+		<div class="mx-auto max-w-225">
+			<CodeBlock code={noLanguageCode} />
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Long Single Line">
+	{#snippet template()}
+		<div class="mx-auto max-w-225">
+			<CodeBlock language="javascript" code={longSingleLine} />
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Copy Button">
+	{#snippet template()}
+		<div class="mx-auto max-w-225">
+			<p class="mb-2 text-xs text-foreground-muted">
+				Click the copy button in the header to copy code to clipboard.
+			</p>
+			<CodeBlock language="bash" code="npm install @tauri-apps/api@latest" />
+		</div>
+	{/snippet}
+</Story>

--- a/src/lib/components/blocks/chat/CodeBlock.svelte
+++ b/src/lib/components/blocks/chat/CodeBlock.svelte
@@ -16,7 +16,8 @@
 	let copied = $state(false);
 	let copyTimeout: ReturnType<typeof setTimeout> | undefined;
 
-	async function handleCopy() {
+	async function handleCopy(event: MouseEvent) {
+		event.stopPropagation();
 		try {
 			await navigator.clipboard.writeText(code);
 			copied = true;

--- a/src/lib/components/blocks/creation-wizard/CreationWizard.stories.svelte
+++ b/src/lib/components/blocks/creation-wizard/CreationWizard.stories.svelte
@@ -1,0 +1,116 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import CreationWizard from './CreationWizard.svelte';
+	import CreationWizardStoryWrapper from './CreationWizardStoryWrapper.svelte';
+
+	const { Story } = defineMeta({
+		title: 'Blocks/CreationWizard/CreationWizard',
+		component: CreationWizard,
+		tags: ['autodocs'],
+	});
+</script>
+
+<script lang="ts">
+	import { fn } from 'storybook/test';
+	import type { Issue } from '$lib/modules/issues';
+	import { MOCK_ASSIGNED_ISSUES_RESULT } from '$lib/tauri_mock_data.js';
+	import { WIZARD_STEPS } from '$lib/modules/creation-wizard/types.js';
+
+	const mockIssue: Issue = {
+		id: 'mock-created-issue',
+		dashboard_id: 'mock-dashboard-grovekeeper',
+		name: 'Mock Created Issue',
+		priority: 'medium',
+		color: '#f97316',
+		status: 'active',
+		github_issue_url: null,
+		github_issue_number: null,
+		branch_name: 'mock-issue-branch',
+		base_branch: 'dev',
+		worktree_folder: null,
+		worktree_state: 'none',
+		parent_issue_id: null,
+		editor_folder: null,
+		dev_server_command: null,
+		dev_server_port: null,
+		dev_server_pid: null,
+		browser_url: null,
+		labels: [],
+		sort_order: 0,
+		created_at: '2026-05-14T10:00:00Z',
+		character_pack_id: null,
+		character_avatar: null,
+		is_sound_muted: false,
+	};
+
+	const assignedIssues = MOCK_ASSIGNED_ISSUES_RESULT.issues;
+
+	const mockOnCreate = fn().mockResolvedValue(mockIssue);
+	const mockOnUpdate = fn().mockResolvedValue(mockIssue);
+	const mockOnSetupWorktree = fn().mockResolvedValue(undefined);
+</script>
+
+<Story name="Default (GitHub Search)">
+	{#snippet template()}
+		<CreationWizardStoryWrapper>
+			<CreationWizard
+				{assignedIssues}
+				onCreate={mockOnCreate}
+				onUpdate={mockOnUpdate}
+				onSetupWorktree={mockOnSetupWorktree}
+			/>
+		</CreationWizardStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story name="Step: Issue Name">
+	{#snippet template()}
+		<CreationWizardStoryWrapper initialStep={WIZARD_STEPS.ISSUE_NAME}>
+			<CreationWizard
+				{assignedIssues}
+				onCreate={mockOnCreate}
+				onUpdate={mockOnUpdate}
+				onSetupWorktree={mockOnSetupWorktree}
+			/>
+		</CreationWizardStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story name="Step: Worktree Choice">
+	{#snippet template()}
+		<CreationWizardStoryWrapper initialStep={WIZARD_STEPS.WORKTREE_CHOICE}>
+			<CreationWizard
+				{assignedIssues}
+				onCreate={mockOnCreate}
+				onUpdate={mockOnUpdate}
+				onSetupWorktree={mockOnSetupWorktree}
+			/>
+		</CreationWizardStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story name="Step: Color Selection">
+	{#snippet template()}
+		<CreationWizardStoryWrapper initialStep={WIZARD_STEPS.COLOR_SELECTION}>
+			<CreationWizard
+				{assignedIssues}
+				onCreate={mockOnCreate}
+				onUpdate={mockOnUpdate}
+				onSetupWorktree={mockOnSetupWorktree}
+			/>
+		</CreationWizardStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story name="Closed">
+	{#snippet template()}
+		<CreationWizardStoryWrapper openOnMount={false}>
+			<CreationWizard
+				{assignedIssues}
+				onCreate={mockOnCreate}
+				onUpdate={mockOnUpdate}
+				onSetupWorktree={mockOnSetupWorktree}
+			/>
+		</CreationWizardStoryWrapper>
+	{/snippet}
+</Story>

--- a/src/lib/components/blocks/creation-wizard/CreationWizardStoryWrapper.svelte
+++ b/src/lib/components/blocks/creation-wizard/CreationWizardStoryWrapper.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import type { Snippet } from 'svelte';
+	import { setCreationWizardContext } from '$lib/modules/creation-wizard/creation_wizard.context.svelte.js';
+	import { WIZARD_STEPS } from '$lib/modules/creation-wizard/types.js';
+	import type { WizardDependencies, WizardStep } from '$lib/modules/creation-wizard/types.js';
+
+	interface Props {
+		initialStep?: WizardStep;
+		openOnMount?: boolean;
+		children?: Snippet;
+	}
+
+	let { initialStep, openOnMount = true, children }: Props = $props();
+
+	const MOCK_DEPENDENCIES: WizardDependencies = {
+		dashboardId: 'mock-dashboard-grovekeeper',
+		paletteColors: [
+			'#ef4444',
+			'#f97316',
+			'#eab308',
+			'#22c55e',
+			'#10b981',
+			'#06b6d4',
+			'#3b82f6',
+			'#8b5cf6',
+		],
+		usedColors: ['#ef4444'],
+		nextAvailableColor: '#f97316',
+		localFolder: 'C:/_MP_projects/Grovekeeper',
+		defaultBaseBranch: 'dev',
+		githubRepo: { owner: 'MartinoPolo', repo: 'Grovekeeper' },
+		assignedIssues: [],
+	};
+
+	const wizardContext = setCreationWizardContext();
+
+	onMount(() => {
+		if (!openOnMount) {
+			return;
+		}
+
+		wizardContext.openWizard(MOCK_DEPENDENCIES);
+
+		if (initialStep === undefined || initialStep === WIZARD_STEPS.GITHUB_SEARCH) {
+			return;
+		}
+
+		// github-search -> issue-name
+		wizardContext.skipGithubSearch();
+		if (initialStep === WIZARD_STEPS.ISSUE_NAME) {
+			return;
+		}
+
+		// issue-name -> worktree-choice (or color-selection if no worktree)
+		wizardContext.confirmIssueName('Mock Issue Name', 'mock-issue-branch');
+		if (initialStep === WIZARD_STEPS.WORKTREE_CHOICE) {
+			return;
+		}
+
+		// worktree-choice -> color-selection
+		wizardContext.selectWorktreeChoice(false);
+	});
+</script>
+
+{@render children?.()}

--- a/src/lib/components/blocks/dependency-graph/DependencyGraphStoryWrapper.svelte
+++ b/src/lib/components/blocks/dependency-graph/DependencyGraphStoryWrapper.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import { setSelectionContext } from '$lib/modules/board/selection.context.svelte.js';
+
+	interface Props {
+		children?: Snippet;
+	}
+
+	let { children }: Props = $props();
+	setSelectionContext();
+</script>
+
+{@render children?.()}

--- a/src/lib/components/blocks/dependency-graph/DependencyGraphView.stories.svelte
+++ b/src/lib/components/blocks/dependency-graph/DependencyGraphView.stories.svelte
@@ -1,0 +1,84 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import DependencyGraphView from './DependencyGraphView.svelte';
+
+	const { Story } = defineMeta({
+		title: 'Blocks/DependencyGraph/DependencyGraphView',
+		component: DependencyGraphView,
+		tags: ['autodocs'],
+	});
+</script>
+
+<script lang="ts">
+	import { fn } from 'storybook/test';
+	import type { Issue } from '$lib/modules/issues';
+	import { MOCK_ISSUES, MOCK_ISSUE_DEPENDENCIES } from '$lib/tauri_mock_data.js';
+	import DependencyGraphStoryWrapper from './DependencyGraphStoryWrapper.svelte';
+
+	function parseMockIssue(raw: (typeof MOCK_ISSUES)[number]): Issue {
+		return {
+			...raw,
+			labels: typeof raw.labels === 'string' ? JSON.parse(raw.labels) : (raw.labels ?? []),
+		} as Issue;
+	}
+
+	const allIssues = MOCK_ISSUES.map(parseMockIssue);
+	const singleIssue = allIssues.slice(0, 1);
+	const onhitlquickstart = fn();
+</script>
+
+<Story name="With Dependencies">
+	{#snippet template()}
+		<DependencyGraphStoryWrapper>
+			<div class="min-h-[400px] w-full">
+				<DependencyGraphView
+					issues={allIssues}
+					dependencies={MOCK_ISSUE_DEPENDENCIES}
+					{onhitlquickstart}
+				/>
+			</div>
+		</DependencyGraphStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story name="Empty Graph">
+	{#snippet template()}
+		<DependencyGraphStoryWrapper>
+			<div class="min-h-[400px] w-full">
+				<DependencyGraphView issues={[]} dependencies={[]} {onhitlquickstart} />
+			</div>
+		</DependencyGraphStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story name="Single Isolated Node">
+	{#snippet template()}
+		<DependencyGraphStoryWrapper>
+			<div class="min-h-[400px] w-full">
+				<DependencyGraphView issues={singleIssue} dependencies={[]} {onhitlquickstart} />
+			</div>
+		</DependencyGraphStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story name="Many Dependencies">
+	{#snippet template()}
+		<DependencyGraphStoryWrapper>
+			<div class="min-h-[400px] w-full">
+				<DependencyGraphView
+					issues={allIssues}
+					dependencies={[
+						...MOCK_ISSUE_DEPENDENCIES,
+						...MOCK_ISSUE_DEPENDENCIES.map((dep, index) => ({
+							...dep,
+							id: `extra-dep-${index}`,
+							blocker_issue_id: dep.blocked_issue_id,
+							blocked_issue_id: dep.blocker_issue_id,
+						})),
+					]}
+					{onhitlquickstart}
+				/>
+			</div>
+		</DependencyGraphStoryWrapper>
+	{/snippet}
+</Story>

--- a/src/lib/components/blocks/forest/ForestView.stories.svelte
+++ b/src/lib/components/blocks/forest/ForestView.stories.svelte
@@ -1,0 +1,116 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import ForestView from './ForestView.svelte';
+
+	const { Story } = defineMeta({
+		title: 'Blocks/Forest/ForestView',
+		component: ForestView,
+		tags: ['autodocs'],
+	});
+</script>
+
+<script lang="ts">
+	import { fn } from 'storybook/test';
+	import type { Issue } from '$lib/modules/issues';
+	import { MOCK_ISSUES, MOCK_ISSUE_DEPENDENCIES } from '$lib/tauri_mock_data.js';
+	import ForestViewStoryWrapper from './ForestViewStoryWrapper.svelte';
+
+	function parseMockIssue(raw: (typeof MOCK_ISSUES)[number]): Issue {
+		return {
+			...raw,
+			labels: typeof raw.labels === 'string' ? JSON.parse(raw.labels) : (raw.labels ?? []),
+		} as Issue;
+	}
+
+	const allParsedIssues = MOCK_ISSUES.map(parseMockIssue);
+
+	const callbacks = {
+		onAddIssue: fn(),
+		onArchiveIssue: fn(),
+		onChangeIssueColor: fn(),
+	};
+
+	function stubGetGitStatus() {
+		return undefined;
+	}
+
+	function stubGetSessionsForIssue() {
+		return [] as const;
+	}
+</script>
+
+<Story name="Full Forest">
+	{#snippet template()}
+		<ForestViewStoryWrapper>
+			<div class="min-h-[500px] w-full">
+				<ForestView
+					issues={allParsedIssues}
+					allIssues={allParsedIssues}
+					dependencies={MOCK_ISSUE_DEPENDENCIES}
+					getGitStatus={stubGetGitStatus}
+					getSessionsForIssue={stubGetSessionsForIssue}
+					{...callbacks}
+				/>
+			</div>
+		</ForestViewStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story name="Empty Forest">
+	{#snippet template()}
+		<ForestViewStoryWrapper>
+			<div class="min-h-[500px] w-full">
+				<ForestView
+					issues={[]}
+					allIssues={[]}
+					dependencies={[]}
+					getGitStatus={stubGetGitStatus}
+					getSessionsForIssue={stubGetSessionsForIssue}
+					{...callbacks}
+				/>
+			</div>
+		</ForestViewStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story name="Single Issue">
+	{#snippet template()}
+		<ForestViewStoryWrapper>
+			<div class="min-h-[500px] w-full">
+				<ForestView
+					issues={[allParsedIssues[0]]}
+					allIssues={[allParsedIssues[0]]}
+					dependencies={[]}
+					getGitStatus={stubGetGitStatus}
+					getSessionsForIssue={stubGetSessionsForIssue}
+					{...callbacks}
+				/>
+			</div>
+		</ForestViewStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story name="Many Issues">
+	{#snippet template()}
+		{@const duplicated = [
+			...allParsedIssues,
+			...allParsedIssues.map((issue, index) => ({
+				...issue,
+				id: `dup-${index}-${issue.id}`,
+				name: `${issue.name} (copy)`,
+			})),
+		]}
+		<ForestViewStoryWrapper>
+			<div class="min-h-[500px] w-full">
+				<ForestView
+					issues={duplicated}
+					allIssues={duplicated}
+					dependencies={MOCK_ISSUE_DEPENDENCIES}
+					getGitStatus={stubGetGitStatus}
+					getSessionsForIssue={stubGetSessionsForIssue}
+					{...callbacks}
+				/>
+			</div>
+		</ForestViewStoryWrapper>
+	{/snippet}
+</Story>

--- a/src/lib/components/blocks/forest/ForestViewStoryWrapper.svelte
+++ b/src/lib/components/blocks/forest/ForestViewStoryWrapper.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import { setSelectionContext } from '$lib/modules/board/selection.context.svelte.js';
+
+	interface Props {
+		children?: Snippet;
+	}
+
+	let { children }: Props = $props();
+	setSelectionContext();
+</script>
+
+{@render children?.()}

--- a/src/lib/components/blocks/github-auth/GitHubAuthWizard.stories.svelte
+++ b/src/lib/components/blocks/github-auth/GitHubAuthWizard.stories.svelte
@@ -1,0 +1,27 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import { fn } from 'storybook/test';
+	import GitHubAuthWizard from './GitHubAuthWizard.svelte';
+
+	const { Story } = defineMeta({
+		title: 'Blocks/GitHub/GitHubAuthWizard',
+		component: GitHubAuthWizard,
+		tags: ['autodocs'],
+	});
+
+	const connectedHandler = fn();
+</script>
+
+<!-- Dialog open: shows initial loading state, then fires device flow (no-op in Storybook) -->
+<Story name="Default">
+	{#snippet template()}
+		<GitHubAuthWizard open={true} onconnected={connectedHandler} />
+	{/snippet}
+</Story>
+
+<!-- Dialog closed: should render nothing -->
+<Story name="Closed">
+	{#snippet template()}
+		<GitHubAuthWizard open={false} onconnected={connectedHandler} />
+	{/snippet}
+</Story>

--- a/src/lib/components/blocks/github/GhSetupBanner.stories.svelte
+++ b/src/lib/components/blocks/github/GhSetupBanner.stories.svelte
@@ -1,0 +1,51 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import { fn } from 'storybook/test';
+	import GhSetupBanner from './GhSetupBanner.svelte';
+	import type { GhAuthStatus } from '$lib/types/generated';
+
+	const { Story } = defineMeta({
+		title: 'Blocks/GitHub/GhSetupBanner',
+		component: GhSetupBanner,
+		tags: ['autodocs'],
+	});
+
+	const notConnected: GhAuthStatus = { status: 'not-connected' };
+	const oauthConnected: GhAuthStatus = {
+		status: 'oauth-connected',
+		user: { login: 'octocat', avatar_url: 'https://avatars.githubusercontent.com/u/583231' },
+	};
+	const cliConnected: GhAuthStatus = { status: 'cli-connected' };
+</script>
+
+<Story name="Not Connected (with callback)" args={{ authStatus: notConnected, onconnect: fn() }}>
+	{#snippet template(args)}
+		<div class="max-w-xl p-4">
+			<GhSetupBanner {...args} />
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Not Connected (no callback)" args={{ authStatus: notConnected }}>
+	{#snippet template(args)}
+		<div class="max-w-xl p-4">
+			<GhSetupBanner {...args} />
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="OAuth Connected" args={{ authStatus: oauthConnected }}>
+	{#snippet template(args)}
+		<div class="max-w-xl p-4">
+			<GhSetupBanner {...args} />
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="CLI Connected" args={{ authStatus: cliConnected }}>
+	{#snippet template(args)}
+		<div class="max-w-xl p-4">
+			<GhSetupBanner {...args} />
+		</div>
+	{/snippet}
+</Story>

--- a/src/lib/components/blocks/issue/AssignedIssuesPanel.stories.svelte
+++ b/src/lib/components/blocks/issue/AssignedIssuesPanel.stories.svelte
@@ -1,0 +1,101 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import AssignedIssuesPanel from './AssignedIssuesPanel.svelte';
+
+	const { Story } = defineMeta({
+		title: 'Blocks/Issue/AssignedIssuesPanel',
+		component: AssignedIssuesPanel,
+		tags: ['autodocs'],
+	});
+</script>
+
+<script lang="ts">
+	import { fn } from 'storybook/test';
+	import type { Issue } from '$lib/modules/issues';
+	import { MOCK_ASSIGNED_ISSUES_RESULT, MOCK_ISSUES } from '$lib/tauri_mock_data.js';
+
+	function parseMockIssue(raw: (typeof MOCK_ISSUES)[number]): Issue {
+		return {
+			...raw,
+			labels: typeof raw.labels === 'string' ? JSON.parse(raw.labels) : (raw.labels ?? []),
+		} as Issue;
+	}
+
+	const dashboardIssues = MOCK_ISSUES.map(parseMockIssue);
+	const defaultArgs = {
+		issues: MOCK_ASSIGNED_ISSUES_RESULT.issues,
+		dashboardIssues,
+		hasMore: false,
+		loading: false,
+		lastSynced: new Date(Date.now() - 30_000),
+		disabled: false,
+		onWizardOpen: fn(),
+		onQuickAddWithWorktree: fn(),
+		onLoadMore: fn(),
+		onRefresh: fn(),
+	};
+</script>
+
+<Story name="Default">
+	{#snippet template()}
+		<div class="h-[500px] w-[800px] border border-border">
+			<AssignedIssuesPanel {...defaultArgs} />
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Empty">
+	{#snippet template()}
+		<div class="h-[500px] w-[800px] border border-border">
+			<AssignedIssuesPanel {...defaultArgs} issues={[]} hasMore={false} />
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Loading">
+	{#snippet template()}
+		<div class="h-[500px] w-[800px] border border-border">
+			<AssignedIssuesPanel {...defaultArgs} loading={true} />
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Has More">
+	{#snippet template()}
+		<div class="h-[500px] w-[800px] border border-border">
+			<AssignedIssuesPanel {...defaultArgs} hasMore={true} />
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Disabled">
+	{#snippet template()}
+		<div class="h-[500px] w-[800px] border border-border">
+			<AssignedIssuesPanel {...defaultArgs} disabled={true} />
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Recently Synced">
+	{#snippet template()}
+		<div class="h-[500px] w-[800px] border border-border">
+			<AssignedIssuesPanel {...defaultArgs} lastSynced={new Date()} />
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Stale Sync">
+	{#snippet template()}
+		<div class="h-[500px] w-[800px] border border-border">
+			<AssignedIssuesPanel {...defaultArgs} lastSynced={new Date(Date.now() - 10 * 60_000)} />
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Never Synced">
+	{#snippet template()}
+		<div class="h-[500px] w-[800px] border border-border">
+			<AssignedIssuesPanel {...defaultArgs} lastSynced={null} />
+		</div>
+	{/snippet}
+</Story>

--- a/src/lib/components/blocks/issue/IssueCard.stories.svelte
+++ b/src/lib/components/blocks/issue/IssueCard.stories.svelte
@@ -1,0 +1,199 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import IssueCard from './IssueCard.svelte';
+
+	const { Story } = defineMeta({
+		title: 'Blocks/Issue/IssueCard',
+		component: IssueCard,
+		tags: ['autodocs'],
+	});
+</script>
+
+<script lang="ts">
+	import { fn } from 'storybook/test';
+	import type { Issue } from '$lib/modules/issues';
+	import type { GitStatusCache } from '$lib/types/generated';
+	import { MOCK_ISSUES } from '$lib/tauri_mock_data.js';
+	import IssueCardStoryWrapper from './IssueCardStoryWrapper.svelte';
+
+	function parseMockIssue(raw: (typeof MOCK_ISSUES)[number]): Issue {
+		return {
+			...raw,
+			labels: typeof raw.labels === 'string' ? JSON.parse(raw.labels) : (raw.labels ?? []),
+		} as Issue;
+	}
+
+	const baseIssue = parseMockIssue(MOCK_ISSUES[0]);
+
+	const noWorktreeIssue: Issue = {
+		...parseMockIssue(MOCK_ISSUES[4]),
+		worktree_state: 'none',
+		worktree_folder: null,
+		branch_name: null,
+	};
+
+	const archivedIssue: Issue = {
+		...parseMockIssue(MOCK_ISSUES[5]),
+		status: 'archived',
+	};
+
+	const withPrCache: GitStatusCache = {
+		issue_id: baseIssue.id,
+		branch_status: 'ahead 2',
+		pr_state: 'open',
+		pr_number: 101,
+		pr_url: 'https://github.com/MartinoPolo/Grovekeeper/pull/101',
+		github_issue_state: 'open',
+		behind_base_count: 0,
+		merge_conflict: false,
+		has_local_changes: true,
+		ahead_remote_count: 2,
+		fetched_at: '2026-05-14T10:00:00Z',
+	};
+
+	const callbacks = {
+		onCardClick: fn(),
+		onTitleClick: fn(),
+		onMouseEnter: fn(),
+		onMouseLeave: fn(),
+		onExecuteAction: fn(),
+		onPriorityClick: fn(),
+		onQuickActionAssignFolder: fn(),
+	};
+</script>
+
+<Story name="Default">
+	{#snippet template()}
+		<IssueCardStoryWrapper>
+			<div class="max-w-md">
+				<IssueCard issue={baseIssue} ghAvailable={true} {...callbacks} />
+			</div>
+		</IssueCardStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story name="Active">
+	{#snippet template()}
+		<IssueCardStoryWrapper>
+			<div class="max-w-md">
+				<IssueCard issue={baseIssue} isActive={true} ghAvailable={true} {...callbacks} />
+			</div>
+		</IssueCardStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story name="Batch Selected">
+	{#snippet template()}
+		<IssueCardStoryWrapper>
+			<div class="max-w-md">
+				<IssueCard
+					issue={baseIssue}
+					isBatchSelected={true}
+					ghAvailable={true}
+					{...callbacks}
+				/>
+			</div>
+		</IssueCardStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story name="With Worktree Active">
+	{#snippet template()}
+		<IssueCardStoryWrapper>
+			<div class="max-w-md">
+				<IssueCard
+					issue={baseIssue}
+					cache={withPrCache}
+					ghAvailable={true}
+					{...callbacks}
+				/>
+			</div>
+		</IssueCardStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story name="With GitHub PR">
+	{#snippet template()}
+		<IssueCardStoryWrapper>
+			<div class="max-w-md">
+				<IssueCard
+					issue={baseIssue}
+					cache={withPrCache}
+					ghAvailable={true}
+					childCount={3}
+					prdParent={{
+						number: 95,
+						url: 'https://github.com/MartinoPolo/Grovekeeper/issues/95',
+					}}
+					{...callbacks}
+				/>
+			</div>
+		</IssueCardStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story name="Archived">
+	{#snippet template()}
+		<IssueCardStoryWrapper>
+			<div class="max-w-md">
+				<IssueCard issue={archivedIssue} ghAvailable={false} {...callbacks} />
+			</div>
+		</IssueCardStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story name="With Notification Dot">
+	{#snippet template()}
+		<IssueCardStoryWrapper>
+			<div class="max-w-md">
+				<IssueCard
+					issue={baseIssue}
+					notificationDotColor="bg-orange-500"
+					ghAvailable={true}
+					{...callbacks}
+				/>
+			</div>
+		</IssueCardStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story name="With Session State">
+	{#snippet template()}
+		<IssueCardStoryWrapper>
+			<div class="max-w-md">
+				<IssueCard
+					issue={baseIssue}
+					sessionState="executing"
+					ghAvailable={true}
+					{...callbacks}
+				/>
+			</div>
+		</IssueCardStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story name="No Worktree">
+	{#snippet template()}
+		<IssueCardStoryWrapper>
+			<div class="max-w-md">
+				<IssueCard issue={noWorktreeIssue} ghAvailable={true} {...callbacks} />
+			</div>
+		</IssueCardStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story name="Hovered with Modifier">
+	{#snippet template()}
+		<IssueCardStoryWrapper>
+			<div class="max-w-md">
+				<IssueCard
+					issue={baseIssue}
+					isHovered={true}
+					isModifierHeld={true}
+					ghAvailable={true}
+					{...callbacks}
+				/>
+			</div>
+		</IssueCardStoryWrapper>
+	{/snippet}
+</Story>

--- a/src/lib/components/blocks/issue/IssueCardList.stories.svelte
+++ b/src/lib/components/blocks/issue/IssueCardList.stories.svelte
@@ -1,0 +1,149 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import IssueCardList from './IssueCardList.svelte';
+
+	const { Story } = defineMeta({
+		title: 'Blocks/Issue/IssueCardList',
+		component: IssueCardList,
+		tags: ['autodocs'],
+	});
+</script>
+
+<script lang="ts">
+	import { fn } from 'storybook/test';
+	import type { Issue } from '$lib/modules/issues';
+	import { MOCK_ISSUES } from '$lib/tauri_mock_data.js';
+	import IssueCardListStoryWrapper from './IssueCardListStoryWrapper.svelte';
+
+	function parseMockIssue(raw: (typeof MOCK_ISSUES)[number]): Issue {
+		return {
+			...raw,
+			labels: typeof raw.labels === 'string' ? JSON.parse(raw.labels) : (raw.labels ?? []),
+		} as Issue;
+	}
+
+	const allIssues = MOCK_ISSUES.map(parseMockIssue);
+	const singleIssue = [allIssues[0]];
+
+	const archivedIssues: Issue[] = allIssues.slice(0, 2).map((issue) => ({
+		...issue,
+		id: `archived-${issue.id}`,
+		status: 'archived' as const,
+		name: `[Archived] ${issue.name}`,
+	}));
+
+	const callbacks = {
+		onArchive: fn(),
+		onUnarchive: fn(),
+		onEdit: fn(),
+		onDelete: fn(),
+		onChangePriority: fn(),
+		onRename: fn(),
+		onSetupWorktree: fn(),
+		onRemoveWorktree: fn(),
+		onExecuteAction: fn(),
+		onChangeColor: fn(),
+		onBatchArchive: fn(),
+		onBatchUnarchive: fn(),
+		onBatchDelete: fn(),
+		onBatchChangePriority: fn(),
+		onBatchPrune: fn(),
+	};
+
+	function getChildrenStub(): Issue[] {
+		return [];
+	}
+
+	function getNotificationDotColorStub(): string | null {
+		return null;
+	}
+
+	function getVisualizationStub() {
+		return undefined;
+	}
+</script>
+
+<Story name="Full List">
+	{#snippet template()}
+		<IssueCardListStoryWrapper>
+			<IssueCardList
+				parentIssues={allIssues}
+				archivedIssues={[]}
+				showArchived={false}
+				isPortfolio={false}
+				getChildren={getChildrenStub}
+				getNotificationDotColor={getNotificationDotColorStub}
+				getVisualization={getVisualizationStub}
+				{...callbacks}
+			/>
+		</IssueCardListStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story name="Empty List">
+	{#snippet template()}
+		<IssueCardListStoryWrapper>
+			<IssueCardList
+				parentIssues={[]}
+				archivedIssues={[]}
+				showArchived={false}
+				isPortfolio={false}
+				getChildren={getChildrenStub}
+				getNotificationDotColor={getNotificationDotColorStub}
+				getVisualization={getVisualizationStub}
+				{...callbacks}
+			/>
+		</IssueCardListStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story name="Single Issue">
+	{#snippet template()}
+		<IssueCardListStoryWrapper>
+			<IssueCardList
+				parentIssues={singleIssue}
+				archivedIssues={[]}
+				showArchived={false}
+				isPortfolio={false}
+				getChildren={getChildrenStub}
+				getNotificationDotColor={getNotificationDotColorStub}
+				getVisualization={getVisualizationStub}
+				{...callbacks}
+			/>
+		</IssueCardListStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story name="With Archived Issues">
+	{#snippet template()}
+		<IssueCardListStoryWrapper>
+			<IssueCardList
+				parentIssues={allIssues}
+				{archivedIssues}
+				showArchived={true}
+				isPortfolio={false}
+				getChildren={getChildrenStub}
+				getNotificationDotColor={getNotificationDotColorStub}
+				getVisualization={getVisualizationStub}
+				{...callbacks}
+			/>
+		</IssueCardListStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story name="Portfolio Mode">
+	{#snippet template()}
+		<IssueCardListStoryWrapper>
+			<IssueCardList
+				parentIssues={allIssues}
+				archivedIssues={[]}
+				showArchived={false}
+				isPortfolio={true}
+				getChildren={getChildrenStub}
+				getNotificationDotColor={getNotificationDotColorStub}
+				getVisualization={getVisualizationStub}
+				{...callbacks}
+			/>
+		</IssueCardListStoryWrapper>
+	{/snippet}
+</Story>

--- a/src/lib/components/blocks/issue/IssueCardListStoryWrapper.svelte
+++ b/src/lib/components/blocks/issue/IssueCardListStoryWrapper.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import type { Snippet } from 'svelte';
+	import { setSelectionContext } from '$lib/modules/board/selection.context.svelte.js';
+	import { setIssuesContext } from '$lib/modules/issues/index.js';
+	import { MOCK_DASHBOARDS } from '$lib/tauri_mock_data.js';
+
+	interface Props {
+		children?: Snippet;
+	}
+
+	let { children }: Props = $props();
+
+	setSelectionContext();
+	const issuesCtx = setIssuesContext();
+	onMount(() => issuesCtx.loadIssues(MOCK_DASHBOARDS[0].id));
+</script>
+
+{@render children?.()}

--- a/src/lib/components/blocks/issue/IssueCardStoryWrapper.svelte
+++ b/src/lib/components/blocks/issue/IssueCardStoryWrapper.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import type { Snippet } from 'svelte';
+	import { setIssuesContext } from '$lib/modules/issues/index.js';
+	import { MOCK_DASHBOARDS } from '$lib/tauri_mock_data.js';
+
+	interface Props {
+		children?: Snippet;
+	}
+
+	let { children }: Props = $props();
+
+	const issuesCtx = setIssuesContext();
+	onMount(() => issuesCtx.loadIssues(MOCK_DASHBOARDS[0].id));
+</script>
+
+{@render children?.()}

--- a/src/lib/components/blocks/issue/IssueDetail.stories.svelte
+++ b/src/lib/components/blocks/issue/IssueDetail.stories.svelte
@@ -1,0 +1,202 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import IssueDetail from './IssueDetail.svelte';
+
+	const { Story } = defineMeta({
+		title: 'Blocks/Issue/IssueDetail',
+		component: IssueDetail,
+		tags: ['autodocs'],
+	});
+</script>
+
+<script lang="ts">
+	import { fn } from 'storybook/test';
+	import type { Issue } from '$lib/modules/issues';
+	import type { GitStatusCache } from '$lib/types/generated';
+	import { MOCK_ISSUES } from '$lib/tauri_mock_data.js';
+
+	// MOCK_ISSUES labels are JSON strings at runtime; parse them for properly typed Issue objects.
+	function parseMockIssue(raw: (typeof MOCK_ISSUES)[number]): Issue {
+		return {
+			...raw,
+			labels: typeof raw.labels === 'string' ? JSON.parse(raw.labels) : (raw.labels ?? []),
+		} as Issue;
+	}
+
+	const baseIssue = parseMockIssue(MOCK_ISSUES[0]);
+
+	const minimalIssue: Issue = {
+		...baseIssue,
+		priority: null,
+		color: null,
+		github_issue_url: null,
+		github_issue_number: null,
+		branch_name: null,
+		worktree_folder: null,
+		worktree_state: 'none',
+		parent_issue_id: null,
+		labels: [],
+		name: 'Standalone local issue',
+	};
+
+	const withPrIssue = parseMockIssue(MOCK_ISSUES[0]);
+
+	const withPrCache: GitStatusCache = {
+		issue_id: withPrIssue.id,
+		branch_status: 'ahead 2',
+		pr_state: 'open',
+		pr_number: 101,
+		pr_url: 'https://github.com/MartinoPolo/Grovekeeper/pull/101',
+		github_issue_state: 'open',
+		behind_base_count: 0,
+		merge_conflict: false,
+		has_local_changes: true,
+		ahead_remote_count: 2,
+		fetched_at: '2026-05-14T10:00:00Z',
+	};
+
+	const worktreeActiveIssue: Issue = {
+		...parseMockIssue(MOCK_ISSUES[1]),
+		worktree_state: 'active',
+		worktree_folder: 'C:/_MP_projects/worktrees/55-dark-mode-toggle',
+	};
+
+	const worktreeActiveCache: GitStatusCache = {
+		issue_id: worktreeActiveIssue.id,
+		branch_status: 'up to date',
+		pr_state: null,
+		pr_number: null,
+		pr_url: null,
+		github_issue_state: 'open',
+		behind_base_count: 0,
+		merge_conflict: false,
+		has_local_changes: false,
+		ahead_remote_count: 0,
+		fetched_at: '2026-05-14T10:00:00Z',
+	};
+
+	const archivedIssue: Issue = {
+		...parseMockIssue(MOCK_ISSUES[2]),
+		status: 'archived',
+	};
+
+	const failedWorktreeIssue: Issue = {
+		...parseMockIssue(MOCK_ISSUES[3]),
+		worktree_state: 'failed',
+	};
+
+	const failedWorktreeCache: GitStatusCache = {
+		issue_id: failedWorktreeIssue.id,
+		branch_status: null,
+		pr_state: null,
+		pr_number: null,
+		pr_url: null,
+		github_issue_state: 'open',
+		behind_base_count: null,
+		merge_conflict: null,
+		has_local_changes: null,
+		ahead_remote_count: null,
+		fetched_at: null,
+	};
+
+	const paletteColors = [
+		'#ef4444',
+		'#f97316',
+		'#f59e0b',
+		'#10b981',
+		'#06b6d4',
+		'#3b82f6',
+		'#8b5cf6',
+		'#ec4899',
+	];
+
+	const usedColors = ['#ef4444', '#8b5cf6'];
+
+	const callbacks = {
+		onArchive: fn(),
+		onUnarchive: fn(),
+		onEdit: fn(),
+		onDelete: fn(),
+		onChangePriority: fn(),
+		onRename: fn(),
+		onSetupWorktree: fn(),
+		onRemoveWorktree: fn(),
+		onChangeColor: fn(),
+	};
+</script>
+
+<Story name="Full Detail">
+	{#snippet template()}
+		<div class="mx-auto max-w-sm border border-border rounded-lg bg-card">
+			<IssueDetail
+				issue={withPrIssue}
+				cache={withPrCache}
+				ghAvailable={true}
+				{paletteColors}
+				{usedColors}
+				{...callbacks}
+			/>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Minimal Info">
+	{#snippet template()}
+		<div class="mx-auto max-w-sm border border-border rounded-lg bg-card">
+			<IssueDetail issue={minimalIssue} {paletteColors} {usedColors} {...callbacks} />
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="With GitHub PR Linked">
+	{#snippet template()}
+		<div class="mx-auto max-w-sm border border-border rounded-lg bg-card">
+			<IssueDetail
+				issue={withPrIssue}
+				cache={withPrCache}
+				ghAvailable={true}
+				{paletteColors}
+				{usedColors}
+				{...callbacks}
+			/>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Worktree Active">
+	{#snippet template()}
+		<div class="mx-auto max-w-sm border border-border rounded-lg bg-card">
+			<IssueDetail
+				issue={worktreeActiveIssue}
+				cache={worktreeActiveCache}
+				ghAvailable={true}
+				{paletteColors}
+				{usedColors}
+				{...callbacks}
+			/>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Archived">
+	{#snippet template()}
+		<div class="mx-auto max-w-sm border border-border rounded-lg bg-card">
+			<IssueDetail issue={archivedIssue} {paletteColors} {usedColors} {...callbacks} />
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Worktree Failed (Retry)">
+	{#snippet template()}
+		<div class="mx-auto max-w-sm border border-border rounded-lg bg-card">
+			<IssueDetail
+				issue={failedWorktreeIssue}
+				cache={failedWorktreeCache}
+				ghAvailable={true}
+				{paletteColors}
+				{usedColors}
+				{...callbacks}
+			/>
+		</div>
+	{/snippet}
+</Story>

--- a/src/lib/components/blocks/layout/DashboardSidebar.stories.svelte
+++ b/src/lib/components/blocks/layout/DashboardSidebar.stories.svelte
@@ -1,0 +1,103 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import { fn } from 'storybook/test';
+	import DashboardSidebar from './DashboardSidebar.svelte';
+	import DashboardSidebarStoryWrapper from './DashboardSidebarStoryWrapper.svelte';
+
+	const { Story } = defineMeta({
+		title: 'Blocks/Layout/DashboardSidebar',
+		component: DashboardSidebar,
+		tags: ['autodocs'],
+		args: {
+			workspaceName: 'Grovekeeper',
+			username: 'Martin',
+			userInitials: 'MP',
+			activeSessionCount: 0,
+			collapsed: false,
+			onToggleSidebar: fn(),
+			onEditWorkspace: fn(),
+		},
+	});
+</script>
+
+<Story name="Expanded">
+	{#snippet template()}
+		<DashboardSidebarStoryWrapper>
+			<div class="flex h-150">
+				<DashboardSidebar
+					workspaceName="Grovekeeper"
+					username="Martin"
+					userInitials="MP"
+					collapsed={false}
+					onToggleSidebar={fn()}
+					onEditWorkspace={fn()}
+				/>
+				<div class="flex-1 bg-background p-4">
+					<span class="text-sm text-foreground-muted">Main content area</span>
+				</div>
+			</div>
+		</DashboardSidebarStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story name="Collapsed">
+	{#snippet template()}
+		<DashboardSidebarStoryWrapper>
+			<div class="flex h-150">
+				<DashboardSidebar
+					workspaceName="Grovekeeper"
+					username="Martin"
+					userInitials="MP"
+					collapsed={true}
+					onToggleSidebar={fn()}
+					onEditWorkspace={fn()}
+				/>
+				<div class="flex-1 bg-background p-4">
+					<span class="text-sm text-foreground-muted">Main content area</span>
+				</div>
+			</div>
+		</DashboardSidebarStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story name="With Active Sessions">
+	{#snippet template()}
+		<DashboardSidebarStoryWrapper>
+			<div class="flex h-150">
+				<DashboardSidebar
+					workspaceName="Grovekeeper"
+					username="Martin"
+					userInitials="MP"
+					activeSessionCount={3}
+					collapsed={false}
+					onToggleSidebar={fn()}
+					onEditWorkspace={fn()}
+				/>
+				<div class="flex-1 bg-background p-4">
+					<span class="text-sm text-foreground-muted">Main content area</span>
+				</div>
+			</div>
+		</DashboardSidebarStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story name="Long Workspace Name">
+	{#snippet template()}
+		<DashboardSidebarStoryWrapper>
+			<div class="flex h-150">
+				<DashboardSidebar
+					workspaceName="My Very Long Workspace Name That Should Be Truncated"
+					username="Martin Pavelka"
+					userInitials="MP"
+					activeSessionCount={1}
+					collapsed={false}
+					onToggleSidebar={fn()}
+					onEditWorkspace={fn()}
+				/>
+				<div class="flex-1 bg-background p-4">
+					<span class="text-sm text-foreground-muted">Main content area</span>
+				</div>
+			</div>
+		</DashboardSidebarStoryWrapper>
+	{/snippet}
+</Story>

--- a/src/lib/components/blocks/layout/DashboardSidebarStoryWrapper.svelte
+++ b/src/lib/components/blocks/layout/DashboardSidebarStoryWrapper.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import { setKeyboardShortcutsContext } from '$lib/modules/keyboard-shortcuts/keyboard_shortcuts.context.svelte.js';
+
+	interface Props {
+		children?: Snippet;
+	}
+
+	let { children }: Props = $props();
+	setKeyboardShortcutsContext();
+</script>
+
+{@render children?.()}

--- a/src/lib/components/blocks/layout/TopBar.stories.svelte
+++ b/src/lib/components/blocks/layout/TopBar.stories.svelte
@@ -1,0 +1,85 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import { fn } from 'storybook/test';
+	import TopBar from './TopBar.svelte';
+
+	const { Story } = defineMeta({
+		title: 'Blocks/Layout/TopBar',
+		component: TopBar,
+		tags: ['autodocs'],
+		args: {
+			title: 'Dashboard',
+			onSync: fn(),
+			onQuickIdeas: fn(),
+			onCreateIssue: fn(),
+			onToggleForest: fn(),
+		},
+	});
+</script>
+
+<Story name="Default">
+	{#snippet template()}
+		<TopBar title="Dashboard" />
+	{/snippet}
+</Story>
+
+<Story name="With Subtitle">
+	{#snippet template()}
+		<TopBar title="Dashboard" subtitle="workspace/grovekeeper" />
+	{/snippet}
+</Story>
+
+<Story name="With Notifications Badge">
+	{#snippet template()}
+		<TopBar
+			title="Dashboard"
+			hasNotifications={true}
+			onSync={fn()}
+			onQuickIdeas={fn()}
+			onCreateIssue={fn()}
+			onToggleForest={fn()}
+		/>
+	{/snippet}
+</Story>
+
+<Story name="Syncing State">
+	{#snippet template()}
+		<TopBar
+			title="Dashboard"
+			syncing={true}
+			onSync={fn()}
+			onQuickIdeas={fn()}
+			onCreateIssue={fn()}
+			onToggleForest={fn()}
+		/>
+	{/snippet}
+</Story>
+
+<Story name="Forest Collapsed">
+	{#snippet template()}
+		<TopBar
+			title="Dashboard"
+			forestCollapsed={true}
+			onSync={fn()}
+			onQuickIdeas={fn()}
+			onCreateIssue={fn()}
+			onToggleForest={fn()}
+		/>
+	{/snippet}
+</Story>
+
+<Story name="With All Actions">
+	{#snippet template()}
+		<TopBar
+			title="Dashboard"
+			subtitle="workspace/grovekeeper"
+			hasNotifications={true}
+			syncing={false}
+			forestCollapsed={false}
+			onSync={fn()}
+			onQuickIdeas={fn()}
+			onCreateIssue={fn()}
+			onToggleForest={fn()}
+		/>
+	{/snippet}
+</Story>

--- a/src/lib/components/blocks/layout/WorkspaceBottomPanel.stories.svelte
+++ b/src/lib/components/blocks/layout/WorkspaceBottomPanel.stories.svelte
@@ -1,0 +1,195 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import WorkspaceBottomPanel from './WorkspaceBottomPanel.svelte';
+
+	const { Story } = defineMeta({
+		title: 'Blocks/Layout/WorkspaceBottomPanel',
+		component: WorkspaceBottomPanel,
+		tags: ['autodocs'],
+	});
+</script>
+
+<script lang="ts">
+	import { fn } from 'storybook/test';
+	import WorkspaceBottomPanelStoryWrapper from './WorkspaceBottomPanelStoryWrapper.svelte';
+	import {
+		MOCK_ISSUES,
+		MOCK_ISSUE_DEPENDENCIES,
+		MOCK_ASSIGNED_ISSUES_RESULT,
+		MOCK_COLOR_PALETTES,
+	} from '$lib/tauri_mock_data.js';
+	import type { Issue } from '$lib/modules/issues';
+	import type { TreeVisualization } from '$lib/modules/visualization';
+
+	function parseMockIssue(raw: (typeof MOCK_ISSUES)[number]): Issue {
+		return {
+			...raw,
+			labels: typeof raw.labels === 'string' ? JSON.parse(raw.labels) : (raw.labels ?? []),
+		} as Issue;
+	}
+
+	const issues = MOCK_ISSUES.map(parseMockIssue);
+	const parentIssues = issues.filter((issue) => issue.parent_issue_id === null);
+	const paletteColors = MOCK_COLOR_PALETTES[0]?.colors ?? [];
+
+	function getVisualization(): TreeVisualization | undefined {
+		return undefined;
+	}
+
+	function getChildren(_parentId: string): Issue[] {
+		return issues.filter((issue) => issue.parent_issue_id === _parentId);
+	}
+
+	function getNotificationDotColor(): string | null {
+		return null;
+	}
+
+	const callbacks = {
+		onArchive: fn(),
+		onUnarchive: fn(),
+		onEdit: fn(),
+		onDelete: fn(),
+		onChangePriority: fn(),
+		onRename: fn(),
+		onSetupWorktree: fn(),
+		onRemoveWorktree: fn(),
+		onExecuteAction: fn(),
+		onChangeColor: fn(),
+		onconnect: fn(),
+		onWizardOpen: fn(),
+		onQuickAddWithWorktree: fn(),
+		onLoadMoreAssignedIssues: fn(),
+		onRefreshAssignedIssues: fn(),
+		onPrune: fn(),
+	};
+</script>
+
+<Story name="Issues Tab (Default)">
+	{#snippet template()}
+		<WorkspaceBottomPanelStoryWrapper>
+			<div class="h-[500px] w-[900px] border border-border">
+				<WorkspaceBottomPanel
+					{issues}
+					{parentIssues}
+					archivedIssues={[]}
+					showArchived={false}
+					isPortfolio={false}
+					ghAvailable={true}
+					prioritiesEnabled={true}
+					{paletteColors}
+					usedColors={[]}
+					dependencies={MOCK_ISSUE_DEPENDENCIES}
+					{getVisualization}
+					{getChildren}
+					{getNotificationDotColor}
+					{...callbacks}
+				/>
+			</div>
+		</WorkspaceBottomPanelStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story name="Dependencies Tab">
+	{#snippet template()}
+		<WorkspaceBottomPanelStoryWrapper>
+			<div class="h-[500px] w-[900px] border border-border">
+				<WorkspaceBottomPanel
+					{issues}
+					{parentIssues}
+					archivedIssues={[]}
+					showArchived={false}
+					isPortfolio={false}
+					ghAvailable={true}
+					prioritiesEnabled={true}
+					{paletteColors}
+					usedColors={[]}
+					dependencies={MOCK_ISSUE_DEPENDENCIES}
+					{getVisualization}
+					{getChildren}
+					{getNotificationDotColor}
+					{...callbacks}
+				/>
+			</div>
+		</WorkspaceBottomPanelStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story name="Empty State">
+	{#snippet template()}
+		<WorkspaceBottomPanelStoryWrapper>
+			<div class="h-[500px] w-[900px] border border-border">
+				<WorkspaceBottomPanel
+					issues={[]}
+					parentIssues={[]}
+					archivedIssues={[]}
+					showArchived={false}
+					isPortfolio={false}
+					ghAvailable={false}
+					prioritiesEnabled={true}
+					paletteColors={[]}
+					usedColors={[]}
+					dependencies={[]}
+					{getVisualization}
+					{getChildren}
+					{getNotificationDotColor}
+					{...callbacks}
+				/>
+			</div>
+		</WorkspaceBottomPanelStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story name="With GitHub Setup Banner">
+	{#snippet template()}
+		<WorkspaceBottomPanelStoryWrapper>
+			<div class="h-[500px] w-[900px] border border-border">
+				<WorkspaceBottomPanel
+					{issues}
+					{parentIssues}
+					archivedIssues={[]}
+					showArchived={false}
+					isPortfolio={false}
+					ghAvailable={false}
+					prioritiesEnabled={true}
+					{paletteColors}
+					usedColors={[]}
+					dependencies={MOCK_ISSUE_DEPENDENCIES}
+					authStatus={{ status: 'not-connected' }}
+					{getVisualization}
+					{getChildren}
+					{getNotificationDotColor}
+					{...callbacks}
+				/>
+			</div>
+		</WorkspaceBottomPanelStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story name="With Assigned Issues Panel">
+	{#snippet template()}
+		<WorkspaceBottomPanelStoryWrapper>
+			<div class="h-[500px] w-[900px] border border-border">
+				<WorkspaceBottomPanel
+					{issues}
+					{parentIssues}
+					archivedIssues={[]}
+					showArchived={false}
+					isPortfolio={false}
+					ghAvailable={true}
+					prioritiesEnabled={true}
+					{paletteColors}
+					usedColors={[]}
+					dependencies={MOCK_ISSUE_DEPENDENCIES}
+					assignedIssues={MOCK_ASSIGNED_ISSUES_RESULT.issues}
+					assignedIssuesHasMore={false}
+					assignedIssuesLoading={false}
+					assignedIssuesLastSynced={new Date(Date.now() - 30_000)}
+					{getVisualization}
+					{getChildren}
+					{getNotificationDotColor}
+					{...callbacks}
+				/>
+			</div>
+		</WorkspaceBottomPanelStoryWrapper>
+	{/snippet}
+</Story>

--- a/src/lib/components/blocks/layout/WorkspaceBottomPanelStoryWrapper.svelte
+++ b/src/lib/components/blocks/layout/WorkspaceBottomPanelStoryWrapper.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import type { Snippet } from 'svelte';
+	import { setSelectionContext } from '$lib/modules/board/selection.context.svelte.js';
+	import { setIssuesContext } from '$lib/modules/issues/index.js';
+	import { MOCK_DASHBOARDS } from '$lib/tauri_mock_data.js';
+
+	interface Props {
+		children?: Snippet;
+	}
+
+	let { children }: Props = $props();
+
+	setSelectionContext();
+	const issuesCtx = setIssuesContext();
+	onMount(() => issuesCtx.loadIssues(MOCK_DASHBOARDS[0].id));
+</script>
+
+{@render children?.()}

--- a/src/lib/components/blocks/session/SessionChatView.stories.svelte
+++ b/src/lib/components/blocks/session/SessionChatView.stories.svelte
@@ -1,0 +1,98 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import SessionChatView from './SessionChatView.svelte';
+
+	const { Story } = defineMeta({
+		title: 'Blocks/Session/SessionChatView',
+		component: SessionChatView,
+		tags: ['autodocs'],
+	});
+</script>
+
+<script lang="ts">
+	import { fn } from 'storybook/test';
+	import type { Session } from '$lib/types/generated/Session.js';
+	import SessionChatViewStoryWrapper from './SessionChatViewStoryWrapper.svelte';
+
+	function makeMockSession(overrides: Partial<Session> = {}): Session {
+		return {
+			id: 'mock-session-1',
+			issue_id: null,
+			provider: 'claude-code',
+			state: 'running',
+			pid: 12345,
+			cli_session_id: 'ses_01HXK4mZ',
+			started_at: new Date().toISOString(),
+			ended_at: null,
+			cost_usd: 4.387,
+			token_count: 48200,
+			original_intent: 'Implement the OpenCode provider trait',
+			last_prompt: null,
+			last_response_summary: null,
+			execution_phase: 'none',
+			source: 'spawned',
+			working_directory: '/projects/grovekeeper',
+			...overrides,
+		};
+	}
+
+	const runningSession = makeMockSession();
+	const emptySession = makeMockSession({ id: 'mock-empty', cost_usd: 0, token_count: 0 });
+	const needsInputSession = makeMockSession({ id: 'mock-needs-input', state: 'needs-input' });
+	const erroredSession = makeMockSession({
+		id: 'mock-errored',
+		state: 'errored',
+		ended_at: new Date().toISOString(),
+	});
+	const onBack = fn();
+</script>
+
+<Story name="Running">
+	{#snippet template()}
+		<SessionChatViewStoryWrapper>
+			<div class="h-[600px] w-full bg-background">
+				<SessionChatView session={runningSession} />
+			</div>
+		</SessionChatViewStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story name="Empty Session">
+	{#snippet template()}
+		<SessionChatViewStoryWrapper>
+			<div class="h-[600px] w-full bg-background">
+				<SessionChatView session={emptySession} />
+			</div>
+		</SessionChatViewStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story name="Needs Input">
+	{#snippet template()}
+		<SessionChatViewStoryWrapper>
+			<div class="h-[600px] w-full bg-background">
+				<SessionChatView session={needsInputSession} />
+			</div>
+		</SessionChatViewStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story name="Errored">
+	{#snippet template()}
+		<SessionChatViewStoryWrapper>
+			<div class="h-[600px] w-full bg-background">
+				<SessionChatView session={erroredSession} />
+			</div>
+		</SessionChatViewStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story name="With Back Button">
+	{#snippet template()}
+		<SessionChatViewStoryWrapper>
+			<div class="h-[600px] w-full bg-background">
+				<SessionChatView session={runningSession} {onBack} />
+			</div>
+		</SessionChatViewStoryWrapper>
+	{/snippet}
+</Story>

--- a/src/lib/components/blocks/session/SessionChatViewStoryWrapper.svelte
+++ b/src/lib/components/blocks/session/SessionChatViewStoryWrapper.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import { setSessionsContext } from '$lib/modules/sessions/sessions.context.svelte.js';
+
+	interface Props {
+		children?: Snippet;
+	}
+
+	let { children }: Props = $props();
+
+	const noopNotifications = { addPending: () => {}, clearPending: () => {} };
+	setSessionsContext(noopNotifications);
+</script>
+
+{@render children?.()}

--- a/src/lib/components/blocks/session/SessionLayout.stories.svelte
+++ b/src/lib/components/blocks/session/SessionLayout.stories.svelte
@@ -71,56 +71,6 @@
 	{/snippet}
 </Story>
 
-<Story name="Sidebar — Expanded">
-	{#snippet template()}
-		<div class="flex h-150">
-			<div class="flex-1 bg-background p-4">
-				<span class="text-sm text-foreground-muted">Chat content area</span>
-			</div>
-			<SessionSidebar
-				session={runningSession}
-				contextPercent={54}
-				quota5hPercent={42}
-				quota7dPercent={18}
-				subAgentCount={5}
-			/>
-		</div>
-	{/snippet}
-</Story>
-
-<Story name="Sidebar — Quota Warning">
-	{#snippet template()}
-		<div class="flex h-150">
-			<div class="flex-1 bg-background p-4">
-				<span class="text-sm text-foreground-muted">Chat content area</span>
-			</div>
-			<SessionSidebar
-				session={runningSession}
-				contextPercent={72}
-				quota5hPercent={88}
-				quota7dPercent={65}
-				subAgentCount={3}
-			/>
-		</div>
-	{/snippet}
-</Story>
-
-<Story name="Sidebar — Errored Session">
-	{#snippet template()}
-		<div class="flex h-150">
-			<div class="flex-1 bg-background p-4">
-				<span class="text-sm text-foreground-muted">Chat content area</span>
-			</div>
-			<SessionSidebar
-				session={erroredSession}
-				contextPercent={95}
-				quota5hPercent={50}
-				quota7dPercent={10}
-			/>
-		</div>
-	{/snippet}
-</Story>
-
 <Story name="Full Layout">
 	{#snippet template()}
 		<div class="flex h-175 w-full flex-col">

--- a/src/lib/components/blocks/session/SessionSidebar.stories.svelte
+++ b/src/lib/components/blocks/session/SessionSidebar.stories.svelte
@@ -1,0 +1,128 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import SessionSidebar from './SessionSidebar.svelte';
+
+	const { Story } = defineMeta({
+		title: 'Blocks/Session/SessionSidebar',
+		component: SessionSidebar,
+		tags: ['autodocs'],
+	});
+</script>
+
+<script lang="ts">
+	import type { Session } from '$lib/types/generated/Session.js';
+
+	function makeMockSession(overrides: Partial<Session> = {}): Session {
+		return {
+			id: 'mock-session-1',
+			issue_id: null,
+			provider: 'claude-code',
+			state: 'running',
+			pid: 12345,
+			cli_session_id: 'ses_01HXK4mZ',
+			started_at: new Date().toISOString(),
+			ended_at: null,
+			cost_usd: 4.387,
+			token_count: 48200,
+			original_intent: 'Implement the OpenCode provider trait',
+			last_prompt: null,
+			last_response_summary: null,
+			execution_phase: 'none',
+			source: 'spawned',
+			working_directory: '/projects/grovekeeper',
+			...overrides,
+		};
+	}
+
+	const runningSession = makeMockSession();
+	const erroredSession = makeMockSession({ state: 'errored', cost_usd: 12.45 });
+	const finishedSession = makeMockSession({
+		state: 'finished',
+		ended_at: new Date().toISOString(),
+		cost_usd: 2.15,
+		token_count: 22400,
+	});
+</script>
+
+<Story name="Expanded — Running">
+	{#snippet template()}
+		<div class="flex h-150">
+			<div class="flex-1 bg-background p-4">
+				<span class="text-sm text-foreground-muted">Chat area</span>
+			</div>
+			<SessionSidebar
+				session={runningSession}
+				contextPercent={54}
+				quota5hPercent={42}
+				quota7dPercent={18}
+				subAgentCount={0}
+			/>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Quota Warning">
+	{#snippet template()}
+		<div class="flex h-150">
+			<div class="flex-1 bg-background p-4">
+				<span class="text-sm text-foreground-muted">Chat area</span>
+			</div>
+			<SessionSidebar
+				session={runningSession}
+				contextPercent={72}
+				quota5hPercent={88}
+				quota7dPercent={65}
+				subAgentCount={3}
+			/>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Errored Session">
+	{#snippet template()}
+		<div class="flex h-150">
+			<div class="flex-1 bg-background p-4">
+				<span class="text-sm text-foreground-muted">Chat area</span>
+			</div>
+			<SessionSidebar
+				session={erroredSession}
+				contextPercent={95}
+				quota5hPercent={50}
+				quota7dPercent={10}
+			/>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="With Sub-Agents">
+	{#snippet template()}
+		<div class="flex h-150">
+			<div class="flex-1 bg-background p-4">
+				<span class="text-sm text-foreground-muted">Chat area</span>
+			</div>
+			<SessionSidebar
+				session={runningSession}
+				contextPercent={61}
+				quota5hPercent={55}
+				quota7dPercent={30}
+				subAgentCount={5}
+			/>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Idle Session">
+	{#snippet template()}
+		<div class="flex h-150">
+			<div class="flex-1 bg-background p-4">
+				<span class="text-sm text-foreground-muted">Chat area</span>
+			</div>
+			<SessionSidebar
+				session={finishedSession}
+				contextPercent={38}
+				quota5hPercent={25}
+				quota7dPercent={8}
+			/>
+		</div>
+	{/snippet}
+</Story>

--- a/src/lib/components/blocks/workspace/DiscoveredSessionCard.stories.svelte
+++ b/src/lib/components/blocks/workspace/DiscoveredSessionCard.stories.svelte
@@ -1,0 +1,135 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import { fn } from 'storybook/test';
+	import DiscoveredSessionCard from './DiscoveredSessionCard.svelte';
+	import type { DiscoveredSession } from '$lib/types/generated';
+	import type { DiscoveredSessionStatus } from '$lib/types/generated';
+
+	const { Story } = defineMeta({
+		title: 'Blocks/Workspace/DiscoveredSessionCard',
+		component: DiscoveredSessionCard,
+		tags: ['autodocs'],
+	});
+
+	function makeMockDiscoveredSession(
+		overrides: Partial<DiscoveredSession> = {},
+	): DiscoveredSession {
+		return {
+			id: 'my-project/abc-123-def',
+			pid: 12345,
+			working_directory: '/home/user/projects/my-project',
+			project_directory_name: 'my-project',
+			session_id: 'abc-123-def',
+			project_name: 'my-project',
+			status: 'working',
+			first_prompt: 'Fix the authentication token refresh logic',
+			git_branch: 'feat/auth-refresh',
+			message_count: 14,
+			cost_usd: 0,
+			token_count: 0,
+			latest_message: null,
+			modified_at: null,
+			...overrides,
+		};
+	}
+
+	const onAdopt = fn();
+</script>
+
+<Story name="Default" args={{ session: makeMockDiscoveredSession(), onAdopt }}>
+	{#snippet template(args: {
+		session: DiscoveredSession;
+		onAdopt: (s: DiscoveredSession) => void;
+	})}
+		<div class="max-w-lg p-8">
+			<DiscoveredSessionCard session={args.session} onAdopt={args.onAdopt} />
+		</div>
+	{/snippet}
+</Story>
+
+<Story
+	name="With Cost Info"
+	args={{
+		session: makeMockDiscoveredSession({
+			cost_usd: 2.847,
+			token_count: 48200,
+			message_count: 32,
+			first_prompt: 'Refactor the database layer to use connection pooling',
+			git_branch: 'refactor/db-pooling',
+		}),
+		onAdopt,
+	}}
+>
+	{#snippet template(args: {
+		session: DiscoveredSession;
+		onAdopt: (s: DiscoveredSession) => void;
+	})}
+		<div class="max-w-lg p-8">
+			<DiscoveredSessionCard session={args.session} onAdopt={args.onAdopt} />
+		</div>
+	{/snippet}
+</Story>
+
+<Story
+	name="With Process ID"
+	args={{
+		session: makeMockDiscoveredSession({
+			pid: 98712,
+			status: 'idle',
+			first_prompt: null,
+			git_branch: null,
+			message_count: 0,
+			project_name: 'backend-api',
+			project_directory_name: 'backend-api',
+		}),
+		onAdopt,
+	}}
+>
+	{#snippet template(args: {
+		session: DiscoveredSession;
+		onAdopt: (s: DiscoveredSession) => void;
+	})}
+		<div class="max-w-lg p-8">
+			<DiscoveredSessionCard session={args.session} onAdopt={args.onAdopt} />
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="All Statuses">
+	{#snippet template()}
+		<div class="flex max-w-lg flex-col gap-4 p-8">
+			{#each ['working', 'needs_attention', 'idle', 'finished', 'unknown'] as status (status)}
+				<DiscoveredSessionCard
+					session={makeMockDiscoveredSession({
+						status: status as DiscoveredSessionStatus,
+						first_prompt: `Session in "${status}" state`,
+						message_count: 8,
+						cost_usd: 0.45,
+						token_count: 12000,
+					})}
+					onAdopt={fn()}
+				/>
+			{/each}
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Long Content (Truncation)">
+	{#snippet template()}
+		<div class="max-w-lg p-8">
+			<DiscoveredSessionCard
+				session={makeMockDiscoveredSession({
+					project_name:
+						'super-long-project-name-that-should-truncate-gracefully-in-the-card',
+					first_prompt:
+						'Implement a comprehensive end-to-end testing suite covering all authentication flows including OAuth, SAML, and passwordless login with proper mocking of external identity providers',
+					git_branch: 'feat/very-long-branch-name-for-testing-truncation',
+					cost_usd: 15.234,
+					token_count: 285000,
+					message_count: 142,
+				})}
+				onAdopt={fn()}
+			/>
+		</div>
+	{/snippet}
+</Story>

--- a/src/lib/components/blocks/workspace/NoteCard.stories.svelte
+++ b/src/lib/components/blocks/workspace/NoteCard.stories.svelte
@@ -1,0 +1,123 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import NoteCard from './NoteCard.svelte';
+	import type { RawRequirementNote } from '$lib/modules/raw-requirements/index.js';
+
+	const { Story } = defineMeta({
+		title: 'Blocks/Workspace/NoteCard',
+		component: NoteCard,
+		tags: ['autodocs'],
+	});
+
+	function makeMockNote(overrides: Partial<RawRequirementNote> = {}): RawRequirementNote {
+		return {
+			timestamp: '2026-05-10 14:30',
+			content: 'Add keyboard shortcut for quick issue creation',
+			processed: false,
+			...overrides,
+		};
+	}
+</script>
+
+<script lang="ts">
+	import NoteCardStoryWrapper from './NoteCardStoryWrapper.svelte';
+</script>
+
+<Story name="Default" args={{ note: makeMockNote(), index: 0 }}>
+	{#snippet template(args: { note: RawRequirementNote; index: number })}
+		<NoteCardStoryWrapper>
+			<div class="max-w-md p-8">
+				<NoteCard note={args.note} index={args.index} />
+			</div>
+		</NoteCardStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story name="Empty Content" args={{ note: makeMockNote({ content: '' }), index: 1 }}>
+	{#snippet template(args: { note: RawRequirementNote; index: number })}
+		<NoteCardStoryWrapper>
+			<div class="max-w-md p-8">
+				<NoteCard note={args.note} index={args.index} />
+			</div>
+		</NoteCardStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story
+	name="Long Note"
+	args={{
+		note: makeMockNote({
+			content:
+				'This is a very long note that tests overflow behavior. It contains multiple sentences to simulate real-world usage where users might write extensive requirements or ideas. The card should handle this gracefully without breaking the layout. Additional text is added here to ensure wrapping and scrolling behavior can be observed in the story preview. Consider edge cases like word-break on extremely long unbroken strings and whitespace preservation in pre-wrap mode.',
+		}),
+		index: 2,
+	}}
+>
+	{#snippet template(args: { note: RawRequirementNote; index: number })}
+		<NoteCardStoryWrapper>
+			<div class="max-w-md p-8">
+				<NoteCard note={args.note} index={args.index} />
+			</div>
+		</NoteCardStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story name="Processed" args={{ note: makeMockNote({ processed: true }), index: 3 }}>
+	{#snippet template(args: { note: RawRequirementNote; index: number })}
+		<NoteCardStoryWrapper>
+			<div class="max-w-md p-8">
+				<NoteCard note={args.note} index={args.index} />
+			</div>
+		</NoteCardStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story
+	name="With Toggle Processed"
+	args={{
+		note: makeMockNote(),
+		index: 4,
+		showToggleProcessed: true,
+	}}
+>
+	{#snippet template(args: {
+		note: RawRequirementNote;
+		index: number;
+		showToggleProcessed?: boolean;
+	})}
+		<NoteCardStoryWrapper>
+			<div class="max-w-md p-8">
+				<NoteCard
+					note={args.note}
+					index={args.index}
+					showToggleProcessed={args.showToggleProcessed}
+				/>
+			</div>
+		</NoteCardStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story
+	name="Processed With Toggle"
+	args={{
+		note: makeMockNote({ processed: true }),
+		index: 5,
+		showToggleProcessed: true,
+	}}
+>
+	{#snippet template(args: {
+		note: RawRequirementNote;
+		index: number;
+		showToggleProcessed?: boolean;
+	})}
+		<NoteCardStoryWrapper>
+			<div class="max-w-md p-8">
+				<NoteCard
+					note={args.note}
+					index={args.index}
+					showToggleProcessed={args.showToggleProcessed}
+				/>
+			</div>
+		</NoteCardStoryWrapper>
+	{/snippet}
+</Story>

--- a/src/lib/components/blocks/workspace/NoteCardStoryWrapper.svelte
+++ b/src/lib/components/blocks/workspace/NoteCardStoryWrapper.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import { setWindowContext } from '$lib/modules/window/index.js';
+	import { setToastsContext } from '$lib/modules/toasts/index.js';
+	import { setRawRequirementsContext } from '$lib/modules/raw-requirements/index.js';
+
+	interface Props {
+		children?: Snippet;
+	}
+
+	let { children }: Props = $props();
+
+	setWindowContext();
+	setToastsContext();
+	setRawRequirementsContext();
+</script>
+
+{@render children?.()}

--- a/src/lib/components/blocks/workspace/SessionCard.stories.svelte
+++ b/src/lib/components/blocks/workspace/SessionCard.stories.svelte
@@ -1,0 +1,258 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import { fn } from 'storybook/test';
+	import SessionCard from './SessionCard.svelte';
+	import SessionCardStoryWrapper from './SessionCardStoryWrapper.svelte';
+	import type { Session } from '$lib/types/generated';
+	import { MOCK_SESSIONS } from '$lib/tauri_mock_data.js';
+
+	const { Story } = defineMeta({
+		title: 'Blocks/Workspace/SessionCard',
+		component: SessionCard,
+		tags: ['autodocs'],
+	});
+
+	function makeSession(overrides: Partial<Session> = {}): Session {
+		return { ...MOCK_SESSIONS[0], ...overrides };
+	}
+
+	const onClick = fn();
+	const onTerminate = fn();
+</script>
+
+<Story name="Running" args={{ session: makeSession(), onClick, onTerminate }}>
+	{#snippet template(args: {
+		session: Session;
+		onClick: (session: Session) => void;
+		onTerminate: (id: string) => void;
+	})}
+		<SessionCardStoryWrapper>
+			<div class="max-w-lg p-8">
+				<SessionCard
+					session={args.session}
+					onClick={args.onClick}
+					onTerminate={args.onTerminate}
+				/>
+			</div>
+		</SessionCardStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story
+	name="Needs Input"
+	args={{
+		session: makeSession({
+			id: 'story-needs-input',
+			state: 'needs-input',
+			original_intent: 'Add dark mode toggle component',
+			last_response_summary: 'Should the toggle persist preference to localStorage or DB?',
+			cost_usd: 0.28,
+			token_count: 9800,
+		}),
+		onClick,
+		onTerminate,
+	}}
+>
+	{#snippet template(args: {
+		session: Session;
+		onClick: (session: Session) => void;
+		onTerminate: (id: string) => void;
+	})}
+		<SessionCardStoryWrapper>
+			<div class="max-w-lg p-8">
+				<SessionCard
+					session={args.session}
+					onClick={args.onClick}
+					onTerminate={args.onTerminate}
+				/>
+			</div>
+		</SessionCardStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story
+	name="Errored"
+	args={{
+		session: makeSession({
+			id: 'story-errored',
+			state: 'errored',
+			original_intent: 'Database migration script',
+			last_response_summary: 'Fatal: connection refused to database host',
+			cost_usd: 0.05,
+			token_count: 1200,
+		}),
+		onClick,
+		onTerminate,
+	}}
+>
+	{#snippet template(args: {
+		session: Session;
+		onClick: (session: Session) => void;
+		onTerminate: (id: string) => void;
+	})}
+		<SessionCardStoryWrapper>
+			<div class="max-w-lg p-8">
+				<SessionCard
+					session={args.session}
+					onClick={args.onClick}
+					onTerminate={args.onTerminate}
+				/>
+			</div>
+		</SessionCardStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story
+	name="Finished"
+	args={{
+		session: makeSession({
+			id: 'story-finished',
+			state: 'finished',
+			original_intent: 'Fix E2E test timeouts in CI',
+			last_response_summary:
+				'Increased Playwright timeout and added retry logic for flaky tests.',
+			cost_usd: 1.05,
+			token_count: 42000,
+			ended_at: '2026-05-02T14:45:00Z',
+		}),
+		onClick,
+		onTerminate,
+	}}
+>
+	{#snippet template(args: {
+		session: Session;
+		onClick: (session: Session) => void;
+		onTerminate: (id: string) => void;
+	})}
+		<SessionCardStoryWrapper>
+			<div class="max-w-lg p-8">
+				<SessionCard
+					session={args.session}
+					onClick={args.onClick}
+					onTerminate={args.onTerminate}
+				/>
+			</div>
+		</SessionCardStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story
+	name="With Cost"
+	args={{
+		session: makeSession({
+			id: 'story-with-cost',
+			cost_usd: 3.847,
+			token_count: 128500,
+		}),
+		onClick,
+		onTerminate,
+	}}
+>
+	{#snippet template(args: {
+		session: Session;
+		onClick: (session: Session) => void;
+		onTerminate: (id: string) => void;
+	})}
+		<SessionCardStoryWrapper>
+			<div class="max-w-lg p-8">
+				<SessionCard
+					session={args.session}
+					onClick={args.onClick}
+					onTerminate={args.onTerminate}
+				/>
+			</div>
+		</SessionCardStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story
+	name="With Issue Linked"
+	args={{
+		session: makeSession({
+			id: 'story-with-issue',
+			issue_id: 'mock-issue-auth',
+		}),
+		onClick,
+		onTerminate,
+	}}
+>
+	{#snippet template(args: {
+		session: Session;
+		onClick: (session: Session) => void;
+		onTerminate: (id: string) => void;
+	})}
+		<SessionCardStoryWrapper>
+			<div class="max-w-lg p-8">
+				<SessionCard
+					session={args.session}
+					onClick={args.onClick}
+					onTerminate={args.onTerminate}
+				/>
+			</div>
+		</SessionCardStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story name="All States">
+	{#snippet template()}
+		<SessionCardStoryWrapper>
+			<div class="flex max-w-lg flex-col gap-4 p-8">
+				<SessionCard
+					session={makeSession({ id: 'all-running', state: 'running' })}
+					onClick={fn()}
+					onTerminate={fn()}
+				/>
+				<SessionCard
+					session={makeSession({
+						id: 'all-needs-input',
+						state: 'needs-input',
+						original_intent: 'Needs input session',
+						last_response_summary: 'Waiting for user decision...',
+					})}
+					onClick={fn()}
+					onTerminate={fn()}
+				/>
+				<SessionCard
+					session={makeSession({
+						id: 'all-needs-review',
+						state: 'needs-review',
+						original_intent: 'Needs review session',
+						last_response_summary: 'Changes ready for review',
+					})}
+					onClick={fn()}
+					onTerminate={fn()}
+				/>
+				<SessionCard
+					session={makeSession({
+						id: 'all-paused',
+						state: 'paused',
+						original_intent: 'Paused session',
+						last_response_summary: 'Session paused by user',
+					})}
+					onClick={fn()}
+					onTerminate={fn()}
+				/>
+				<SessionCard
+					session={makeSession({
+						id: 'all-finished',
+						state: 'finished',
+						original_intent: 'Finished session',
+						last_response_summary: 'All tasks completed successfully.',
+					})}
+					onClick={fn()}
+					onTerminate={fn()}
+				/>
+				<SessionCard
+					session={makeSession({
+						id: 'all-errored',
+						state: 'errored',
+						original_intent: 'Errored session',
+						last_response_summary: 'Fatal error occurred',
+					})}
+					onClick={fn()}
+					onTerminate={fn()}
+				/>
+			</div>
+		</SessionCardStoryWrapper>
+	{/snippet}
+</Story>

--- a/src/lib/components/blocks/workspace/SessionCardStoryWrapper.svelte
+++ b/src/lib/components/blocks/workspace/SessionCardStoryWrapper.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import { setNotificationsContext } from '$lib/modules/notifications/notifications.context.svelte.js';
+
+	interface Props {
+		children?: Snippet;
+	}
+
+	let { children }: Props = $props();
+	setNotificationsContext();
+</script>
+
+{@render children?.()}

--- a/src/lib/components/blocks/workspace/WorkspaceCard.stories.svelte
+++ b/src/lib/components/blocks/workspace/WorkspaceCard.stories.svelte
@@ -1,0 +1,169 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import { fn } from 'storybook/test';
+	import WorkspaceCard from './WorkspaceCard.svelte';
+	import { MOCK_OVERVIEW_DATA } from '$lib/tauri_mock_data.js';
+	import type { OverviewWorkspaceData } from '$lib/types/generated';
+
+	const { Story } = defineMeta({
+		title: 'Blocks/Workspace/WorkspaceCard',
+		component: WorkspaceCard,
+		tags: ['autodocs'],
+	});
+
+	const base = MOCK_OVERVIEW_DATA[0];
+
+	function makeWorkspace(overrides: Partial<OverviewWorkspaceData> = {}): OverviewWorkspaceData {
+		return { ...base, ...overrides };
+	}
+
+	const onclick = fn();
+	const onGithubClick = fn();
+	const onFolderClick = fn();
+	const onGithubRightClick = fn();
+	const onFolderRightClick = fn();
+	const onIssuesClick = fn();
+	const onPrsClick = fn();
+	const onAttnClick = fn();
+	const onHitlClick = fn();
+	const onPrdClick = fn();
+	const onAfkClick = fn();
+</script>
+
+<Story name="Active Workspace (Default)">
+	{#snippet template()}
+		<div class="max-w-xs p-8">
+			<WorkspaceCard
+				workspace={makeWorkspace()}
+				{onclick}
+				{onGithubClick}
+				{onFolderClick}
+				{onGithubRightClick}
+				{onFolderRightClick}
+				{onIssuesClick}
+				{onPrsClick}
+				{onAttnClick}
+				{onHitlClick}
+				{onPrdClick}
+				{onAfkClick}
+			/>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Dormant (No Active Sessions)">
+	{#snippet template()}
+		<div class="max-w-xs p-8">
+			<WorkspaceCard
+				workspace={makeWorkspace({
+					active_session_count: 0,
+					afk_loop_status: 'off',
+					last_activity: new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString(),
+				})}
+				{onclick}
+				{onGithubClick}
+				{onFolderClick}
+				{onIssuesClick}
+				{onPrsClick}
+				{onAttnClick}
+				{onHitlClick}
+				{onPrdClick}
+				{onAfkClick}
+			/>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Busy (Multiple Sessions)">
+	{#snippet template()}
+		<div class="max-w-xs p-8">
+			<WorkspaceCard
+				workspace={makeWorkspace({
+					active_session_count: 3,
+					afk_loop_status: 'running',
+				})}
+				{onclick}
+				{onGithubClick}
+				{onFolderClick}
+				{onIssuesClick}
+				{onPrsClick}
+				{onAttnClick}
+				{onHitlClick}
+				{onPrdClick}
+				{onAfkClick}
+			/>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Empty Workspace (No Issues)">
+	{#snippet template()}
+		<div class="max-w-xs p-8">
+			<WorkspaceCard
+				workspace={makeWorkspace({
+					open_issue_count: 0,
+					afk_ready_count: 0,
+					active_session_count: 0,
+					hitl_count: 0,
+					open_pr_count: 0,
+					prs_needing_attention: 0,
+					prd_count: 0,
+					prd_completed_subs: 0,
+					prd_total_subs: 0,
+					afk_loop_status: 'off',
+				})}
+				{onclick}
+				{onGithubClick}
+				{onFolderClick}
+				{onIssuesClick}
+				{onPrsClick}
+				{onAttnClick}
+				{onHitlClick}
+				{onPrdClick}
+				{onAfkClick}
+			/>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="With Attention Badge">
+	{#snippet template()}
+		<div class="max-w-xs p-8">
+			<WorkspaceCard
+				workspace={makeWorkspace({
+					prs_needing_attention: 2,
+				})}
+				{onclick}
+				{onGithubClick}
+				{onFolderClick}
+				{onIssuesClick}
+				{onPrsClick}
+				{onAttnClick}
+				{onHitlClick}
+				{onPrdClick}
+				{onAfkClick}
+			/>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="With Open PRs">
+	{#snippet template()}
+		<div class="max-w-xs p-8">
+			<WorkspaceCard
+				workspace={makeWorkspace({
+					open_pr_count: 3,
+				})}
+				{onclick}
+				{onGithubClick}
+				{onFolderClick}
+				{onIssuesClick}
+				{onPrsClick}
+				{onAttnClick}
+				{onHitlClick}
+				{onPrdClick}
+				{onAfkClick}
+			/>
+		</div>
+	{/snippet}
+</Story>

--- a/src/lib/components/derived/sidebar-collapsed-item/SidebarCollapsedItem.stories.svelte
+++ b/src/lib/components/derived/sidebar-collapsed-item/SidebarCollapsedItem.stories.svelte
@@ -24,8 +24,15 @@
 			<div class="flex gap-4 rounded-lg bg-sidebar p-4">
 				{#each [false, true] as active (active)}
 					<div class="flex flex-col items-center gap-2">
-						<p class="text-xs text-muted-foreground">{active ? 'active' : 'inactive'}</p>
-						<SidebarCollapsedItem {...args} icon={HomeIcon} label="Dashboard" {active} />
+						<p class="text-xs text-muted-foreground">
+							{active ? 'active' : 'inactive'}
+						</p>
+						<SidebarCollapsedItem
+							{...args}
+							icon={HomeIcon}
+							label="Dashboard"
+							{active}
+						/>
 					</div>
 				{/each}
 			</div>

--- a/src/lib/components/shadcn/kbd/Kbd.stories.svelte
+++ b/src/lib/components/shadcn/kbd/Kbd.stories.svelte
@@ -81,7 +81,9 @@
 					<div
 						class={[
 							'flex justify-center rounded-md p-3',
-							tone === 'inverted' ? 'bg-primary text-primary-foreground' : 'bg-surface',
+							tone === 'inverted'
+								? 'bg-primary text-primary-foreground'
+								: 'bg-surface',
 						]}
 					>
 						<Kbd {...args} {format} {tone}>


### PR DESCRIPTION
## Description
- Added 18 new Storybook stories for block-level components (ChatComponents, CreationWizard, DependencyGraphView, ForestView, GitHubAuthWizard, GhSetupBanner, AssignedIssuesPanel, IssueCard, IssueCardList, IssueDetail, DashboardSidebar, TopBar, WorkspaceBottomPanel, SessionChatView, SessionSidebar, DiscoveredSessionCard, NoteCard, SessionCard, WorkspaceCard)
- Created 10 context wrapper components (CreationWizardStoryWrapper, DependencyGraphStoryWrapper, ForestViewStoryWrapper, IssueCardListStoryWrapper, IssueCardStoryWrapper, DashboardSidebarStoryWrapper, WorkspaceBottomPanelStoryWrapper, SessionChatViewStoryWrapper, NoteCardStoryWrapper, SessionCardStoryWrapper) to provide required providers and state
- Extracted CodeBlock into separate story file from ChatComponents with isolated context
- Extracted SessionSidebar into separate story file from SessionLayout
- Fixed event propagation with stopPropagation in StatCell, StatusRow, and CodeBlock to prevent parent click handlers from interfering
- Updated testing framework documentation and architecture references to reflect Phase 2 completion
- All checks pass (pnpm check:all, 817 tests green)

## Resolves
None

## Testing
- [x] All 18 new stories render without errors
- [x] Context wrappers properly provide required providers and state
- [x] Event propagation fixes verified in component interactions
- [x] Full test suite passes (817 tests)
- [x] Code quality checks pass (prettier, oxlint, typecheck, eslint, dead-code analysis)