### PR TITLE
#298 feat(ui): shared components — IssueStateChip, IssueColorButton, SplitButton, badges

### DIFF
--- a/fallow-baselines/dead-code-regression.json
+++ b/fallow-baselines/dead-code-regression.json
@@ -1,13 +1,13 @@
 {
 	"schema_version": 1,
 	"fallow_version": "2.48.4",
-	"timestamp": "2026-05-12T06:37:02Z",
-	"git_sha": "c2031dc5825f47631f9d50986a92073e9729871f",
+	"timestamp": "2026-05-15T21:35:11Z",
+	"git_sha": "bfdb35fe0d12b13e23b5b8b0abb2057fcb57f133",
 	"check": {
-		"total_issues": 0,
+		"total_issues": 12,
 		"unused_files": 0,
-		"unused_exports": 0,
-		"unused_types": 0,
+		"unused_exports": 2,
+		"unused_types": 10,
 		"unused_dependencies": 0,
 		"unused_dev_dependencies": 0,
 		"unused_optional_dependencies": 0,

--- a/src/lib/components/derived/command-badges/CommandResultBadge.stories.svelte
+++ b/src/lib/components/derived/command-badges/CommandResultBadge.stories.svelte
@@ -1,0 +1,72 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import { CommandResultBadge, COMMAND_RESULT_STATES } from './index.js';
+	import { BADGE_STYLES } from '$lib/components/shadcn/badge/index.js';
+
+	const { Story } = defineMeta({
+		title: 'Derived/CommandResultBadge',
+		component: CommandResultBadge,
+		tags: ['autodocs'],
+		argTypes: {
+			state: {
+				control: 'select',
+				options: [...COMMAND_RESULT_STATES],
+			},
+			badgeStyle: {
+				control: 'select',
+				options: [...BADGE_STYLES],
+			},
+		},
+	});
+</script>
+
+<script lang="ts">
+	import type { CommandResultBadgeProps } from './command_result_badge_types.js';
+</script>
+
+<Story name="All States">
+	{#snippet template()}
+		<div class="flex flex-wrap items-center gap-3">
+			<CommandResultBadge state="running" commandName="check:all" />
+			<CommandResultBadge state="passed" commandName="check:all" />
+			<CommandResultBadge state="failed" commandName="check:all" />
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Stale Results">
+	{#snippet template()}
+		<div class="flex flex-wrap items-center gap-3">
+			<CommandResultBadge state="passed" commandName="test" isStale />
+			<CommandResultBadge state="failed" commandName="lint" isStale />
+			<CommandResultBadge state="passed" commandName="test" isStale={false} />
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Badge Styles">
+	{#snippet template()}
+		<div class="flex flex-col gap-4">
+			{#each BADGE_STYLES as style (style)}
+				<div class="flex flex-col gap-2">
+					<p class="text-xs font-medium text-foreground-muted">{style}</p>
+					<div class="flex flex-wrap items-center gap-3">
+						<CommandResultBadge
+							state="running"
+							commandName="check"
+							badgeStyle={style}
+						/>
+						<CommandResultBadge state="passed" commandName="check" badgeStyle={style} />
+						<CommandResultBadge state="failed" commandName="check" badgeStyle={style} />
+					</div>
+				</div>
+			{/each}
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Interactive" args={{ state: 'running', commandName: 'pnpm test' }}>
+	{#snippet template(args: CommandResultBadgeProps)}
+		<CommandResultBadge {...args} />
+	{/snippet}
+</Story>

--- a/src/lib/components/derived/command-badges/CommandResultBadge.svelte
+++ b/src/lib/components/derived/command-badges/CommandResultBadge.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+	import CircleCheckIcon from '@lucide/svelte/icons/circle-check';
+	import CircleXIcon from '@lucide/svelte/icons/circle-x';
+	import { cn } from '$lib/utils.js';
+	import type { CommandResultBadgeProps } from './command_result_badge_types.js';
+
+	let {
+		state,
+		commandName,
+		isStale = false,
+		badgeStyle = 'borderless-dark',
+	}: CommandResultBadgeProps = $props();
+
+	let isCollapsed = $derived(state !== 'running');
+
+	let cmdColorValue = $derived.by(() => {
+		if (state === 'passed') {
+			return 'var(--status-success)';
+		}
+		if (state === 'failed') {
+			return 'var(--status-danger)';
+		}
+		return 'var(--status-info)';
+	});
+
+	let badgeClasses = $derived.by(() => {
+		const base =
+			'inline-flex items-center gap-1.5 font-mono text-[10px] leading-none overflow-hidden transition-all duration-300 ease-in-out';
+
+		const sizing = isCollapsed
+			? 'size-5 p-0 justify-center rounded-full'
+			: 'h-5 px-1.5 py-1 rounded-full';
+		const staleClass = isStale ? 'opacity-40' : '';
+
+		if (badgeStyle === 'solid') {
+			return cn(
+				base,
+				sizing,
+				staleClass,
+				'bg-[var(--cmd-color)] text-white border border-transparent',
+			);
+		}
+		if (badgeStyle === 'bordered-dark') {
+			return cn(
+				base,
+				sizing,
+				staleClass,
+				'bg-[color-mix(in_oklch,var(--cmd-color)_14%,transparent)] text-[var(--cmd-color)] border border-[color-mix(in_oklch,var(--cmd-color)_25%,transparent)]',
+			);
+		}
+		return cn(
+			base,
+			sizing,
+			staleClass,
+			'bg-[color-mix(in_oklch,var(--cmd-color)_14%,transparent)] text-[var(--cmd-color)] border border-transparent',
+		);
+	});
+</script>
+
+<span
+	class={badgeClasses}
+	style:--cmd-color={cmdColorValue}
+	role="status"
+	aria-label="{commandName}: {state}"
+>
+	{#if state === 'running'}
+		<span
+			class="size-2.5 shrink-0 animate-spin rounded-full border-2 border-current border-t-transparent"
+		></span>
+		<span class="truncate">{commandName}</span>
+	{:else if state === 'passed'}
+		<CircleCheckIcon class="size-3 shrink-0" />
+	{:else}
+		<CircleXIcon class="size-3 shrink-0" />
+	{/if}
+</span>

--- a/src/lib/components/derived/command-badges/ServerPortBadge.stories.svelte
+++ b/src/lib/components/derived/command-badges/ServerPortBadge.stories.svelte
@@ -1,0 +1,55 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import { fn } from 'storybook/test';
+	import { ServerPortBadge } from './index.js';
+	import { BADGE_STYLES } from '$lib/components/shadcn/badge/index.js';
+
+	const { Story } = defineMeta({
+		title: 'Derived/ServerPortBadge',
+		component: ServerPortBadge,
+		tags: ['autodocs'],
+		args: {
+			onclick: fn(),
+		},
+		argTypes: {
+			badgeStyle: {
+				control: 'select',
+				options: [...BADGE_STYLES],
+			},
+		},
+	});
+</script>
+
+<script lang="ts">
+	import type { ServerPortBadgeProps } from './server_port_badge_types.js';
+</script>
+
+<Story name="Default">
+	{#snippet template(args: ServerPortBadgeProps)}
+		<ServerPortBadge port={5173} onclick={args.onclick} />
+	{/snippet}
+</Story>
+
+<Story name="Badge Styles">
+	{#snippet template(args: ServerPortBadgeProps)}
+		<div class="flex flex-col gap-4">
+			{#each BADGE_STYLES as style (style)}
+				<div class="flex items-center gap-3">
+					<span class="w-28 text-xs text-foreground-muted">{style}</span>
+					<ServerPortBadge port={3000} badgeStyle={style} onclick={args.onclick} />
+				</div>
+			{/each}
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Various Ports">
+	{#snippet template(args: ServerPortBadgeProps)}
+		<div class="flex flex-wrap gap-3">
+			<ServerPortBadge port={3000} onclick={args.onclick} />
+			<ServerPortBadge port={5173} onclick={args.onclick} />
+			<ServerPortBadge port={8080} onclick={args.onclick} />
+			<ServerPortBadge port={1420} onclick={args.onclick} />
+		</div>
+	{/snippet}
+</Story>

--- a/src/lib/components/derived/command-badges/ServerPortBadge.svelte
+++ b/src/lib/components/derived/command-badges/ServerPortBadge.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+	import { openUrl } from '$lib/opener.js';
+	import type { ServerPortBadgeProps } from './server_port_badge_types.js';
+
+	let { port, badgeStyle = 'borderless-dark', onclick }: ServerPortBadgeProps = $props();
+
+	function handleClick() {
+		if (onclick !== undefined) {
+			onclick();
+		} else {
+			void openUrl(`http://localhost:${port}`);
+		}
+	}
+
+	let badgeClasses = $derived.by(() => {
+		const base =
+			'inline-flex items-center gap-1.5 font-mono text-[10px] leading-none px-1.5 py-1 rounded-sm cursor-pointer hover:brightness-125 select-none';
+
+		if (badgeStyle === 'solid') {
+			return cn(base, 'bg-status-success text-white border border-transparent');
+		}
+		if (badgeStyle === 'bordered-dark') {
+			return cn(
+				base,
+				'bg-[color-mix(in_oklch,var(--status-success)_14%,transparent)] text-status-success border border-[color-mix(in_oklch,var(--status-success)_25%,transparent)]',
+			);
+		}
+		return cn(
+			base,
+			'bg-[color-mix(in_oklch,var(--status-success)_14%,transparent)] text-status-success border border-transparent',
+		);
+	});
+</script>
+
+<button type="button" class={badgeClasses} onclick={handleClick} aria-label="Open port {port}">
+	<span class="size-1.5 shrink-0 rounded-full bg-status-success"></span>
+	{port}
+</button>

--- a/src/lib/components/derived/command-badges/command_result_badge_types.ts
+++ b/src/lib/components/derived/command-badges/command_result_badge_types.ts
@@ -1,0 +1,13 @@
+import type { BadgeStyle } from '$lib/components/shadcn/badge/index.js';
+
+export const COMMAND_RESULT_STATES = ['running', 'passed', 'failed'] as const;
+/** @public */
+export type CommandResultState = (typeof COMMAND_RESULT_STATES)[number];
+
+/** @public */
+export interface CommandResultBadgeProps {
+	state: CommandResultState;
+	commandName: string;
+	isStale?: boolean;
+	badgeStyle?: BadgeStyle;
+}

--- a/src/lib/components/derived/command-badges/index.ts
+++ b/src/lib/components/derived/command-badges/index.ts
@@ -1,0 +1,8 @@
+export { default as CommandResultBadge } from './CommandResultBadge.svelte';
+export { default as ServerPortBadge } from './ServerPortBadge.svelte';
+export {
+	COMMAND_RESULT_STATES,
+	type CommandResultState,
+	type CommandResultBadgeProps,
+} from './command_result_badge_types.js';
+export type { ServerPortBadgeProps } from './server_port_badge_types.js';

--- a/src/lib/components/derived/command-badges/server_port_badge_types.ts
+++ b/src/lib/components/derived/command-badges/server_port_badge_types.ts
@@ -1,0 +1,8 @@
+import type { BadgeStyle } from '$lib/components/shadcn/badge/index.js';
+
+/** @public */
+export interface ServerPortBadgeProps {
+	port: number;
+	badgeStyle?: BadgeStyle;
+	onclick?: () => void;
+}

--- a/src/lib/components/derived/issue-color-button/IssueColorButton.stories.svelte
+++ b/src/lib/components/derived/issue-color-button/IssueColorButton.stories.svelte
@@ -1,0 +1,45 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import { IssueColorButton } from './index.js';
+
+	const { Story } = defineMeta({
+		title: 'Derived/IssueColorButton',
+		component: IssueColorButton,
+		tags: ['autodocs'],
+	});
+</script>
+
+<script lang="ts">
+</script>
+
+<Story name="With Colors">
+	{#snippet template()}
+		<div class="flex flex-wrap gap-3">
+			<IssueColorButton color="#4CAF50">Open Issue</IssueColorButton>
+			<IssueColorButton color="#2196F3">In Progress</IssueColorButton>
+			<IssueColorButton color="#FF5722">Blocked</IssueColorButton>
+			<IssueColorButton color="#9C27B0">Review</IssueColorButton>
+			<IssueColorButton color="#FFC107">Pending</IssueColorButton>
+			<IssueColorButton color="#00BCD4">Testing</IssueColorButton>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="No Color (Fallback)">
+	{#snippet template()}
+		<div class="flex flex-wrap gap-3">
+			<IssueColorButton>Done Card</IssueColorButton>
+			<IssueColorButton color={null}>Ghost Card</IssueColorButton>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Sizes">
+	{#snippet template()}
+		<div class="flex flex-wrap items-center gap-3">
+			<IssueColorButton color="#4CAF50" size="sm">Small</IssueColorButton>
+			<IssueColorButton color="#4CAF50" size="md">Medium</IssueColorButton>
+			<IssueColorButton color="#4CAF50" size="lg">Large</IssueColorButton>
+		</div>
+	{/snippet}
+</Story>

--- a/src/lib/components/derived/issue-color-button/IssueColorButton.svelte
+++ b/src/lib/components/derived/issue-color-button/IssueColorButton.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import { Button } from '$lib/components/shadcn/button/index.js';
+	import { getContrastTextColor } from '$lib/components/derived/color-picker/color_utils.js';
+	import type { IssueColorButtonProps } from './issue_color_button_types.js';
+
+	let {
+		color = null,
+		class: className,
+		children,
+		...restProps
+	}: IssueColorButtonProps = $props();
+
+	let inlineStyle = $derived.by(() => {
+		if (color === null || color === undefined || color === '') {
+			return '';
+		}
+		const textColor = getContrastTextColor(color);
+		return `--issue-btn-bg: ${color}; --issue-btn-text: ${textColor}; --issue-btn-border: ${color};`;
+	});
+</script>
+
+<Button
+	intent="issue-color"
+	class={className}
+	style={inlineStyle !== '' ? inlineStyle : undefined}
+	{...restProps}
+>
+	{@render children?.()}
+</Button>

--- a/src/lib/components/derived/issue-color-button/index.ts
+++ b/src/lib/components/derived/issue-color-button/index.ts
@@ -1,0 +1,2 @@
+export { default as IssueColorButton } from './IssueColorButton.svelte';
+export type { IssueColorButtonProps } from './issue_color_button_types.js';

--- a/src/lib/components/derived/issue-color-button/issue_color_button_types.ts
+++ b/src/lib/components/derived/issue-color-button/issue_color_button_types.ts
@@ -1,0 +1,8 @@
+import type { Snippet } from 'svelte';
+import type { ButtonProps } from '$lib/components/shadcn/button/index.js';
+
+/** @public */
+export type IssueColorButtonProps = Omit<ButtonProps, 'intent' | 'children'> & {
+	color?: string | null;
+	children?: Snippet;
+};

--- a/src/lib/components/derived/issue-state-chip/IssueStateChip.stories.svelte
+++ b/src/lib/components/derived/issue-state-chip/IssueStateChip.stories.svelte
@@ -1,0 +1,110 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import { IssueStateChip } from './index.js';
+	import { BADGE_STYLES } from '$lib/components/shadcn/badge/index.js';
+	import { CHIP_COLORS } from '$lib/modules/issue-card/index.js';
+
+	const { Story } = defineMeta({
+		title: 'Derived/IssueStateChip',
+		component: IssueStateChip,
+		tags: ['autodocs'],
+		argTypes: {
+			badgeStyle: {
+				control: 'select',
+				options: [...BADGE_STYLES],
+			},
+		},
+	});
+</script>
+
+<script lang="ts">
+	import type { IssueStateChipProps } from './issue_state_chip_types.js';
+	import type { BadgeStyle } from '$lib/components/shadcn/badge/index.js';
+
+	const ALL_CHIP_STATES: IssueStateChipProps[] = [
+		{ label: 'ERROR', colorVariable: CHIP_COLORS.error },
+		{ label: 'NEEDS INPUT', colorVariable: CHIP_COLORS.warning },
+		{ label: 'MERGE CONFLICT', colorVariable: CHIP_COLORS.error },
+		{ label: 'SETUP FAILED', colorVariable: CHIP_COLORS.error },
+		{ label: 'ANALYZING', colorVariable: CHIP_COLORS.success },
+		{ label: 'BUILDING', colorVariable: CHIP_COLORS.success },
+		{ label: 'REVIEWING', colorVariable: CHIP_COLORS.info },
+		{ label: 'VERIFYING', colorVariable: CHIP_COLORS.success },
+		{ label: 'SHIPPING', colorVariable: CHIP_COLORS.success },
+		{ label: 'EXECUTING', colorVariable: CHIP_COLORS.success },
+		{ label: 'REVIEW', colorVariable: CHIP_COLORS.info },
+		{ label: 'PAUSED', colorVariable: CHIP_COLORS.muted },
+		{ label: 'RUNNING CHECKS', colorVariable: CHIP_COLORS.info },
+		{ label: 'RUNNING TESTS', colorVariable: CHIP_COLORS.info },
+		{ label: 'BEHIND BASE', colorVariable: CHIP_COLORS.warning },
+		{ label: 'CHANGES REQ', colorVariable: CHIP_COLORS.warning },
+		{ label: 'CI RUNNING', colorVariable: CHIP_COLORS.info },
+		{ label: 'APPROVED', colorVariable: CHIP_COLORS.success },
+		{ label: 'READY TO MERGE', colorVariable: CHIP_COLORS.success },
+		{ label: 'WORKTREE SETUP', colorVariable: CHIP_COLORS.warning },
+		{ label: 'REMOVING WORKTREE', colorVariable: CHIP_COLORS.warning },
+		{ label: 'DONE', colorVariable: CHIP_COLORS.muted },
+	];
+</script>
+
+<Story name="All 22 States">
+	{#snippet template(args: { badgeStyle?: BadgeStyle })}
+		<div class="flex flex-wrap gap-2">
+			{#each ALL_CHIP_STATES as chip (chip.label)}
+				<IssueStateChip
+					label={chip.label}
+					colorVariable={chip.colorVariable}
+					badgeStyle={args.badgeStyle}
+				/>
+			{/each}
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Badge Styles Comparison">
+	{#snippet template()}
+		<div class="flex flex-col gap-4">
+			{#each BADGE_STYLES as style (style)}
+				<div class="flex flex-col gap-2">
+					<p class="text-xs font-medium text-foreground-muted">{style}</p>
+					<div class="flex flex-wrap gap-2">
+						<IssueStateChip
+							label="ERROR"
+							colorVariable={CHIP_COLORS.error}
+							badgeStyle={style}
+						/>
+						<IssueStateChip
+							label="BUILDING"
+							colorVariable={CHIP_COLORS.success}
+							badgeStyle={style}
+						/>
+						<IssueStateChip
+							label="REVIEWING"
+							colorVariable={CHIP_COLORS.info}
+							badgeStyle={style}
+						/>
+						<IssueStateChip
+							label="NEEDS INPUT"
+							colorVariable={CHIP_COLORS.warning}
+							badgeStyle={style}
+						/>
+						<IssueStateChip
+							label="PAUSED"
+							colorVariable={CHIP_COLORS.muted}
+							badgeStyle={style}
+						/>
+					</div>
+				</div>
+			{/each}
+		</div>
+	{/snippet}
+</Story>
+
+<Story
+	name="Single Chip"
+	args={{ label: 'EXECUTING', colorVariable: CHIP_COLORS.success, badgeStyle: 'borderless-dark' }}
+>
+	{#snippet template(args: IssueStateChipProps)}
+		<IssueStateChip {...args} />
+	{/snippet}
+</Story>

--- a/src/lib/components/derived/issue-state-chip/IssueStateChip.svelte
+++ b/src/lib/components/derived/issue-state-chip/IssueStateChip.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+	import type { IssueStateChipProps } from './issue_state_chip_types.js';
+
+	let { label, colorVariable, badgeStyle = 'borderless-dark' }: IssueStateChipProps = $props();
+
+	let chipColorValue = $derived(`var(${colorVariable})`);
+
+	let chipClasses = $derived.by(() => {
+		const base =
+			'inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-wider leading-none px-1.5 py-1 rounded-sm';
+
+		if (badgeStyle === 'solid') {
+			return cn(base, 'bg-[var(--chip-color)] text-white border border-transparent');
+		}
+		if (badgeStyle === 'bordered-dark') {
+			return cn(
+				base,
+				'bg-[color-mix(in_oklch,var(--chip-color)_14%,transparent)] text-[var(--chip-color)] border border-[color-mix(in_oklch,var(--chip-color)_25%,transparent)]',
+			);
+		}
+		return cn(
+			base,
+			'bg-[color-mix(in_oklch,var(--chip-color)_14%,transparent)] text-[var(--chip-color)] border border-transparent',
+		);
+	});
+</script>
+
+<span class={chipClasses} style:--chip-color={chipColorValue} role="status" aria-label={label}>
+	<span class="size-1.5 shrink-0 rounded-full bg-[var(--chip-color)]"></span>
+	{label}
+</span>

--- a/src/lib/components/derived/issue-state-chip/index.ts
+++ b/src/lib/components/derived/issue-state-chip/index.ts
@@ -1,0 +1,2 @@
+export { default as IssueStateChip } from './IssueStateChip.svelte';
+export type { IssueStateChipProps } from './issue_state_chip_types.js';

--- a/src/lib/components/derived/issue-state-chip/issue_state_chip_types.ts
+++ b/src/lib/components/derived/issue-state-chip/issue_state_chip_types.ts
@@ -1,0 +1,9 @@
+import type { BadgeStyle } from '$lib/components/shadcn/badge/index.js';
+import type { ChipColor } from '$lib/modules/issue-card/index.js';
+
+/** @public */
+export interface IssueStateChipProps {
+	label: string;
+	colorVariable: ChipColor;
+	badgeStyle?: BadgeStyle;
+}

--- a/src/lib/components/derived/priority-badge/PriorityBadge.stories.svelte
+++ b/src/lib/components/derived/priority-badge/PriorityBadge.stories.svelte
@@ -1,0 +1,81 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import { fn } from 'storybook/test';
+	import { PriorityBadge, PRIORITY_POSITIONS } from './index.js';
+	import { BADGE_STYLES } from '$lib/components/shadcn/badge/index.js';
+
+	const { Story } = defineMeta({
+		title: 'Derived/PriorityBadge',
+		component: PriorityBadge,
+		tags: ['autodocs'],
+		args: {
+			onclick: fn(),
+		},
+		argTypes: {
+			priority: {
+				control: 'select',
+				options: ['top', 'high', 'low', 'lowest'],
+			},
+			badgeStyle: {
+				control: 'select',
+				options: [...BADGE_STYLES],
+			},
+			position: {
+				control: 'select',
+				options: [...PRIORITY_POSITIONS],
+			},
+		},
+	});
+</script>
+
+<script lang="ts">
+	import type { DisplayPriority, PriorityBadgeProps } from './priority_badge_types.js';
+
+	const ALL_PRIORITIES: DisplayPriority[] = ['top', 'high', 'low', 'lowest'];
+</script>
+
+<Story name="All Priorities">
+	{#snippet template(args: PriorityBadgeProps)}
+		<div class="flex flex-wrap gap-2">
+			{#each ALL_PRIORITIES as priority (priority)}
+				<PriorityBadge {priority} onclick={args.onclick} />
+			{/each}
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Badge Styles Comparison">
+	{#snippet template(args: PriorityBadgeProps)}
+		<div class="flex flex-col gap-4">
+			{#each BADGE_STYLES as style (style)}
+				<div class="flex flex-col gap-2">
+					<p class="text-xs font-medium text-foreground-muted">{style}</p>
+					<div class="flex flex-wrap gap-2">
+						{#each ALL_PRIORITIES as priority (priority)}
+							<PriorityBadge {priority} badgeStyle={style} onclick={args.onclick} />
+						{/each}
+					</div>
+				</div>
+			{/each}
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Positions" args={{ priority: 'high' }}>
+	{#snippet template(args: PriorityBadgeProps)}
+		<div class="flex flex-col gap-2">
+			{#each PRIORITY_POSITIONS as position (position)}
+				<div class="flex items-center gap-3">
+					<span class="w-40 text-xs text-foreground-muted">{position}</span>
+					<PriorityBadge priority={args.priority} {position} onclick={args.onclick} />
+				</div>
+			{/each}
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Non-Interactive" args={{ priority: 'high' }}>
+	{#snippet template()}
+		<PriorityBadge priority="high" />
+	{/snippet}
+</Story>

--- a/src/lib/components/derived/priority-badge/PriorityBadge.svelte
+++ b/src/lib/components/derived/priority-badge/PriorityBadge.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+	import {
+		PRIORITY_LABELS,
+		PRIORITY_COLOR_VARIABLES,
+		type PriorityBadgeProps,
+	} from './priority_badge_types.js';
+
+	let {
+		priority,
+		position = 'header-right',
+		badgeStyle = 'borderless-dark',
+		onclick,
+	}: PriorityBadgeProps = $props();
+
+	let label = $derived(PRIORITY_LABELS[priority]);
+	let priorityColorValue = $derived(`var(${PRIORITY_COLOR_VARIABLES[priority]})`);
+
+	let badgeClasses = $derived.by(() => {
+		const base =
+			'inline-flex items-center font-mono text-[10px] uppercase tracking-wider leading-none px-1.5 py-1 rounded-sm select-none';
+		const interactive = onclick ? 'cursor-pointer hover:brightness-125' : '';
+
+		if (badgeStyle === 'solid') {
+			return cn(
+				base,
+				interactive,
+				'bg-[var(--priority-color)] text-white border border-transparent',
+			);
+		}
+		if (badgeStyle === 'bordered-dark') {
+			return cn(
+				base,
+				interactive,
+				'bg-[color-mix(in_oklch,var(--priority-color)_14%,transparent)] text-[var(--priority-color)] border border-[color-mix(in_oklch,var(--priority-color)_25%,transparent)]',
+			);
+		}
+		return cn(
+			base,
+			interactive,
+			'bg-[color-mix(in_oklch,var(--priority-color)_14%,transparent)] text-[var(--priority-color)] border border-transparent',
+		);
+	});
+</script>
+
+<button
+	type="button"
+	class={badgeClasses}
+	style:--priority-color={priorityColorValue}
+	data-position={position}
+	disabled={!onclick}
+	{onclick}
+	aria-label="{label} priority"
+>
+	{label}
+</button>

--- a/src/lib/components/derived/priority-badge/index.ts
+++ b/src/lib/components/derived/priority-badge/index.ts
@@ -1,0 +1,9 @@
+export { default as PriorityBadge } from './PriorityBadge.svelte';
+export {
+	PRIORITY_POSITIONS,
+	PRIORITY_LABELS,
+	PRIORITY_COLOR_VARIABLES,
+	type PriorityPosition,
+	type DisplayPriority,
+	type PriorityBadgeProps,
+} from './priority_badge_types.js';

--- a/src/lib/components/derived/priority-badge/priority_badge_types.ts
+++ b/src/lib/components/derived/priority-badge/priority_badge_types.ts
@@ -1,0 +1,44 @@
+import type { BadgeStyle } from '$lib/components/shadcn/badge/index.js';
+import type { IssuePriority } from '$lib/modules/issues/types.js';
+
+export const PRIORITY_POSITIONS = [
+	'header-right',
+	'preview-bottom-half',
+	'preview-top-half',
+	'preview-bottom-inside',
+	'preview-top-inside',
+	'preview-tl',
+	'preview-tr',
+	'preview-bl',
+	'preview-br',
+] as const;
+
+/** @public */
+export type PriorityPosition = (typeof PRIORITY_POSITIONS)[number];
+
+/** @public */
+export type DisplayPriority = Exclude<IssuePriority, 'medium'>;
+
+/** @public */
+export const PRIORITY_LABELS = {
+	top: 'TOP',
+	high: 'HIGH',
+	low: 'LOW',
+	lowest: 'LOWEST',
+} as const satisfies Record<DisplayPriority, string>;
+
+/** @public */
+export const PRIORITY_COLOR_VARIABLES = {
+	top: '--priority-top',
+	high: '--priority-high',
+	low: '--priority-low',
+	lowest: '--priority-lowest',
+} as const satisfies Record<DisplayPriority, string>;
+
+/** @public */
+export interface PriorityBadgeProps {
+	priority: DisplayPriority;
+	position?: PriorityPosition;
+	badgeStyle?: BadgeStyle;
+	onclick?: () => void;
+}

--- a/src/lib/components/derived/split-button/SplitButton.stories.svelte
+++ b/src/lib/components/derived/split-button/SplitButton.stories.svelte
@@ -1,0 +1,81 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import { fn } from 'storybook/test';
+	import { SplitButton } from './index.js';
+
+	const ADOPT_OPTIONS = [
+		{ value: 'adopt', label: 'Adopt' },
+		{ value: 'adopt-start', label: 'Adopt & Start' },
+		{ value: 'adopt-setup', label: 'Adopt & Setup' },
+	] as const;
+
+	const { Story } = defineMeta({
+		title: 'Derived/SplitButton',
+		component: SplitButton,
+		tags: ['autodocs'],
+		args: {
+			onselect: fn(),
+			options: [...ADOPT_OPTIONS],
+			defaultValue: 'adopt',
+		},
+	});
+</script>
+
+<script lang="ts">
+	import { expect, userEvent, waitFor, within } from 'storybook/test';
+	import type { SplitButtonProps } from './split_button_types.js';
+</script>
+
+<Story name="Default" args={{ options: [...ADOPT_OPTIONS], defaultValue: 'adopt' }}>
+	{#snippet template(args: SplitButtonProps)}
+		<SplitButton {...args} />
+	{/snippet}
+</Story>
+
+<Story name="Sizes">
+	{#snippet template(args: SplitButtonProps)}
+		<div class="flex flex-col gap-4">
+			<div class="flex items-center gap-3">
+				<span class="w-12 text-xs text-foreground-muted">sm</span>
+				<SplitButton {...args} size="sm" />
+			</div>
+			<div class="flex items-center gap-3">
+				<span class="w-12 text-xs text-foreground-muted">md</span>
+				<SplitButton {...args} size="md" />
+			</div>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Disabled">
+	{#snippet template(args: SplitButtonProps)}
+		<SplitButton {...args} disabled />
+	{/snippet}
+</Story>
+
+<Story
+	name="Dropdown Selection"
+	args={{ options: [...ADOPT_OPTIONS], defaultValue: 'adopt' }}
+	play={async ({ canvasElement, args: playArgs }) => {
+		const canvas = within(canvasElement);
+
+		const group = canvas.getByRole('group');
+		expect(group).toBeInTheDocument();
+
+		const groupCanvas = within(group);
+		const mainButton = groupCanvas.getByRole('button', { name: 'Adopt' });
+		expect(mainButton).toBeInTheDocument();
+
+		await userEvent.click(mainButton);
+		await waitFor(() => {
+			expect(playArgs.onselect).toHaveBeenCalledWith('adopt');
+		});
+
+		const groupButtons = groupCanvas.getAllByRole('button');
+		expect(groupButtons.length).toBe(2);
+	}}
+>
+	{#snippet template(args: SplitButtonProps)}
+		<SplitButton {...args} />
+	{/snippet}
+</Story>

--- a/src/lib/components/derived/split-button/SplitButton.svelte
+++ b/src/lib/components/derived/split-button/SplitButton.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import ChevronDownIcon from '@lucide/svelte/icons/chevron-down';
+	import { Button } from '$lib/components/shadcn/button/index.js';
+	import * as DropdownMenu from '$lib/components/shadcn/dropdown-menu/index.js';
+	import { Separator } from '$lib/components/shadcn/separator/index.js';
+	import { getAppSetting, setAppSetting } from '$lib/modules/window/window_commands.js';
+	import type { SplitButtonProps } from './split_button_types.js';
+
+	let {
+		options,
+		defaultValue,
+		settingsKey,
+		size = 'sm',
+		disabled = false,
+		onselect,
+	}: SplitButtonProps = $props();
+
+	let selectedValue = $state(defaultValue);
+
+	let selectedLabel = $derived(
+		options.find((option) => option.value === selectedValue)?.label ?? selectedValue,
+	);
+
+	function handleMainClick() {
+		onselect(selectedValue);
+	}
+
+	function handleOptionSelect(value: string) {
+		selectedValue = value;
+		onselect(value);
+		if (settingsKey !== undefined && settingsKey !== '') {
+			void setAppSetting(settingsKey, value);
+		}
+	}
+
+	onMount(() => {
+		if (settingsKey !== undefined && settingsKey !== '') {
+			void getAppSetting(settingsKey).then((setting) => {
+				if (setting !== null && setting.value !== '') {
+					const matchesOption = options.some((option) => option.value === setting.value);
+					if (matchesOption) {
+						selectedValue = setting.value;
+					}
+				}
+			});
+		}
+	});
+</script>
+
+<div class="inline-flex items-stretch" role="group">
+	<Button
+		intent="secondary"
+		{size}
+		{disabled}
+		class="rounded-r-none border-r-0"
+		onclick={handleMainClick}
+	>
+		{selectedLabel}
+	</Button>
+	<Separator orientation="vertical" />
+	<DropdownMenu.Root>
+		<DropdownMenu.Trigger {disabled}>
+			{#snippet child({ props })}
+				<Button
+					intent="secondary"
+					size={size === 'sm' ? 'icon-sm' : 'icon'}
+					class="rounded-l-none border-l-0"
+					{...props}
+				>
+					<ChevronDownIcon data-icon="inline-start" />
+				</Button>
+			{/snippet}
+		</DropdownMenu.Trigger>
+		<DropdownMenu.Content align="end">
+			{#each options as option (option.value)}
+				<DropdownMenu.Item
+					onclick={() => handleOptionSelect(option.value)}
+					data-active={option.value === selectedValue ? '' : undefined}
+				>
+					{option.label}
+				</DropdownMenu.Item>
+			{/each}
+		</DropdownMenu.Content>
+	</DropdownMenu.Root>
+</div>

--- a/src/lib/components/derived/split-button/index.ts
+++ b/src/lib/components/derived/split-button/index.ts
@@ -1,0 +1,2 @@
+export { default as SplitButton } from './SplitButton.svelte';
+export type { SplitButtonOption, SplitButtonProps } from './split_button_types.js';

--- a/src/lib/components/derived/split-button/split_button_types.ts
+++ b/src/lib/components/derived/split-button/split_button_types.ts
@@ -1,0 +1,17 @@
+import type { ButtonSize } from '$lib/components/shadcn/button/index.js';
+
+/** @public */
+export interface SplitButtonOption {
+	readonly value: string;
+	readonly label: string;
+}
+
+/** @public */
+export interface SplitButtonProps {
+	options: readonly SplitButtonOption[];
+	defaultValue: string;
+	settingsKey?: string;
+	size?: ButtonSize;
+	disabled?: boolean;
+	onselect: (value: string) => void;
+}

--- a/src/lib/components/shadcn/badge/Badge.stories.svelte
+++ b/src/lib/components/shadcn/badge/Badge.stories.svelte
@@ -1,6 +1,13 @@
 <script module lang="ts">
 	import { defineMeta } from '@storybook/addon-svelte-csf';
-	import { BADGE_DOT_OPTIONS, BADGE_FORMATS, BADGE_SIZES, BADGE_TONES, Badge } from './index.js';
+	import {
+		BADGE_DOT_OPTIONS,
+		BADGE_FORMATS,
+		BADGE_SIZES,
+		BADGE_STYLES,
+		BADGE_TONES,
+		Badge,
+	} from './index.js';
 
 	const { Story } = defineMeta({
 		title: 'Base/Badge',
@@ -18,6 +25,10 @@
 			size: {
 				control: 'select',
 				options: [...BADGE_SIZES],
+			},
+			badgeStyle: {
+				control: 'select',
+				options: [...BADGE_STYLES],
 			},
 			dot: {
 				control: 'select',
@@ -106,6 +117,23 @@
 			<Badge format="mono" {...args}>v2.1.0</Badge>
 			<Badge format="mono" {...args}>GET</Badge>
 			<Badge format="mono" {...args}>200</Badge>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Badge Styles (A/B/C)">
+	{#snippet template(args: BadgeProps)}
+		<div class="flex flex-col gap-4">
+			{#each BADGE_STYLES as style (style)}
+				<div class="flex flex-col gap-2">
+					<p class="text-sm font-medium text-foreground-muted">{style}</p>
+					<div class="flex flex-wrap gap-2">
+						{#each BADGE_TONES as tone (tone)}
+							<Badge {...args} {tone} badgeStyle={style}>{tone}</Badge>
+						{/each}
+					</div>
+				</div>
+			{/each}
 		</div>
 	{/snippet}
 </Story>

--- a/src/lib/components/shadcn/badge/Badge.svelte
+++ b/src/lib/components/shadcn/badge/Badge.svelte
@@ -5,6 +5,7 @@
 	let {
 		class: className,
 		tone = 'neutral',
+		badgeStyle = 'bordered-dark',
 		format = 'default',
 		size = 'default',
 		dot,
@@ -18,7 +19,7 @@
 <span
 	bind:this={ref}
 	data-slot="badge"
-	class={cn(badgeVariants({ tone, format, size }), className)}
+	class={cn(badgeVariants({ tone, badgeStyle, format, size }), className)}
 	{...restProps}
 >
 	{#if icon}

--- a/src/lib/components/shadcn/badge/badge-variants.ts
+++ b/src/lib/components/shadcn/badge/badge-variants.ts
@@ -19,6 +19,11 @@ export const badgeVariants = tv({
 			accent: 'bg-[color-mix(in_oklch,var(--accent)_16%,transparent)] text-[color-mix(in_oklch,var(--accent)_70%,var(--foreground))] border-[color-mix(in_oklch,var(--accent)_32%,transparent)]',
 			merged: 'bg-[color-mix(in_oklch,var(--status-merged)_14%,transparent)] text-status-merged border-[color-mix(in_oklch,var(--status-merged)_30%,transparent)]',
 		},
+		badgeStyle: {
+			'bordered-dark': '',
+			'borderless-dark': 'border-transparent',
+			solid: 'border-transparent',
+		},
 		format: {
 			default: '',
 			mono: 'font-mono text-[10.5px]',
@@ -28,18 +33,31 @@ export const badgeVariants = tv({
 			compact: 'px-1.5 py-0.5 text-[10px] leading-tight rounded',
 		},
 	},
+	compoundVariants: [
+		{ badgeStyle: 'solid', tone: 'success', class: 'bg-status-success text-white' },
+		{ badgeStyle: 'solid', tone: 'warning', class: 'bg-status-warning text-black' },
+		{ badgeStyle: 'solid', tone: 'danger', class: 'bg-status-danger text-white' },
+		{ badgeStyle: 'solid', tone: 'info', class: 'bg-status-info text-white' },
+		{ badgeStyle: 'solid', tone: 'primary', class: 'bg-primary text-primary-foreground' },
+		{ badgeStyle: 'solid', tone: 'accent', class: 'bg-accent text-white' },
+		{ badgeStyle: 'solid', tone: 'merged', class: 'bg-status-merged text-white' },
+		{ badgeStyle: 'solid', tone: 'neutral', class: 'bg-foreground-muted text-surface-1' },
+	],
 	defaultVariants: {
 		tone: 'neutral',
+		badgeStyle: 'bordered-dark',
 		format: 'default',
 		size: 'default',
 	},
 });
 
 export type BadgeTone = keyof typeof badgeVariants.variants.tone;
+export type BadgeStyle = keyof typeof badgeVariants.variants.badgeStyle;
 export type BadgeFormat = keyof typeof badgeVariants.variants.format;
 export type BadgeSize = keyof typeof badgeVariants.variants.size;
 
 export const BADGE_TONES = Object.keys(badgeVariants.variants.tone) as BadgeTone[];
+export const BADGE_STYLES = Object.keys(badgeVariants.variants.badgeStyle) as BadgeStyle[];
 export const BADGE_FORMATS = Object.keys(badgeVariants.variants.format) as BadgeFormat[];
 export const BADGE_SIZES = Object.keys(badgeVariants.variants.size) as BadgeSize[];
 
@@ -48,6 +66,7 @@ export type BadgeDot = (typeof BADGE_DOT_OPTIONS)[number];
 
 export type BadgeProps = WithElementRef<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> & {
 	tone?: BadgeTone;
+	badgeStyle?: BadgeStyle;
 	format?: BadgeFormat;
 	size?: BadgeSize;
 	dot?: BadgeDot;

--- a/src/lib/components/shadcn/badge/index.ts
+++ b/src/lib/components/shadcn/badge/index.ts
@@ -3,11 +3,13 @@ export { Root, Root as Badge };
 export {
 	badgeVariants,
 	BADGE_TONES,
+	BADGE_STYLES,
 	BADGE_FORMATS,
 	BADGE_SIZES,
 	BADGE_DOT_OPTIONS,
 	type BadgeProps,
 	type BadgeTone,
+	type BadgeStyle,
 	type BadgeFormat,
 	type BadgeSize,
 	type BadgeDot,

--- a/src/lib/components/shadcn/button/button-variants.ts
+++ b/src/lib/components/shadcn/button/button-variants.ts
@@ -19,6 +19,7 @@ export const buttonVariants = tv({
 			danger: 'bg-transparent text-status-danger border-[color-mix(in_oklch,var(--status-danger)_35%,transparent)] hover:bg-[color-mix(in_oklch,var(--status-danger)_12%,transparent)]',
 			'contextual-primary': `bg-moss-700 text-white shadow-sm hover:bg-moss-600 dark:bg-moss-600 dark:hover:bg-moss-500 ${FILLED_BUTTON_KBD_CLASSES}`,
 			'primary-destructive': `bg-status-danger text-white shadow-sm hover:bg-[color-mix(in_oklch,var(--status-danger)_88%,white_12%)] dark:hover:bg-[color-mix(in_oklch,var(--status-danger)_88%,black_12%)] ${FILLED_BUTTON_KBD_CLASSES}`,
+			'issue-color': `bg-[var(--issue-btn-bg,var(--surface-2))] text-[var(--issue-btn-text,var(--foreground))] border-[var(--issue-btn-border,var(--border))] shadow-sm hover:brightness-110 ${FILLED_BUTTON_KBD_CLASSES}`,
 		},
 		size: {
 			sm: 'h-(--size-control-sm) px-2.25 text-(length:--text-sm) rounded-sm [&_[data-icon]]:size-3.5',


### PR DESCRIPTION
## Summary
- Add 7 new shared components for Issue Card v2 redesign (PRD #296): IssueStateChip, IssueColorButton, SplitButton, PriorityBadge, CommandResultBadge, ServerPortBadge
- Extend Badge with `badgeStyle` variant (solid/borderless-dark/bordered-dark) and Button with `issue-color` intent
- Storybook stories with interaction tests for all components

## Test plan
- [ ] `pnpm check:all` passes (0 errors)
- [ ] `pnpm test` — 1437 tests pass
- [ ] Storybook renders all new component stories without errors
- [ ] Badge styles A/B/C look consistent across dark/light modes
- [ ] SplitButton dropdown opens and selects options
- [ ] CommandResultBadge animates from pill to circle
- [ ] IssueColorButton shows WCAG-contrast text on colored backgrounds

Closes #298