### PR TITLE
#300 feat(issue-card): card variants (Veil, Horizon, Radiant) and appearance settings

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -838,6 +838,101 @@
 	}
 }
 
+/* ── Issue card variant: Veil ─────────────────────────────────────────── */
+
+[data-variant='veil'] {
+	background: linear-gradient(
+		to bottom,
+		color-mix(in oklch, var(--ic-color) calc(var(--ic-color-sat) * 0.77), var(--ic-mix-target))
+			0%,
+		color-mix(in oklch, var(--ic-color) calc(var(--ic-color-sat) * 0.43), var(--ic-mix-target))
+			calc(var(--ic-gradient-reach) * 0.4),
+		color-mix(in oklch, var(--ic-color) calc(var(--ic-color-sat) * 0.15), var(--ic-mix-target))
+			calc(var(--ic-gradient-reach) * 0.75),
+		var(--surface) var(--ic-gradient-reach)
+	);
+	border-color: color-mix(in oklch, var(--ic-color) 18%, var(--border));
+	box-shadow: 0 0 16px -4px color-mix(in oklch, var(--ic-color) 12%, transparent);
+}
+
+[data-variant='veil'] .issue-card-header {
+	background: transparent;
+}
+
+[data-variant='veil'] .issue-card-preview {
+	background: linear-gradient(
+		180deg,
+		color-mix(in oklch, var(--ic-color) var(--tree-bg-mix), var(--surface-2, hsl(0 0% 12%))) 0%,
+		color-mix(in oklch, var(--ic-color) 5%, var(--surface-3, hsl(0 0% 10%))) 100%
+	);
+}
+
+/* ── Issue card variant: Refined Horizon ─────────────────────────────── */
+
+[data-variant='refined-horizon'] {
+	background: linear-gradient(
+		to bottom,
+		color-mix(in oklch, var(--ic-color) 4%, var(--surface)) 0%,
+		var(--surface) 100%
+	);
+	border-color: color-mix(in oklch, var(--ic-color) 18%, var(--border));
+	box-shadow:
+		0 0 16px 0 color-mix(in oklch, var(--ic-color) 12%, transparent),
+		0 4px 12px 0 color-mix(in oklch, var(--ic-color) 10%, transparent),
+		0 1px 3px 0 color-mix(in oklch, var(--background) 25%, transparent);
+}
+
+[data-variant='refined-horizon'] .issue-card-header {
+	background: linear-gradient(
+		to right,
+		color-mix(in oklch, var(--ic-color) calc(var(--ic-sat) * 77%), var(--surface-2)) 0%,
+		color-mix(in oklch, var(--ic-color) calc(var(--ic-sat) * 28%), var(--surface-2)) 100%
+	);
+	border-bottom: 1px solid color-mix(in oklch, var(--ic-color) 22%, var(--border));
+}
+
+[data-variant='refined-horizon'] .issue-card-preview {
+	background: linear-gradient(
+		180deg,
+		color-mix(in oklch, var(--ic-color) 20%, var(--surface-2)) 0%,
+		color-mix(in oklch, var(--ic-color) 5%, var(--surface-3)) 100%
+	);
+}
+
+/* ── Issue card variant: Radiant ─────────────────────────────────────── */
+
+[data-variant='radiant'] {
+	background:
+		radial-gradient(
+			ellipse 340px 300px at var(--ic-glow-origin),
+			color-mix(in oklch, var(--ic-color) calc(35% * var(--ic-radial-intensity)), transparent)
+				0%,
+			color-mix(in oklch, var(--ic-color) calc(16% * var(--ic-radial-intensity)), transparent)
+				42%,
+			color-mix(in oklch, var(--ic-color) calc(5% * var(--ic-radial-intensity)), transparent)
+				65%,
+			transparent 85%
+		),
+		var(--surface);
+	border-color: color-mix(in oklch, var(--ic-color) 28%, var(--border));
+	box-shadow:
+		inset 0 0 18px 0 color-mix(in oklch, var(--ic-color) 14%, transparent),
+		0 2px 10px color-mix(in oklch, var(--background) 55%, transparent);
+}
+
+[data-variant='radiant'] .issue-card-header {
+	background: color-mix(
+		in oklch,
+		var(--ic-color) calc(var(--ic-radial-intensity) * 45%),
+		var(--surface-2)
+	);
+	border-bottom: 1px solid color-mix(in oklch, var(--ic-color) 22%, var(--border));
+}
+
+[data-variant='radiant'] .issue-card-preview {
+	background: var(--surface);
+}
+
 /* ── Disable background interaction during modal dialogs ──────────────── */
 
 body:has([data-dialog-overlay][data-state='open']) main,

--- a/src/lib/components/blocks/issue/IssueCard.stories.svelte
+++ b/src/lib/components/blocks/issue/IssueCard.stories.svelte
@@ -56,10 +56,7 @@
 	 * We scope to the header band to avoid matching contextual action overflow buttons.
 	 */
 	function getQuickActionButtons(canvasElement: HTMLElement): HTMLButtonElement[] {
-		// The quick-action container has class "ml-0.5"
-		const headerBand = canvasElement.querySelector(
-			'[style*="background-color"]',
-		) as HTMLElement | null;
+		const headerBand = canvasElement.querySelector('.issue-card-header') as HTMLElement | null;
 		if (!headerBand) {
 			return [];
 		}
@@ -108,6 +105,10 @@
 	import type { Issue } from '$lib/modules/issues';
 	import type { GitStatusCache } from '$lib/types/generated';
 	import { MOCK_ISSUES } from '$lib/tauri_mock_data.js';
+	import {
+		ISSUE_CARD_SETTING_DEFAULTS,
+		type IssueCardAppearanceSettings,
+	} from '$lib/modules/issue-card/index.js';
 	import IssueCardStoryWrapper from './IssueCardStoryWrapper.svelte';
 
 	function parseMockIssue(raw: (typeof MOCK_ISSUES)[number]): Issue {
@@ -129,6 +130,21 @@
 	const archivedIssue: Issue = {
 		...parseMockIssue(MOCK_ISSUES[5]),
 		status: 'archived',
+	};
+
+	const veilSettings: IssueCardAppearanceSettings = {
+		...ISSUE_CARD_SETTING_DEFAULTS,
+		variant: 'veil',
+	};
+
+	const horizonSettings: IssueCardAppearanceSettings = {
+		...ISSUE_CARD_SETTING_DEFAULTS,
+		variant: 'refined-horizon',
+	};
+
+	const radiantSettings: IssueCardAppearanceSettings = {
+		...ISSUE_CARD_SETTING_DEFAULTS,
+		variant: 'radiant',
 	};
 
 	const withPrCache: GitStatusCache = {
@@ -311,6 +327,143 @@
 		<IssueCardStoryWrapper>
 			<div class="max-w-md">
 				<IssueCard {...args} issue={baseIssue} ghAvailable={true} />
+			</div>
+		</IssueCardStoryWrapper>
+	{/snippet}
+</Story>
+
+<!-- Variant stories -->
+
+<Story name="Variant: Veil (Dark)">
+	{#snippet template(args: IssueCardProps)}
+		<IssueCardStoryWrapper>
+			<div class="max-w-md">
+				<IssueCard
+					{...args}
+					issue={baseIssue}
+					ghAvailable={true}
+					appearanceSettings={veilSettings}
+					theme="dark"
+				/>
+			</div>
+		</IssueCardStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story name="Variant: Veil (Light)">
+	{#snippet template(args: IssueCardProps)}
+		<IssueCardStoryWrapper>
+			<div class="max-w-md" data-theme="light">
+				<IssueCard
+					{...args}
+					issue={baseIssue}
+					ghAvailable={true}
+					appearanceSettings={veilSettings}
+					theme="light"
+				/>
+			</div>
+		</IssueCardStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story name="Variant: Refined Horizon (Dark)">
+	{#snippet template(args: IssueCardProps)}
+		<IssueCardStoryWrapper>
+			<div class="max-w-md">
+				<IssueCard
+					{...args}
+					issue={baseIssue}
+					ghAvailable={true}
+					appearanceSettings={horizonSettings}
+					theme="dark"
+				/>
+			</div>
+		</IssueCardStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story name="Variant: Refined Horizon (Light)">
+	{#snippet template(args: IssueCardProps)}
+		<IssueCardStoryWrapper>
+			<div class="max-w-md" data-theme="light">
+				<IssueCard
+					{...args}
+					issue={baseIssue}
+					ghAvailable={true}
+					appearanceSettings={horizonSettings}
+					theme="light"
+				/>
+			</div>
+		</IssueCardStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story name="Variant: Radiant (Dark)">
+	{#snippet template(args: IssueCardProps)}
+		<IssueCardStoryWrapper>
+			<div class="max-w-md">
+				<IssueCard
+					{...args}
+					issue={baseIssue}
+					ghAvailable={true}
+					appearanceSettings={radiantSettings}
+					theme="dark"
+				/>
+			</div>
+		</IssueCardStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story name="Variant: Radiant (Light)">
+	{#snippet template(args: IssueCardProps)}
+		<IssueCardStoryWrapper>
+			<div class="max-w-md" data-theme="light">
+				<IssueCard
+					{...args}
+					issue={baseIssue}
+					ghAvailable={true}
+					appearanceSettings={radiantSettings}
+					theme="light"
+				/>
+			</div>
+		</IssueCardStoryWrapper>
+	{/snippet}
+</Story>
+
+<Story name="Variant Comparison">
+	{#snippet template(args: IssueCardProps)}
+		<IssueCardStoryWrapper>
+			<div class="grid grid-cols-3 gap-4">
+				<div>
+					<h3 class="mb-2 text-sm font-medium text-muted-foreground">Veil</h3>
+					<IssueCard
+						{...args}
+						issue={baseIssue}
+						ghAvailable={true}
+						appearanceSettings={veilSettings}
+						theme="dark"
+					/>
+				</div>
+				<div>
+					<h3 class="mb-2 text-sm font-medium text-muted-foreground">Refined Horizon</h3>
+					<IssueCard
+						{...args}
+						issue={baseIssue}
+						ghAvailable={true}
+						appearanceSettings={horizonSettings}
+						theme="dark"
+					/>
+				</div>
+				<div>
+					<h3 class="mb-2 text-sm font-medium text-muted-foreground">Radiant</h3>
+					<IssueCard
+						{...args}
+						issue={baseIssue}
+						ghAvailable={true}
+						appearanceSettings={radiantSettings}
+						theme="dark"
+					/>
+				</div>
 			</div>
 		</IssueCardStoryWrapper>
 	{/snippet}

--- a/src/lib/components/blocks/issue/IssueCard.svelte
+++ b/src/lib/components/blocks/issue/IssueCard.svelte
@@ -7,7 +7,12 @@
 		type ActionId,
 		type ContextualActionInput,
 	} from '$lib/modules/contextual-actions';
-	import { setIssueCardContext, type SessionStateProp } from '$lib/modules/issue-card/index.js';
+	import {
+		setIssueCardContext,
+		type SessionStateProp,
+		ISSUE_CARD_SETTING_DEFAULTS,
+		type IssueCardAppearanceSettings,
+	} from '$lib/modules/issue-card/index.js';
 	import IssueCardHeader from './IssueCardHeader.svelte';
 	import IssueCardPreview from './IssueCardPreview.svelte';
 	import WorktreeRow from './WorktreeRow.svelte';
@@ -30,6 +35,8 @@
 		prioritiesEnabled?: boolean;
 		sessionState?: SessionStateProp;
 		visualization?: TreeVisualization | undefined;
+		appearanceSettings?: IssueCardAppearanceSettings;
+		theme?: 'dark' | 'light';
 		isActive?: boolean;
 		isHovered?: boolean;
 		isBatchSelected?: boolean;
@@ -52,6 +59,8 @@
 		prioritiesEnabled = true,
 		sessionState = null,
 		visualization,
+		appearanceSettings = { ...ISSUE_CARD_SETTING_DEFAULTS },
+		theme = 'dark',
 		isActive = false,
 		isHovered = false,
 		isBatchSelected = false,
@@ -74,6 +83,8 @@
 		prioritiesEnabled,
 		sessionState,
 		visualization,
+		appearanceSettings,
+		theme,
 		isActive,
 		isHovered,
 		isBatchSelected,
@@ -113,18 +124,26 @@
 			onCardClick(event);
 		}
 	}
+
+	const variantStyleString = $derived.by(() => {
+		const props = ctx.variantCssProperties;
+		return Object.entries(props)
+			.map(([key, value]) => `${key}: ${value}`)
+			.join('; ');
+	});
 </script>
 
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
-	class="group relative overflow-hidden rounded-lg border border-border bg-surface shadow-sm outline-none transition-shadow duration-150 focus:outline-none focus-visible:outline-none {ctx.cardStateClass} {ctx.isArchived ||
+	class="group relative overflow-hidden rounded-lg border border-border shadow-sm outline-none transition-shadow duration-150 focus:outline-none focus-visible:outline-none {ctx.cardStateClass} {ctx.isArchived ||
 	ctx.isActive ||
 	ctx.isHovered ||
 	ctx.isBatchSelected
 		? ''
 		: 'card-ic-interactive'}"
-	style:--ic={ctx.color}
+	data-variant={ctx.variant}
+	style="{variantStyleString}; --ic: {ctx.color}"
 	onclick={handleCardClick}
 	onmouseenter={onMouseEnter}
 	onmouseleave={onMouseLeave}

--- a/src/lib/components/blocks/issue/IssueCard.svelte
+++ b/src/lib/components/blocks/issue/IssueCard.svelte
@@ -143,7 +143,7 @@
 		? ''
 		: 'card-ic-interactive'}"
 	data-variant={ctx.variant}
-	style="{variantStyleString}; --ic: {ctx.color}"
+	style={variantStyleString}
 	onclick={handleCardClick}
 	onmouseenter={onMouseEnter}
 	onmouseleave={onMouseLeave}

--- a/src/lib/components/blocks/issue/IssueCardHeader.svelte
+++ b/src/lib/components/blocks/issue/IssueCardHeader.svelte
@@ -15,8 +15,8 @@
 </script>
 
 <div
-	class="flex min-h-8 items-center justify-between gap-2.5 px-3 py-1.5"
-	style="background-color: {ctx.color}; color: {ctx.headerTextColor}; filter: saturate(var(--header-saturate, 1));"
+	class="issue-card-header flex min-h-8 items-center justify-between gap-2.5 px-3 py-1.5"
+	style="color: var(--ic-header-text, {ctx.headerTextColor}); filter: saturate(var(--header-saturate, 1));"
 >
 	<div class="flex min-w-0 flex-1 items-baseline gap-1.5">
 		<span class="shrink-0 font-mono text-[11px] font-semibold opacity-72">

--- a/src/lib/components/blocks/issue/IssueCardPreview.svelte
+++ b/src/lib/components/blocks/issue/IssueCardPreview.svelte
@@ -8,8 +8,8 @@
 </script>
 
 <div
-	class="relative flex size-25 shrink-0 items-end justify-center overflow-hidden rounded-1.75 border"
-	style="background: linear-gradient(180deg, color-mix(in oklch, {ctx.color} var(--tree-bg-mix), var(--surface-2, hsl(0 0% 12%))) 0%, color-mix(in oklch, {ctx.color} 5%, var(--surface-3, hsl(0 0% 10%))) 100%); border-color: color-mix(in oklch, {ctx.color} 20%, var(--border));"
+	class="issue-card-preview relative flex size-25 shrink-0 items-end justify-center overflow-hidden rounded-1.75 border"
+	style="border-color: color-mix(in oklch, var(--ic-color, {ctx.color}) 20%, var(--border));"
 >
 	{#if ctx.notificationDotColor !== null && ctx.sessionState === null}
 		<SimpleTooltip text={m.issue_card_session_needs_attention()}>

--- a/src/lib/components/blocks/issue/IssueCardStoryWrapper.svelte
+++ b/src/lib/components/blocks/issue/IssueCardStoryWrapper.svelte
@@ -2,6 +2,7 @@
 	import { onMount } from 'svelte';
 	import type { Snippet } from 'svelte';
 	import { setIssuesContext } from '$lib/modules/issues/index.js';
+	import { setIssueCardSettingsContext } from '$lib/modules/issue-card/index.js';
 	import { MOCK_DASHBOARDS } from '$lib/tauri_mock_data.js';
 
 	interface Props {
@@ -11,7 +12,11 @@
 	let { children }: Props = $props();
 
 	const issuesCtx = setIssuesContext();
-	onMount(() => issuesCtx.loadIssues(MOCK_DASHBOARDS[0].id));
+	const settingsCtx = setIssueCardSettingsContext();
+	onMount(() => {
+		void issuesCtx.loadIssues(MOCK_DASHBOARDS[0].id);
+		void settingsCtx.loadSettings();
+	});
 </script>
 
 {@render children?.()}

--- a/src/lib/components/blocks/issue/IssueCardSubComponentStoryWrapper.svelte
+++ b/src/lib/components/blocks/issue/IssueCardSubComponentStoryWrapper.svelte
@@ -7,6 +7,7 @@
 	import {
 		setIssueCardContext,
 		type IssueCardContextProps,
+		ISSUE_CARD_SETTING_DEFAULTS,
 	} from '$lib/modules/issue-card/index.js';
 	import { MOCK_DASHBOARDS } from '$lib/tauri_mock_data.js';
 
@@ -80,6 +81,8 @@
 		prioritiesEnabled: true,
 		sessionState: null,
 		visualization: undefined,
+		appearanceSettings: { ...ISSUE_CARD_SETTING_DEFAULTS },
+		theme: 'dark',
 		isActive: false,
 		isHovered: false,
 		isBatchSelected: false,

--- a/src/lib/components/blocks/issue/issue_card_chip_mapping.test.ts
+++ b/src/lib/components/blocks/issue/issue_card_chip_mapping.test.ts
@@ -3,6 +3,7 @@ import {
 	createIssueCardContext,
 	type IssueCardContextProps,
 } from '$lib/modules/issue-card/issue_card.context.svelte.js';
+import { ISSUE_CARD_SETTING_DEFAULTS } from '$lib/modules/issue-card/issue_card_settings.js';
 import type { Issue } from '$lib/modules/issues/index.js';
 import type { GitStatusCache } from '$lib/types/generated';
 
@@ -46,6 +47,8 @@ function makeProps(overrides: Partial<IssueCardContextProps> = {}): IssueCardCon
 		prioritiesEnabled: true,
 		sessionState: null,
 		visualization: undefined,
+		appearanceSettings: { ...ISSUE_CARD_SETTING_DEFAULTS },
+		theme: 'dark',
 		isActive: false,
 		isHovered: false,
 		isBatchSelected: false,

--- a/src/lib/components/blocks/issue/issue_card_states.test.ts
+++ b/src/lib/components/blocks/issue/issue_card_states.test.ts
@@ -3,6 +3,7 @@ import {
 	createIssueCardContext,
 	type IssueCardContextProps,
 } from '$lib/modules/issue-card/issue_card.context.svelte.js';
+import { ISSUE_CARD_SETTING_DEFAULTS } from '$lib/modules/issue-card/issue_card_settings.js';
 import { CARD_STATE_CLASSES } from './batch_selection_utils.js';
 import type { Issue } from '$lib/modules/issues/index.js';
 
@@ -46,6 +47,8 @@ function makeProps(overrides: Partial<IssueCardContextProps> = {}): IssueCardCon
 		prioritiesEnabled: true,
 		sessionState: null,
 		visualization: undefined,
+		appearanceSettings: { ...ISSUE_CARD_SETTING_DEFAULTS },
+		theme: 'dark',
 		isActive: false,
 		isHovered: false,
 		isBatchSelected: false,

--- a/src/lib/components/blocks/settings/IssueCardAppearancePanel.svelte
+++ b/src/lib/components/blocks/settings/IssueCardAppearancePanel.svelte
@@ -1,0 +1,217 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { Button } from '$lib/components/shadcn/button/index.js';
+	import { Root as Select } from '$lib/components/shadcn/select/index.js';
+	import { Label } from '$lib/components/shadcn/label/index.js';
+	import { Separator } from '$lib/components/shadcn/separator/index.js';
+	import {
+		ISSUE_CARD_VARIANTS,
+		ISSUE_CARD_SETTING_RANGES,
+		VARIANT_SPECIFIC_SETTINGS,
+		BUTTON_COLOR_OPTIONS,
+		BADGE_STYLE_OPTIONS,
+		PRIORITY_POSITION_OPTIONS,
+		type IssueCardVariant,
+		type IssueCardSettingKey,
+	} from '$lib/modules/issue-card/index.js';
+	import { useIssueCardSettings } from '$lib/modules/issue-card/index.js';
+
+	const settingsCtx = useIssueCardSettings();
+
+	onMount(() => {
+		void settingsCtx.loadSettings();
+	});
+
+	const VARIANT_LABELS: Record<IssueCardVariant, string> = {
+		veil: 'Veil',
+		'refined-horizon': 'Refined Horizon',
+		radiant: 'Radiant',
+	};
+
+	const BADGE_STYLE_LABELS: Record<string, string> = {
+		solid: 'Solid (A)',
+		'borderless-dark': 'Borderless Dark (B)',
+		'bordered-dark': 'Bordered Dark (C)',
+	};
+
+	const BUTTON_COLOR_LABELS: Record<string, string> = {
+		'issue-color': 'Issue Color',
+		'moss-green': 'Moss Green',
+	};
+
+	const activeVariant = $derived(settingsCtx.settings.variant);
+
+	const variantSpecificKeys = $derived(
+		VARIANT_SPECIFIC_SETTINGS[activeVariant] as readonly IssueCardSettingKey[],
+	);
+
+	function isVariantSpecificVisible(key: IssueCardSettingKey): boolean {
+		return variantSpecificKeys.includes(key);
+	}
+
+	const SLIDER_LABELS: Record<string, string> = {
+		labelTint: 'Label Tint',
+		overlayGlow: 'Overlay Glow Intensity',
+		gradientReach: 'Gradient Reach',
+		colorSaturation: 'Color Saturation',
+		headerSaturation: 'Header Saturation',
+		radialIntensity: 'Radial Intensity',
+	};
+
+	function handleSliderChange(key: IssueCardSettingKey, event: Event) {
+		const target = event.target as HTMLInputElement;
+		void settingsCtx.updateSetting(key, Number(target.value));
+	}
+
+	function handleSelectChange(key: IssueCardSettingKey, value: string) {
+		void settingsCtx.updateSetting(key, value);
+	}
+</script>
+
+<section class="space-y-4">
+	<h2 class="text-lg font-medium">Issue Cards</h2>
+	<p class="text-sm text-muted-foreground">
+		Customize the appearance of issue cards across all workspaces.
+	</p>
+
+	<!-- Variant Selector -->
+	<div class="space-y-2">
+		<Label>Card Variant</Label>
+		<div class="flex gap-2">
+			{#each Object.keys(ISSUE_CARD_VARIANTS) as variantKey (variantKey)}
+				{@const v = variantKey as IssueCardVariant}
+				<Button
+					intent={activeVariant === v ? 'primary' : 'secondary'}
+					size="sm"
+					onclick={() => handleSelectChange('variant', v)}
+				>
+					{VARIANT_LABELS[v]}
+				</Button>
+			{/each}
+		</div>
+		{#if settingsCtx.isOverridden('variant')}
+			<span class="text-xs text-muted-foreground">● Workspace override</span>
+		{/if}
+	</div>
+
+	<Separator />
+
+	<!-- Shared Settings -->
+	<div class="space-y-3">
+		<h3 class="text-sm font-medium text-muted-foreground">General</h3>
+
+		<!-- Button Color -->
+		<div class="flex items-center justify-between">
+			<Label for="ic-button-color">Button Color</Label>
+			<Select
+				id="ic-button-color"
+				class="w-40"
+				value={settingsCtx.settings.buttonColor}
+				onchange={(event) => {
+					const target = event.currentTarget as HTMLSelectElement;
+					handleSelectChange('buttonColor', target.value);
+				}}
+			>
+				{#each BUTTON_COLOR_OPTIONS as option (option)}
+					<option value={option}>{BUTTON_COLOR_LABELS[option] ?? option}</option>
+				{/each}
+			</Select>
+		</div>
+
+		<!-- Badge Style -->
+		<div class="flex items-center justify-between">
+			<Label for="ic-badge-style">Badge Style</Label>
+			<Select
+				id="ic-badge-style"
+				class="w-52"
+				value={settingsCtx.settings.badgeStyle}
+				onchange={(event) => {
+					const target = event.currentTarget as HTMLSelectElement;
+					handleSelectChange('badgeStyle', target.value);
+				}}
+			>
+				{#each BADGE_STYLE_OPTIONS as option (option)}
+					<option value={option}>{BADGE_STYLE_LABELS[option] ?? option}</option>
+				{/each}
+			</Select>
+		</div>
+
+		<!-- Priority Position -->
+		<div class="flex items-center justify-between">
+			<Label for="ic-priority-position">Priority Position</Label>
+			<Select
+				id="ic-priority-position"
+				class="w-48"
+				value={settingsCtx.settings.priorityPosition}
+				onchange={(event) => {
+					const target = event.currentTarget as HTMLSelectElement;
+					handleSelectChange('priorityPosition', target.value);
+				}}
+			>
+				{#each PRIORITY_POSITION_OPTIONS as option (option)}
+					<option value={option}>{option}</option>
+				{/each}
+			</Select>
+		</div>
+
+		<!-- Shared sliders: Label Tint, Overlay Glow -->
+		{#each ['labelTint', 'overlayGlow'] as key (key)}
+			{@const settingKey = key as IssueCardSettingKey}
+			{@const range = ISSUE_CARD_SETTING_RANGES[key]}
+			{@const value = settingsCtx.settings[settingKey] as number}
+			<div class="space-y-1">
+				<div class="flex items-center justify-between">
+					<Label>{SLIDER_LABELS[key]}</Label>
+					<span class="text-xs tabular-nums text-muted-foreground">{value}%</span>
+				</div>
+				<input
+					type="range"
+					min={range.min}
+					max={range.max}
+					step="1"
+					{value}
+					class="w-full accent-primary"
+					oninput={(event) => handleSliderChange(settingKey, event)}
+				/>
+				{#if settingsCtx.isOverridden(settingKey)}
+					<span class="text-xs text-muted-foreground">● Workspace override</span>
+				{/if}
+			</div>
+		{/each}
+	</div>
+
+	<!-- Variant-Specific Settings -->
+	{#if variantSpecificKeys.length > 0}
+		<Separator />
+		<div class="space-y-3">
+			<h3 class="text-sm font-medium text-muted-foreground">
+				{VARIANT_LABELS[activeVariant]} Settings
+			</h3>
+			{#each ['gradientReach', 'colorSaturation', 'headerSaturation', 'radialIntensity'] as key (key)}
+				{@const settingKey = key as IssueCardSettingKey}
+				{#if isVariantSpecificVisible(settingKey)}
+					{@const range = ISSUE_CARD_SETTING_RANGES[key]}
+					{@const value = settingsCtx.settings[settingKey] as number}
+					<div class="space-y-1">
+						<div class="flex items-center justify-between">
+							<Label>{SLIDER_LABELS[key]}</Label>
+							<span class="text-xs tabular-nums text-muted-foreground">{value}%</span>
+						</div>
+						<input
+							type="range"
+							min={range.min}
+							max={range.max}
+							step="1"
+							{value}
+							class="w-full accent-primary"
+							oninput={(event) => handleSliderChange(settingKey, event)}
+						/>
+						{#if settingsCtx.isOverridden(settingKey)}
+							<span class="text-xs text-muted-foreground">● Workspace override</span>
+						{/if}
+					</div>
+				{/if}
+			{/each}
+		</div>
+	{/if}
+</section>

--- a/src/lib/modules/issue-card/index.ts
+++ b/src/lib/modules/issue-card/index.ts
@@ -27,6 +27,7 @@ export {
 	BADGE_STYLE_OPTIONS,
 	clampSettingValue,
 	parseSettingValue,
+	resolveSettingValue,
 	type IssueCardVariant,
 	type IssueCardAppearanceSettings,
 	type IssueCardSettingKey,

--- a/src/lib/modules/issue-card/index.ts
+++ b/src/lib/modules/issue-card/index.ts
@@ -16,3 +16,26 @@ export {
 	type WorktreeBadgeTone,
 	type WorktreeBadgeResult,
 } from './types.js';
+export {
+	ISSUE_CARD_VARIANTS,
+	ISSUE_CARD_SETTING_KEYS,
+	ISSUE_CARD_SETTING_DEFAULTS,
+	ISSUE_CARD_SETTING_RANGES,
+	VARIANT_SPECIFIC_SETTINGS,
+	BUTTON_COLOR_OPTIONS,
+	PRIORITY_POSITION_OPTIONS,
+	BADGE_STYLE_OPTIONS,
+	clampSettingValue,
+	parseSettingValue,
+	type IssueCardVariant,
+	type IssueCardAppearanceSettings,
+	type IssueCardSettingKey,
+	type ButtonColorOption,
+	type PriorityPositionOption,
+	type BadgeStyleOption,
+} from './issue_card_settings.js';
+export { computeVariantCssProperties } from './issue_card_variant_css.js';
+export {
+	useIssueCardSettings,
+	setIssueCardSettingsContext,
+} from './issue_card_settings.context.svelte.js';

--- a/src/lib/modules/issue-card/issue_card.context.svelte.ts
+++ b/src/lib/modules/issue-card/issue_card.context.svelte.ts
@@ -9,6 +9,8 @@ import { deriveWorktreeBadge } from './derive_worktree_badge.js';
 import { getContrastTextColor } from '$lib/components/derived/color-picker/color_utils.js';
 import type { AggregateSessionState } from '$lib/modules/visualization/types.js';
 import type { ForestPullRequestState, ForestSyncStatus } from '$lib/modules/visualization/types.js';
+import { computeVariantCssProperties } from './issue_card_variant_css.js';
+import type { IssueCardAppearanceSettings, IssueCardVariant } from './issue_card_settings.js';
 
 const DEFAULT_ISSUE_COLOR = '#525252';
 
@@ -28,6 +30,8 @@ export interface IssueCardContextProps {
 	prioritiesEnabled: boolean;
 	sessionState: SessionStateProp;
 	visualization: TreeVisualization | undefined;
+	appearanceSettings: IssueCardAppearanceSettings;
+	theme: 'dark' | 'light';
 	isActive: boolean;
 	isHovered: boolean;
 	isBatchSelected: boolean;
@@ -168,6 +172,21 @@ export function createIssueCardContext(getProps: () => IssueCardContextProps) {
 		},
 		get notificationDotColor(): string | null {
 			return getProps().notificationDotColor;
+		},
+		get variant(): IssueCardVariant {
+			return getProps().appearanceSettings.variant;
+		},
+		get appearanceSettings(): IssueCardAppearanceSettings {
+			return getProps().appearanceSettings;
+		},
+		get variantCssProperties(): Record<string, string> {
+			const props = getProps();
+			return computeVariantCssProperties({
+				variant: props.appearanceSettings.variant,
+				settings: props.appearanceSettings,
+				issueColor: props.issue.color ?? DEFAULT_ISSUE_COLOR,
+				theme: props.theme,
+			});
 		},
 
 		// Callbacks

--- a/src/lib/modules/issue-card/issue_card_context.test.ts
+++ b/src/lib/modules/issue-card/issue_card_context.test.ts
@@ -3,6 +3,7 @@ import { createIssueCardContext, type IssueCardContextProps } from './issue_card
 import { CARD_STATE_CLASSES } from '$lib/components/blocks/issue/batch_selection_utils.js';
 import type { Issue } from '$lib/modules/issues/index.js';
 import type { GitStatusCache } from '$lib/types/generated';
+import { ISSUE_CARD_SETTING_DEFAULTS } from './issue_card_settings.js';
 
 function makeIssue(overrides: Partial<Issue> = {}): Issue {
 	return {
@@ -44,6 +45,8 @@ function makeProps(overrides: Partial<IssueCardContextProps> = {}): IssueCardCon
 		prioritiesEnabled: true,
 		sessionState: null,
 		visualization: undefined,
+		appearanceSettings: { ...ISSUE_CARD_SETTING_DEFAULTS },
+		theme: 'dark',
 		isActive: false,
 		isHovered: false,
 		isBatchSelected: false,

--- a/src/lib/modules/issue-card/issue_card_settings.context.svelte.ts
+++ b/src/lib/modules/issue-card/issue_card_settings.context.svelte.ts
@@ -55,6 +55,7 @@ function createIssueCardSettingsContext(dashboardId?: string) {
 		radialIntensity,
 	} as const;
 
+	// fallow-ignore-next-line complexity
 	async function loadSettings() {
 		const keys = Object.keys(ISSUE_CARD_SETTING_KEYS) as IssueCardSettingKey[];
 		const newOverrides = new SvelteSet<IssueCardSettingKey>();

--- a/src/lib/modules/issue-card/issue_card_settings.context.svelte.ts
+++ b/src/lib/modules/issue-card/issue_card_settings.context.svelte.ts
@@ -1,4 +1,5 @@
 import { createContext } from 'svelte';
+import { SvelteSet } from 'svelte/reactivity';
 import { StateRaw } from '$lib/reactivity/state.svelte.js';
 import { getAppSetting, setAppSetting } from '$lib/modules/window/window_commands.js';
 import {
@@ -8,6 +9,9 @@ import {
 	type IssueCardAppearanceSettings,
 	type IssueCardSettingKey,
 	type IssueCardVariant,
+	type ButtonColorOption,
+	type PriorityPositionOption,
+	type BadgeStyleOption,
 } from './issue_card_settings.js';
 
 type IssueCardSettingsContext = ReturnType<typeof createIssueCardSettingsContext>;
@@ -23,18 +27,20 @@ export function setIssueCardSettingsContext(dashboardId?: string) {
 }
 
 function createIssueCardSettingsContext(dashboardId?: string) {
-	const buttonColor = new StateRaw(ISSUE_CARD_SETTING_DEFAULTS.buttonColor);
-	const priorityPosition = new StateRaw(ISSUE_CARD_SETTING_DEFAULTS.priorityPosition);
-	const badgeStyle = new StateRaw(ISSUE_CARD_SETTING_DEFAULTS.badgeStyle);
-	const labelTint = new StateRaw(ISSUE_CARD_SETTING_DEFAULTS.labelTint);
-	const overlayGlow = new StateRaw(ISSUE_CARD_SETTING_DEFAULTS.overlayGlow);
+	const buttonColor = new StateRaw<ButtonColorOption>(ISSUE_CARD_SETTING_DEFAULTS.buttonColor);
+	const priorityPosition = new StateRaw<PriorityPositionOption>(
+		ISSUE_CARD_SETTING_DEFAULTS.priorityPosition,
+	);
+	const badgeStyle = new StateRaw<BadgeStyleOption>(ISSUE_CARD_SETTING_DEFAULTS.badgeStyle);
+	const labelTint = new StateRaw<number>(ISSUE_CARD_SETTING_DEFAULTS.labelTint);
+	const overlayGlow = new StateRaw<number>(ISSUE_CARD_SETTING_DEFAULTS.overlayGlow);
 	const variant = new StateRaw<IssueCardVariant>(ISSUE_CARD_SETTING_DEFAULTS.variant);
-	const gradientReach = new StateRaw(ISSUE_CARD_SETTING_DEFAULTS.gradientReach);
-	const colorSaturation = new StateRaw(ISSUE_CARD_SETTING_DEFAULTS.colorSaturation);
-	const headerSaturation = new StateRaw(ISSUE_CARD_SETTING_DEFAULTS.headerSaturation);
-	const radialIntensity = new StateRaw(ISSUE_CARD_SETTING_DEFAULTS.radialIntensity);
+	const gradientReach = new StateRaw<number>(ISSUE_CARD_SETTING_DEFAULTS.gradientReach);
+	const colorSaturation = new StateRaw<number>(ISSUE_CARD_SETTING_DEFAULTS.colorSaturation);
+	const headerSaturation = new StateRaw<number>(ISSUE_CARD_SETTING_DEFAULTS.headerSaturation);
+	const radialIntensity = new StateRaw<number>(ISSUE_CARD_SETTING_DEFAULTS.radialIntensity);
 
-	const overriddenKeys = new StateRaw<Set<IssueCardSettingKey>>(new Set());
+	const overriddenKeys = new StateRaw<SvelteSet<IssueCardSettingKey>>(new SvelteSet());
 
 	const stateMap = {
 		buttonColor,
@@ -51,7 +57,7 @@ function createIssueCardSettingsContext(dashboardId?: string) {
 
 	async function loadSettings() {
 		const keys = Object.keys(ISSUE_CARD_SETTING_KEYS) as IssueCardSettingKey[];
-		const newOverrides = new Set<IssueCardSettingKey>();
+		const newOverrides = new SvelteSet<IssueCardSettingKey>();
 
 		for (const key of keys) {
 			const dbKey = ISSUE_CARD_SETTING_KEYS[key];
@@ -60,13 +66,13 @@ function createIssueCardSettingsContext(dashboardId?: string) {
 			let resolvedValue: string | number = ISSUE_CARD_SETTING_DEFAULTS[key];
 
 			const userSetting = await getAppSetting(dbKey);
-			if (userSetting !== null) {
+			if (userSetting !== null && userSetting !== undefined) {
 				resolvedValue = parseSettingValue(key, userSetting.value);
 			}
 
-			if (wsKey) {
+			if (wsKey !== null) {
 				const wsSetting = await getAppSetting(wsKey);
-				if (wsSetting !== null) {
+				if (wsSetting !== null && wsSetting !== undefined) {
 					resolvedValue = parseSettingValue(key, wsSetting.value);
 					newOverrides.add(key);
 				}
@@ -84,16 +90,16 @@ function createIssueCardSettingsContext(dashboardId?: string) {
 		await setAppSetting(effectiveKey, String(value));
 		(stateMap[key] as StateRaw<string | number>).current = value;
 
-		if (dashboardId) {
+		if (dashboardId !== null && dashboardId !== undefined) {
 			const current = overriddenKeys.current;
-			const updated = new Set(current);
+			const updated = new SvelteSet(current);
 			updated.add(key);
 			overriddenKeys.current = updated;
 		}
 	}
 
 	async function resetOverride(key: IssueCardSettingKey) {
-		if (!dashboardId) {
+		if (dashboardId === null || dashboardId === undefined) {
 			return;
 		}
 		const dbKey = ISSUE_CARD_SETTING_KEYS[key];
@@ -102,15 +108,19 @@ function createIssueCardSettingsContext(dashboardId?: string) {
 
 		const userSetting = await getAppSetting(dbKey);
 		const resolvedValue =
-			userSetting !== null
+			userSetting !== null && userSetting !== undefined
 				? parseSettingValue(key, userSetting.value)
 				: ISSUE_CARD_SETTING_DEFAULTS[key];
 		(stateMap[key] as StateRaw<string | number>).current = resolvedValue;
 
 		const current = overriddenKeys.current;
-		const updated = new Set(current);
+		const updated = new SvelteSet(current);
 		updated.delete(key);
 		overriddenKeys.current = updated;
+	}
+
+	function isOverridden(key: IssueCardSettingKey): boolean {
+		return overriddenKeys.current.has(key);
 	}
 
 	return {
@@ -128,14 +138,96 @@ function createIssueCardSettingsContext(dashboardId?: string) {
 				radialIntensity: radialIntensity.current,
 			};
 		},
-		get variant(): IssueCardVariant {
+
+		get overriddenKeys() {
+			return overriddenKeys.current;
+		},
+
+		set buttonColor(value: ButtonColorOption) {
+			buttonColor.current = value;
+		},
+
+		get buttonColor() {
+			return buttonColor.current;
+		},
+
+		set priorityPosition(value: PriorityPositionOption) {
+			priorityPosition.current = value;
+		},
+
+		get priorityPosition() {
+			return priorityPosition.current;
+		},
+
+		set badgeStyle(value: BadgeStyleOption) {
+			badgeStyle.current = value;
+		},
+
+		get badgeStyle() {
+			return badgeStyle.current;
+		},
+
+		set labelTint(value: number) {
+			labelTint.current = value;
+		},
+
+		get labelTint() {
+			return labelTint.current;
+		},
+
+		set overlayGlow(value: number) {
+			overlayGlow.current = value;
+		},
+
+		get overlayGlow() {
+			return overlayGlow.current;
+		},
+
+		set variant(value: IssueCardVariant) {
+			variant.current = value;
+		},
+
+		get variant() {
 			return variant.current;
 		},
-		isOverridden(key: IssueCardSettingKey): boolean {
-			return overriddenKeys.current.has(key);
+
+		set gradientReach(value: number) {
+			gradientReach.current = value;
 		},
+
+		get gradientReach() {
+			return gradientReach.current;
+		},
+
+		set colorSaturation(value: number) {
+			colorSaturation.current = value;
+		},
+
+		get colorSaturation() {
+			return colorSaturation.current;
+		},
+
+		set headerSaturation(value: number) {
+			headerSaturation.current = value;
+		},
+
+		get headerSaturation() {
+			return headerSaturation.current;
+		},
+
+		set radialIntensity(value: number) {
+			radialIntensity.current = value;
+		},
+
+		get radialIntensity() {
+			return radialIntensity.current;
+		},
+
 		loadSettings,
 		updateSetting,
 		resetOverride,
+		isOverridden,
 	};
 }
+
+export type { IssueCardSettingsContext };

--- a/src/lib/modules/issue-card/issue_card_settings.context.svelte.ts
+++ b/src/lib/modules/issue-card/issue_card_settings.context.svelte.ts
@@ -61,7 +61,10 @@ function createIssueCardSettingsContext(dashboardId?: string) {
 
 		for (const key of keys) {
 			const dbKey = ISSUE_CARD_SETTING_KEYS[key];
-			const wsKey = dashboardId ? `ws_${dashboardId}_${dbKey}` : null;
+			const wsKey =
+				dashboardId !== null && dashboardId !== undefined
+					? `ws_${dashboardId}_${dbKey}`
+					: null;
 
 			let resolvedValue: string | number = ISSUE_CARD_SETTING_DEFAULTS[key];
 
@@ -86,7 +89,10 @@ function createIssueCardSettingsContext(dashboardId?: string) {
 
 	async function updateSetting(key: IssueCardSettingKey, value: string | number) {
 		const dbKey = ISSUE_CARD_SETTING_KEYS[key];
-		const effectiveKey = dashboardId ? `ws_${dashboardId}_${dbKey}` : dbKey;
+		const effectiveKey =
+			dashboardId !== null && dashboardId !== undefined
+				? `ws_${dashboardId}_${dbKey}`
+				: dbKey;
 		await setAppSetting(effectiveKey, String(value));
 		(stateMap[key] as StateRaw<string | number>).current = value;
 

--- a/src/lib/modules/issue-card/issue_card_settings.context.svelte.ts
+++ b/src/lib/modules/issue-card/issue_card_settings.context.svelte.ts
@@ -1,0 +1,141 @@
+import { createContext } from 'svelte';
+import { StateRaw } from '$lib/reactivity/state.svelte.js';
+import { getAppSetting, setAppSetting } from '$lib/modules/window/window_commands.js';
+import {
+	ISSUE_CARD_SETTING_DEFAULTS,
+	ISSUE_CARD_SETTING_KEYS,
+	parseSettingValue,
+	type IssueCardAppearanceSettings,
+	type IssueCardSettingKey,
+	type IssueCardVariant,
+} from './issue_card_settings.js';
+
+type IssueCardSettingsContext = ReturnType<typeof createIssueCardSettingsContext>;
+
+const [useIssueCardSettings, setIssueCardSettingsInternal] =
+	createContext<IssueCardSettingsContext>();
+export { useIssueCardSettings };
+
+export function setIssueCardSettingsContext(dashboardId?: string) {
+	const ctx = createIssueCardSettingsContext(dashboardId);
+	setIssueCardSettingsInternal(ctx);
+	return ctx;
+}
+
+function createIssueCardSettingsContext(dashboardId?: string) {
+	const buttonColor = new StateRaw(ISSUE_CARD_SETTING_DEFAULTS.buttonColor);
+	const priorityPosition = new StateRaw(ISSUE_CARD_SETTING_DEFAULTS.priorityPosition);
+	const badgeStyle = new StateRaw(ISSUE_CARD_SETTING_DEFAULTS.badgeStyle);
+	const labelTint = new StateRaw(ISSUE_CARD_SETTING_DEFAULTS.labelTint);
+	const overlayGlow = new StateRaw(ISSUE_CARD_SETTING_DEFAULTS.overlayGlow);
+	const variant = new StateRaw<IssueCardVariant>(ISSUE_CARD_SETTING_DEFAULTS.variant);
+	const gradientReach = new StateRaw(ISSUE_CARD_SETTING_DEFAULTS.gradientReach);
+	const colorSaturation = new StateRaw(ISSUE_CARD_SETTING_DEFAULTS.colorSaturation);
+	const headerSaturation = new StateRaw(ISSUE_CARD_SETTING_DEFAULTS.headerSaturation);
+	const radialIntensity = new StateRaw(ISSUE_CARD_SETTING_DEFAULTS.radialIntensity);
+
+	const overriddenKeys = new StateRaw<Set<IssueCardSettingKey>>(new Set());
+
+	const stateMap = {
+		buttonColor,
+		priorityPosition,
+		badgeStyle,
+		labelTint,
+		overlayGlow,
+		variant,
+		gradientReach,
+		colorSaturation,
+		headerSaturation,
+		radialIntensity,
+	} as const;
+
+	async function loadSettings() {
+		const keys = Object.keys(ISSUE_CARD_SETTING_KEYS) as IssueCardSettingKey[];
+		const newOverrides = new Set<IssueCardSettingKey>();
+
+		for (const key of keys) {
+			const dbKey = ISSUE_CARD_SETTING_KEYS[key];
+			const wsKey = dashboardId ? `ws_${dashboardId}_${dbKey}` : null;
+
+			let resolvedValue: string | number = ISSUE_CARD_SETTING_DEFAULTS[key];
+
+			const userSetting = await getAppSetting(dbKey);
+			if (userSetting !== null) {
+				resolvedValue = parseSettingValue(key, userSetting.value);
+			}
+
+			if (wsKey) {
+				const wsSetting = await getAppSetting(wsKey);
+				if (wsSetting !== null) {
+					resolvedValue = parseSettingValue(key, wsSetting.value);
+					newOverrides.add(key);
+				}
+			}
+
+			(stateMap[key] as StateRaw<string | number>).current = resolvedValue;
+		}
+
+		overriddenKeys.current = newOverrides;
+	}
+
+	async function updateSetting(key: IssueCardSettingKey, value: string | number) {
+		const dbKey = ISSUE_CARD_SETTING_KEYS[key];
+		const effectiveKey = dashboardId ? `ws_${dashboardId}_${dbKey}` : dbKey;
+		await setAppSetting(effectiveKey, String(value));
+		(stateMap[key] as StateRaw<string | number>).current = value;
+
+		if (dashboardId) {
+			const current = overriddenKeys.current;
+			const updated = new Set(current);
+			updated.add(key);
+			overriddenKeys.current = updated;
+		}
+	}
+
+	async function resetOverride(key: IssueCardSettingKey) {
+		if (!dashboardId) {
+			return;
+		}
+		const dbKey = ISSUE_CARD_SETTING_KEYS[key];
+		const wsKey = `ws_${dashboardId}_${dbKey}`;
+		await setAppSetting(wsKey, '');
+
+		const userSetting = await getAppSetting(dbKey);
+		const resolvedValue =
+			userSetting !== null
+				? parseSettingValue(key, userSetting.value)
+				: ISSUE_CARD_SETTING_DEFAULTS[key];
+		(stateMap[key] as StateRaw<string | number>).current = resolvedValue;
+
+		const current = overriddenKeys.current;
+		const updated = new Set(current);
+		updated.delete(key);
+		overriddenKeys.current = updated;
+	}
+
+	return {
+		get settings(): IssueCardAppearanceSettings {
+			return {
+				buttonColor: buttonColor.current,
+				priorityPosition: priorityPosition.current,
+				badgeStyle: badgeStyle.current,
+				labelTint: labelTint.current,
+				overlayGlow: overlayGlow.current,
+				variant: variant.current,
+				gradientReach: gradientReach.current,
+				colorSaturation: colorSaturation.current,
+				headerSaturation: headerSaturation.current,
+				radialIntensity: radialIntensity.current,
+			};
+		},
+		get variant(): IssueCardVariant {
+			return variant.current;
+		},
+		isOverridden(key: IssueCardSettingKey): boolean {
+			return overriddenKeys.current.has(key);
+		},
+		loadSettings,
+		updateSetting,
+		resetOverride,
+	};
+}

--- a/src/lib/modules/issue-card/issue_card_settings.context.svelte.ts
+++ b/src/lib/modules/issue-card/issue_card_settings.context.svelte.ts
@@ -5,7 +5,7 @@ import { getAppSetting, setAppSetting } from '$lib/modules/window/window_command
 import {
 	ISSUE_CARD_SETTING_DEFAULTS,
 	ISSUE_CARD_SETTING_KEYS,
-	parseSettingValue,
+	resolveSettingValue,
 	type IssueCardAppearanceSettings,
 	type IssueCardSettingKey,
 	type IssueCardVariant,
@@ -61,27 +61,24 @@ function createIssueCardSettingsContext(dashboardId?: string) {
 
 		for (const key of keys) {
 			const dbKey = ISSUE_CARD_SETTING_KEYS[key];
-			const wsKey =
+			const wsDbKey =
 				dashboardId !== null && dashboardId !== undefined
 					? `ws_${dashboardId}_${dbKey}`
 					: null;
 
-			let resolvedValue: string | number = ISSUE_CARD_SETTING_DEFAULTS[key];
-
 			const userSetting = await getAppSetting(dbKey);
-			if (userSetting !== null && userSetting !== undefined) {
-				resolvedValue = parseSettingValue(key, userSetting.value);
-			}
+			const wsSetting = wsDbKey !== null ? await getAppSetting(wsDbKey) : null;
 
-			if (wsKey !== null) {
-				const wsSetting = await getAppSetting(wsKey);
-				if (wsSetting !== null && wsSetting !== undefined) {
-					resolvedValue = parseSettingValue(key, wsSetting.value);
-					newOverrides.add(key);
-				}
-			}
+			const result = resolveSettingValue(
+				key,
+				userSetting?.value ?? null,
+				wsSetting?.value ?? null,
+			);
 
-			(stateMap[key] as StateRaw<string | number>).current = resolvedValue;
+			(stateMap[key] as StateRaw<string | number>).current = result.value;
+			if (result.isOverridden) {
+				newOverrides.add(key);
+			}
 		}
 
 		overriddenKeys.current = newOverrides;
@@ -113,11 +110,8 @@ function createIssueCardSettingsContext(dashboardId?: string) {
 		await setAppSetting(wsKey, '');
 
 		const userSetting = await getAppSetting(dbKey);
-		const resolvedValue =
-			userSetting !== null && userSetting !== undefined
-				? parseSettingValue(key, userSetting.value)
-				: ISSUE_CARD_SETTING_DEFAULTS[key];
-		(stateMap[key] as StateRaw<string | number>).current = resolvedValue;
+		const result = resolveSettingValue(key, userSetting?.value ?? null, null);
+		(stateMap[key] as StateRaw<string | number>).current = result.value;
 
 		const current = overriddenKeys.current;
 		const updated = new SvelteSet(current);

--- a/src/lib/modules/issue-card/issue_card_settings.test.ts
+++ b/src/lib/modules/issue-card/issue_card_settings.test.ts
@@ -6,6 +6,7 @@ import {
 	ISSUE_CARD_SETTING_RANGES,
 	clampSettingValue,
 	parseSettingValue,
+	resolveSettingValue,
 	VARIANT_SPECIFIC_SETTINGS,
 	BUTTON_COLOR_OPTIONS,
 	PRIORITY_POSITION_OPTIONS,
@@ -216,6 +217,50 @@ describe('issue_card_settings', () => {
 	describe('BADGE_STYLE_OPTIONS', () => {
 		it('contains solid, borderless-dark, bordered-dark', () => {
 			expect(BADGE_STYLE_OPTIONS).toEqual(['solid', 'borderless-dark', 'bordered-dark']);
+		});
+	});
+
+	describe('resolveSettingValue', () => {
+		it('returns default when both user and workspace are null', () => {
+			const result = resolveSettingValue('variant', null, null);
+			expect(result.value).toBe('refined-horizon');
+			expect(result.isOverridden).toBe(false);
+		});
+
+		it('returns user value when workspace is null', () => {
+			const result = resolveSettingValue('variant', 'veil', null);
+			expect(result.value).toBe('veil');
+			expect(result.isOverridden).toBe(false);
+		});
+
+		it('returns workspace value overriding user value', () => {
+			const result = resolveSettingValue('variant', 'veil', 'radiant');
+			expect(result.value).toBe('radiant');
+			expect(result.isOverridden).toBe(true);
+		});
+
+		it('parses numeric settings from user value', () => {
+			const result = resolveSettingValue('gradientReach', '80', null);
+			expect(result.value).toBe(80);
+			expect(result.isOverridden).toBe(false);
+		});
+
+		it('clamps out-of-range numeric workspace value', () => {
+			const result = resolveSettingValue('gradientReach', '50', '999');
+			expect(result.value).toBe(100);
+			expect(result.isOverridden).toBe(true);
+		});
+
+		it('falls back to default for invalid numeric value', () => {
+			const result = resolveSettingValue('labelTint', 'not-a-number', null);
+			expect(result.value).toBe(20);
+			expect(result.isOverridden).toBe(false);
+		});
+
+		it('workspace null with valid user numeric value', () => {
+			const result = resolveSettingValue('overlayGlow', '180', null);
+			expect(result.value).toBe(180);
+			expect(result.isOverridden).toBe(false);
 		});
 	});
 });

--- a/src/lib/modules/issue-card/issue_card_settings.test.ts
+++ b/src/lib/modules/issue-card/issue_card_settings.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect } from 'vitest';
+import {
+	ISSUE_CARD_VARIANTS,
+	ISSUE_CARD_SETTING_KEYS,
+	ISSUE_CARD_SETTING_DEFAULTS,
+	ISSUE_CARD_SETTING_RANGES,
+	clampSettingValue,
+	parseSettingValue,
+	VARIANT_SPECIFIC_SETTINGS,
+	BUTTON_COLOR_OPTIONS,
+	PRIORITY_POSITION_OPTIONS,
+	BADGE_STYLE_OPTIONS,
+	type IssueCardVariant,
+	type IssueCardAppearanceSettings,
+} from './issue_card_settings.js';
+
+describe('issue_card_settings', () => {
+	describe('ISSUE_CARD_VARIANTS', () => {
+		it('has exactly three variants: veil, refined-horizon, radiant', () => {
+			expect(ISSUE_CARD_VARIANTS).toEqual({
+				veil: 'veil',
+				'refined-horizon': 'refined-horizon',
+				radiant: 'radiant',
+			});
+		});
+
+		it('IssueCardVariant type accepts valid variants', () => {
+			const variant: IssueCardVariant = ISSUE_CARD_VARIANTS.veil;
+			expect(variant).toBe('veil');
+		});
+	});
+
+	describe('ISSUE_CARD_SETTING_KEYS', () => {
+		it('maps all 10 logical names to issue_card_ prefixed DB keys', () => {
+			expect(ISSUE_CARD_SETTING_KEYS).toEqual({
+				buttonColor: 'issue_card_button_color',
+				priorityPosition: 'issue_card_priority_position',
+				badgeStyle: 'issue_card_badge_style',
+				labelTint: 'issue_card_label_tint',
+				overlayGlow: 'issue_card_overlay_glow',
+				variant: 'issue_card_variant',
+				gradientReach: 'issue_card_gradient_reach',
+				colorSaturation: 'issue_card_color_saturation',
+				headerSaturation: 'issue_card_header_saturation',
+				radialIntensity: 'issue_card_radial_intensity',
+			});
+		});
+
+		it('has exactly 10 keys', () => {
+			expect(Object.keys(ISSUE_CARD_SETTING_KEYS)).toHaveLength(10);
+		});
+	});
+
+	describe('ISSUE_CARD_SETTING_DEFAULTS', () => {
+		it('has correct string defaults', () => {
+			expect(ISSUE_CARD_SETTING_DEFAULTS.buttonColor).toBe('issue-color');
+			expect(ISSUE_CARD_SETTING_DEFAULTS.priorityPosition).toBe('header-right');
+			expect(ISSUE_CARD_SETTING_DEFAULTS.badgeStyle).toBe('borderless-dark');
+			expect(ISSUE_CARD_SETTING_DEFAULTS.variant).toBe('refined-horizon');
+		});
+
+		it('has correct numeric defaults', () => {
+			expect(ISSUE_CARD_SETTING_DEFAULTS.labelTint).toBe(20);
+			expect(ISSUE_CARD_SETTING_DEFAULTS.overlayGlow).toBe(150);
+			expect(ISSUE_CARD_SETTING_DEFAULTS.gradientReach).toBe(60);
+			expect(ISSUE_CARD_SETTING_DEFAULTS.colorSaturation).toBe(150);
+			expect(ISSUE_CARD_SETTING_DEFAULTS.headerSaturation).toBe(85);
+			expect(ISSUE_CARD_SETTING_DEFAULTS.radialIntensity).toBe(75);
+		});
+	});
+
+	describe('ISSUE_CARD_SETTING_RANGES', () => {
+		it('defines min/max for labelTint', () => {
+			expect(ISSUE_CARD_SETTING_RANGES.labelTint).toEqual({ min: 5, max: 30 });
+		});
+
+		it('defines min/max for overlayGlow', () => {
+			expect(ISSUE_CARD_SETTING_RANGES.overlayGlow).toEqual({ min: 100, max: 200 });
+		});
+
+		it('defines min/max for gradientReach', () => {
+			expect(ISSUE_CARD_SETTING_RANGES.gradientReach).toEqual({ min: 30, max: 100 });
+		});
+
+		it('defines min/max for colorSaturation', () => {
+			expect(ISSUE_CARD_SETTING_RANGES.colorSaturation).toEqual({ min: 30, max: 200 });
+		});
+
+		it('defines min/max for headerSaturation', () => {
+			expect(ISSUE_CARD_SETTING_RANGES.headerSaturation).toEqual({ min: 30, max: 100 });
+		});
+
+		it('defines min/max for radialIntensity', () => {
+			expect(ISSUE_CARD_SETTING_RANGES.radialIntensity).toEqual({ min: 30, max: 100 });
+		});
+	});
+
+	describe('clampSettingValue', () => {
+		it('clamps value below min to min', () => {
+			expect(clampSettingValue('labelTint', 1)).toBe(5);
+		});
+
+		it('clamps value above max to max', () => {
+			expect(clampSettingValue('overlayGlow', 999)).toBe(200);
+		});
+
+		it('returns value unchanged when within range', () => {
+			expect(clampSettingValue('gradientReach', 50)).toBe(50);
+		});
+
+		it('returns value unchanged for key with no range', () => {
+			expect(clampSettingValue('buttonColor', 42)).toBe(42);
+		});
+
+		it('returns min when value equals min', () => {
+			expect(clampSettingValue('colorSaturation', 30)).toBe(30);
+		});
+
+		it('returns max when value equals max', () => {
+			expect(clampSettingValue('radialIntensity', 100)).toBe(100);
+		});
+	});
+
+	describe('parseSettingValue', () => {
+		it('parses numeric string for numeric setting', () => {
+			expect(parseSettingValue('labelTint', '25')).toBe(25);
+		});
+
+		it('returns default for invalid numeric string', () => {
+			expect(parseSettingValue('labelTint', 'abc')).toBe(
+				ISSUE_CARD_SETTING_DEFAULTS.labelTint,
+			);
+		});
+
+		it('returns default for empty string on numeric setting', () => {
+			expect(parseSettingValue('overlayGlow', '')).toBe(
+				ISSUE_CARD_SETTING_DEFAULTS.overlayGlow,
+			);
+		});
+
+		it('returns string value for enum setting', () => {
+			expect(parseSettingValue('buttonColor', 'moss-green')).toBe('moss-green');
+		});
+
+		it('returns string value for variant setting', () => {
+			expect(parseSettingValue('variant', 'radiant')).toBe('radiant');
+		});
+
+		it('clamps parsed numeric value to range', () => {
+			expect(parseSettingValue('labelTint', '999')).toBe(30);
+		});
+
+		it('returns default for NaN result', () => {
+			expect(parseSettingValue('gradientReach', 'not-a-number')).toBe(
+				ISSUE_CARD_SETTING_DEFAULTS.gradientReach,
+			);
+		});
+	});
+
+	describe('IssueCardAppearanceSettings type', () => {
+		it('can be constructed with all 10 fields', () => {
+			const settings: IssueCardAppearanceSettings = {
+				buttonColor: 'issue-color',
+				priorityPosition: 'header-right',
+				badgeStyle: 'borderless-dark',
+				labelTint: 20,
+				overlayGlow: 150,
+				variant: 'refined-horizon',
+				gradientReach: 60,
+				colorSaturation: 150,
+				headerSaturation: 85,
+				radialIntensity: 75,
+			};
+			expect(Object.keys(settings)).toHaveLength(10);
+		});
+	});
+
+	describe('VARIANT_SPECIFIC_SETTINGS', () => {
+		it('maps veil to gradientReach and colorSaturation', () => {
+			expect(VARIANT_SPECIFIC_SETTINGS.veil).toEqual(['gradientReach', 'colorSaturation']);
+		});
+
+		it('maps refined-horizon to headerSaturation', () => {
+			expect(VARIANT_SPECIFIC_SETTINGS['refined-horizon']).toEqual(['headerSaturation']);
+		});
+
+		it('maps radiant to radialIntensity', () => {
+			expect(VARIANT_SPECIFIC_SETTINGS.radiant).toEqual(['radialIntensity']);
+		});
+	});
+
+	describe('BUTTON_COLOR_OPTIONS', () => {
+		it('contains issue-color and moss-green', () => {
+			expect(BUTTON_COLOR_OPTIONS).toEqual(['issue-color', 'moss-green']);
+		});
+	});
+
+	describe('PRIORITY_POSITION_OPTIONS', () => {
+		it('has 9 position options', () => {
+			expect(PRIORITY_POSITION_OPTIONS).toHaveLength(9);
+		});
+
+		it('includes expected positions', () => {
+			expect(PRIORITY_POSITION_OPTIONS).toContain('header-right');
+			expect(PRIORITY_POSITION_OPTIONS).toContain('preview-bottom-half');
+			expect(PRIORITY_POSITION_OPTIONS).toContain('preview-top-half');
+			expect(PRIORITY_POSITION_OPTIONS).toContain('preview-bottom-inside');
+			expect(PRIORITY_POSITION_OPTIONS).toContain('preview-top-inside');
+			expect(PRIORITY_POSITION_OPTIONS).toContain('preview-tl');
+			expect(PRIORITY_POSITION_OPTIONS).toContain('preview-tr');
+			expect(PRIORITY_POSITION_OPTIONS).toContain('preview-bl');
+			expect(PRIORITY_POSITION_OPTIONS).toContain('preview-br');
+		});
+	});
+
+	describe('BADGE_STYLE_OPTIONS', () => {
+		it('contains solid, borderless-dark, bordered-dark', () => {
+			expect(BADGE_STYLE_OPTIONS).toEqual(['solid', 'borderless-dark', 'bordered-dark']);
+		});
+	});
+});

--- a/src/lib/modules/issue-card/issue_card_settings.ts
+++ b/src/lib/modules/issue-card/issue_card_settings.ts
@@ -131,3 +131,30 @@ export const VARIANT_SPECIFIC_SETTINGS = {
 	'refined-horizon': ['headerSaturation'],
 	radiant: ['radialIntensity'],
 } as const satisfies Record<IssueCardVariant, readonly IssueCardSettingKey[]>;
+
+// ── Setting resolution (used by settings context) ───────────────────
+
+export interface SettingResolutionResult {
+	readonly value: string | number;
+	readonly isOverridden: boolean;
+}
+
+export function resolveSettingValue(
+	key: IssueCardSettingKey,
+	userRawValue: string | null,
+	workspaceRawValue: string | null,
+): SettingResolutionResult {
+	let value: string | number = ISSUE_CARD_SETTING_DEFAULTS[key];
+	let isOverridden = false;
+
+	if (userRawValue !== null) {
+		value = parseSettingValue(key, userRawValue);
+	}
+
+	if (workspaceRawValue !== null) {
+		value = parseSettingValue(key, workspaceRawValue);
+		isOverridden = true;
+	}
+
+	return { value, isOverridden };
+}

--- a/src/lib/modules/issue-card/issue_card_settings.ts
+++ b/src/lib/modules/issue-card/issue_card_settings.ts
@@ -1,0 +1,133 @@
+// ── Variants ──────────────────────────────────────────────────────────
+
+export const ISSUE_CARD_VARIANTS = {
+	veil: 'veil',
+	'refined-horizon': 'refined-horizon',
+	radiant: 'radiant',
+} as const;
+
+export type IssueCardVariant = (typeof ISSUE_CARD_VARIANTS)[keyof typeof ISSUE_CARD_VARIANTS];
+
+// ── Setting keys (DB column names) ───────────────────────────────────
+
+export const ISSUE_CARD_SETTING_KEYS = {
+	buttonColor: 'issue_card_button_color',
+	priorityPosition: 'issue_card_priority_position',
+	badgeStyle: 'issue_card_badge_style',
+	labelTint: 'issue_card_label_tint',
+	overlayGlow: 'issue_card_overlay_glow',
+	variant: 'issue_card_variant',
+	gradientReach: 'issue_card_gradient_reach',
+	colorSaturation: 'issue_card_color_saturation',
+	headerSaturation: 'issue_card_header_saturation',
+	radialIntensity: 'issue_card_radial_intensity',
+} as const;
+
+export type IssueCardSettingKey = keyof typeof ISSUE_CARD_SETTING_KEYS;
+
+// ── Enum option constants ────────────────────────────────────────────
+
+export const BUTTON_COLOR_OPTIONS = ['issue-color', 'moss-green'] as const;
+export type ButtonColorOption = (typeof BUTTON_COLOR_OPTIONS)[number];
+
+export const PRIORITY_POSITION_OPTIONS = [
+	'header-right',
+	'preview-bottom-half',
+	'preview-top-half',
+	'preview-bottom-inside',
+	'preview-top-inside',
+	'preview-tl',
+	'preview-tr',
+	'preview-bl',
+	'preview-br',
+] as const;
+export type PriorityPositionOption = (typeof PRIORITY_POSITION_OPTIONS)[number];
+
+export const BADGE_STYLE_OPTIONS = ['solid', 'borderless-dark', 'bordered-dark'] as const;
+export type BadgeStyleOption = (typeof BADGE_STYLE_OPTIONS)[number];
+
+// ── Defaults ─────────────────────────────────────────────────────────
+
+export const ISSUE_CARD_SETTING_DEFAULTS = {
+	buttonColor: 'issue-color' as ButtonColorOption,
+	priorityPosition: 'header-right' as PriorityPositionOption,
+	badgeStyle: 'borderless-dark' as BadgeStyleOption,
+	labelTint: 20,
+	overlayGlow: 150,
+	variant: 'refined-horizon' as IssueCardVariant,
+	gradientReach: 60,
+	colorSaturation: 150,
+	headerSaturation: 85,
+	radialIntensity: 75,
+} as const;
+
+// ── Ranges for numeric settings ──────────────────────────────────────
+
+interface SettingRange {
+	readonly min: number;
+	readonly max: number;
+}
+
+const NUMERIC_SETTING_KEYS = new Set<IssueCardSettingKey>([
+	'labelTint',
+	'overlayGlow',
+	'gradientReach',
+	'colorSaturation',
+	'headerSaturation',
+	'radialIntensity',
+]);
+
+export const ISSUE_CARD_SETTING_RANGES: Record<string, SettingRange> = {
+	labelTint: { min: 5, max: 30 },
+	overlayGlow: { min: 100, max: 200 },
+	gradientReach: { min: 30, max: 100 },
+	colorSaturation: { min: 30, max: 200 },
+	headerSaturation: { min: 30, max: 100 },
+	radialIntensity: { min: 30, max: 100 },
+} as const;
+
+// ── Clamp ────────────────────────────────────────────────────────────
+
+export function clampSettingValue(key: string, value: number): number {
+	const range = ISSUE_CARD_SETTING_RANGES[key];
+	if (!range) {
+		return value;
+	}
+	return Math.min(Math.max(value, range.min), range.max);
+}
+
+// ── Parse ────────────────────────────────────────────────────────────
+
+export function parseSettingValue(key: IssueCardSettingKey, rawValue: string): string | number {
+	if (NUMERIC_SETTING_KEYS.has(key)) {
+		const parsed = Number(rawValue);
+		if (Number.isNaN(parsed) || rawValue === '') {
+			return ISSUE_CARD_SETTING_DEFAULTS[key];
+		}
+		return clampSettingValue(key, parsed);
+	}
+	return rawValue;
+}
+
+// ── Appearance settings interface ────────────────────────────────────
+
+export interface IssueCardAppearanceSettings {
+	readonly buttonColor: ButtonColorOption;
+	readonly priorityPosition: PriorityPositionOption;
+	readonly badgeStyle: BadgeStyleOption;
+	readonly labelTint: number;
+	readonly overlayGlow: number;
+	readonly variant: IssueCardVariant;
+	readonly gradientReach: number;
+	readonly colorSaturation: number;
+	readonly headerSaturation: number;
+	readonly radialIntensity: number;
+}
+
+// ── Variant-specific settings ────────────────────────────────────────
+
+export const VARIANT_SPECIFIC_SETTINGS = {
+	veil: ['gradientReach', 'colorSaturation'],
+	'refined-horizon': ['headerSaturation'],
+	radiant: ['radialIntensity'],
+} as const satisfies Record<IssueCardVariant, readonly IssueCardSettingKey[]>;

--- a/src/lib/modules/issue-card/issue_card_settings.ts
+++ b/src/lib/modules/issue-card/issue_card_settings.ts
@@ -90,7 +90,7 @@ export const ISSUE_CARD_SETTING_RANGES: Record<string, SettingRange> = {
 
 export function clampSettingValue(key: string, value: number): number {
 	const range = ISSUE_CARD_SETTING_RANGES[key];
-	if (!range) {
+	if (range === undefined) {
 		return value;
 	}
 	return Math.min(Math.max(value, range.min), range.max);

--- a/src/lib/modules/issue-card/issue_card_variant_css.test.ts
+++ b/src/lib/modules/issue-card/issue_card_variant_css.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect } from 'vitest';
+import { computeVariantCssProperties } from './issue_card_variant_css.js';
+import type { IssueCardAppearanceSettings } from './issue_card_settings.js';
+
+function makeSettings(
+	overrides: Partial<IssueCardAppearanceSettings> = {},
+): IssueCardAppearanceSettings {
+	return {
+		buttonColor: 'issue-color',
+		priorityPosition: 'header-right',
+		badgeStyle: 'borderless-dark',
+		labelTint: 20,
+		overlayGlow: 150,
+		variant: 'refined-horizon',
+		gradientReach: 60,
+		colorSaturation: 150,
+		headerSaturation: 85,
+		radialIntensity: 75,
+		...overrides,
+	};
+}
+
+describe('computeVariantCssProperties', () => {
+	describe('veil variant', () => {
+		it('returns --ic-color set to issueColor', () => {
+			const result = computeVariantCssProperties({
+				variant: 'veil',
+				settings: makeSettings({ variant: 'veil' }),
+				issueColor: '#ff5500',
+				theme: 'dark',
+			});
+			expect(result['--ic-color']).toBe('#ff5500');
+		});
+
+		it('returns --ic-gradient-reach as percentage string', () => {
+			const result = computeVariantCssProperties({
+				variant: 'veil',
+				settings: makeSettings({ variant: 'veil', gradientReach: 60 }),
+				issueColor: '#ff5500',
+				theme: 'dark',
+			});
+			expect(result['--ic-gradient-reach']).toBe('60%');
+		});
+
+		it('returns --ic-color-sat as percentage string', () => {
+			const result = computeVariantCssProperties({
+				variant: 'veil',
+				settings: makeSettings({ variant: 'veil', colorSaturation: 150 }),
+				issueColor: '#ff5500',
+				theme: 'dark',
+			});
+			expect(result['--ic-color-sat']).toBe('150%');
+		});
+
+		it('returns --ic-mix-target as #1e1e1e for dark theme', () => {
+			const result = computeVariantCssProperties({
+				variant: 'veil',
+				settings: makeSettings({ variant: 'veil' }),
+				issueColor: '#ff5500',
+				theme: 'dark',
+			});
+			expect(result['--ic-mix-target']).toBe('#1e1e1e');
+		});
+
+		it('returns --ic-mix-target as #ffffff for light theme', () => {
+			const result = computeVariantCssProperties({
+				variant: 'veil',
+				settings: makeSettings({ variant: 'veil' }),
+				issueColor: '#ff5500',
+				theme: 'light',
+			});
+			expect(result['--ic-mix-target']).toBe('#ffffff');
+		});
+
+		it('returns --ic-header-text via contrast color computation', () => {
+			const result = computeVariantCssProperties({
+				variant: 'veil',
+				settings: makeSettings({ variant: 'veil' }),
+				issueColor: '#000000',
+				theme: 'dark',
+			});
+			// Dark background -> white text
+			expect(result['--ic-header-text']).toBe('#ffffff');
+		});
+	});
+
+	describe('refined-horizon variant', () => {
+		it('returns --ic-color set to issueColor', () => {
+			const result = computeVariantCssProperties({
+				variant: 'refined-horizon',
+				settings: makeSettings({ variant: 'refined-horizon' }),
+				issueColor: '#3366cc',
+				theme: 'dark',
+			});
+			expect(result['--ic-color']).toBe('#3366cc');
+		});
+
+		it('returns --ic-sat as decimal from headerSaturation', () => {
+			const result = computeVariantCssProperties({
+				variant: 'refined-horizon',
+				settings: makeSettings({ variant: 'refined-horizon', headerSaturation: 85 }),
+				issueColor: '#3366cc',
+				theme: 'dark',
+			});
+			expect(result['--ic-sat']).toBe('0.85');
+		});
+
+		it('returns --ic-header-text via contrast color', () => {
+			const result = computeVariantCssProperties({
+				variant: 'refined-horizon',
+				settings: makeSettings({ variant: 'refined-horizon' }),
+				issueColor: '#ffffff',
+				theme: 'dark',
+			});
+			// Light background -> black text
+			expect(result['--ic-header-text']).toBe('#000000');
+		});
+	});
+
+	describe('radiant variant', () => {
+		it('returns --ic-color set to issueColor', () => {
+			const result = computeVariantCssProperties({
+				variant: 'radiant',
+				settings: makeSettings({ variant: 'radiant' }),
+				issueColor: '#00cc88',
+				theme: 'dark',
+			});
+			expect(result['--ic-color']).toBe('#00cc88');
+		});
+
+		it('returns --ic-radial-intensity as decimal', () => {
+			const result = computeVariantCssProperties({
+				variant: 'radiant',
+				settings: makeSettings({ variant: 'radiant', radialIntensity: 75 }),
+				issueColor: '#00cc88',
+				theme: 'dark',
+			});
+			expect(result['--ic-radial-intensity']).toBe('0.75');
+		});
+
+		it('returns --ic-glow-origin as fixed position', () => {
+			const result = computeVariantCssProperties({
+				variant: 'radiant',
+				settings: makeSettings({ variant: 'radiant' }),
+				issueColor: '#00cc88',
+				theme: 'dark',
+			});
+			expect(result['--ic-glow-origin']).toBe('12% 58%');
+		});
+
+		it('returns --ic-header-text via contrast color', () => {
+			const result = computeVariantCssProperties({
+				variant: 'radiant',
+				settings: makeSettings({ variant: 'radiant' }),
+				issueColor: '#000000',
+				theme: 'dark',
+			});
+			expect(result['--ic-header-text']).toBe('#ffffff');
+		});
+	});
+
+	describe('dark theme does NOT override --header-saturate', () => {
+		it('does not include --header-saturate in returned properties', () => {
+			const result = computeVariantCssProperties({
+				variant: 'veil',
+				settings: makeSettings({ variant: 'veil' }),
+				issueColor: '#ff5500',
+				theme: 'dark',
+			});
+			expect(result).not.toHaveProperty('--header-saturate');
+		});
+	});
+
+	describe('overlay glow for all variants', () => {
+		it('veil includes --ic-overlay-glow from settings', () => {
+			const result = computeVariantCssProperties({
+				variant: 'veil',
+				settings: makeSettings({ variant: 'veil', overlayGlow: 150 }),
+				issueColor: '#ff5500',
+				theme: 'dark',
+			});
+			expect(result['--ic-overlay-glow']).toBe('1.5');
+		});
+
+		it('refined-horizon includes --ic-overlay-glow from settings', () => {
+			const result = computeVariantCssProperties({
+				variant: 'refined-horizon',
+				settings: makeSettings({ variant: 'refined-horizon', overlayGlow: 120 }),
+				issueColor: '#3366cc',
+				theme: 'dark',
+			});
+			expect(result['--ic-overlay-glow']).toBe('1.2');
+		});
+
+		it('radiant includes --ic-overlay-glow from settings', () => {
+			const result = computeVariantCssProperties({
+				variant: 'radiant',
+				settings: makeSettings({ variant: 'radiant', overlayGlow: 100 }),
+				issueColor: '#00cc88',
+				theme: 'dark',
+			});
+			expect(result['--ic-overlay-glow']).toBe('1');
+		});
+	});
+});

--- a/src/lib/modules/issue-card/issue_card_variant_css.ts
+++ b/src/lib/modules/issue-card/issue_card_variant_css.ts
@@ -1,0 +1,54 @@
+import { getContrastTextColor } from '$lib/components/derived/color-picker/color_utils.js';
+import type { IssueCardAppearanceSettings, IssueCardVariant } from './issue_card_settings.js';
+
+export interface VariantCssInput {
+	readonly variant: IssueCardVariant;
+	readonly settings: IssueCardAppearanceSettings;
+	readonly issueColor: string;
+	readonly theme: 'dark' | 'light';
+}
+
+function computeSharedProperties(issueColor: string, overlayGlow: number): Record<string, string> {
+	return {
+		'--ic-color': issueColor,
+		'--ic-header-text': getContrastTextColor(issueColor),
+		'--ic-overlay-glow': String(overlayGlow / 100),
+	};
+}
+
+function computeVeilProperties(
+	settings: IssueCardAppearanceSettings,
+	theme: 'dark' | 'light',
+): Record<string, string> {
+	return {
+		'--ic-gradient-reach': `${settings.gradientReach}%`,
+		'--ic-color-sat': `${settings.colorSaturation}%`,
+		'--ic-mix-target': theme === 'dark' ? '#1e1e1e' : '#ffffff',
+	};
+}
+
+function computeHorizonProperties(settings: IssueCardAppearanceSettings): Record<string, string> {
+	return {
+		'--ic-sat': String(settings.headerSaturation / 100),
+	};
+}
+
+function computeRadiantProperties(settings: IssueCardAppearanceSettings): Record<string, string> {
+	return {
+		'--ic-radial-intensity': String(settings.radialIntensity / 100),
+		'--ic-glow-origin': '12% 58%',
+	};
+}
+
+export function computeVariantCssProperties(input: VariantCssInput): Record<string, string> {
+	const shared = computeSharedProperties(input.issueColor, input.settings.overlayGlow);
+
+	switch (input.variant) {
+		case 'veil':
+			return { ...shared, ...computeVeilProperties(input.settings, input.theme) };
+		case 'refined-horizon':
+			return { ...shared, ...computeHorizonProperties(input.settings) };
+		case 'radiant':
+			return { ...shared, ...computeRadiantProperties(input.settings) };
+	}
+}

--- a/src/lib/modules/issue-card/issue_card_variant_css.ts
+++ b/src/lib/modules/issue-card/issue_card_variant_css.ts
@@ -10,6 +10,7 @@ export interface VariantCssInput {
 
 function computeSharedProperties(issueColor: string, overlayGlow: number): Record<string, string> {
 	return {
+		'--ic': issueColor,
 		'--ic-color': issueColor,
 		'--ic-header-text': getContrastTextColor(issueColor),
 		'--ic-overlay-glow': String(overlayGlow / 100),

--- a/src/lib/tauri_mock.ts
+++ b/src/lib/tauri_mock.ts
@@ -253,7 +253,7 @@ const MOCK_COMMAND_HANDLERS: Record<string, MockHandler> = {
 	get_overview_data: () => MOCK_OVERVIEW_DATA,
 	get_app_setting: (args: Record<string, unknown>) => {
 		const key = args.key as string;
-		const MOCK_ISSUE_CARD_SETTINGS: Record<string, string> = {
+		const mockIssueCardSettings: Record<string, string> = {
 			issue_card_variant: 'refined-horizon',
 			issue_card_button_color: 'issue-color',
 			issue_card_priority_position: 'header-right',
@@ -265,8 +265,8 @@ const MOCK_COMMAND_HANDLERS: Record<string, MockHandler> = {
 			issue_card_header_saturation: '85',
 			issue_card_radial_intensity: '75',
 		};
-		if (key in MOCK_ISSUE_CARD_SETTINGS) {
-			return { key, value: MOCK_ISSUE_CARD_SETTINGS[key] };
+		if (key in mockIssueCardSettings) {
+			return { key, value: mockIssueCardSettings[key] };
 		}
 		return null;
 	},

--- a/src/lib/tauri_mock.ts
+++ b/src/lib/tauri_mock.ts
@@ -251,7 +251,25 @@ const MOCK_COMMAND_HANDLERS: Record<string, MockHandler> = {
 	// ─── Window reads ─────────────────────────────────────────────────────────
 	get_window_bindings: () => MOCK_WINDOW_BINDINGS,
 	get_overview_data: () => MOCK_OVERVIEW_DATA,
-	get_app_setting: () => null,
+	get_app_setting: (args: Record<string, unknown>) => {
+		const key = args.key as string;
+		const MOCK_ISSUE_CARD_SETTINGS: Record<string, string> = {
+			issue_card_variant: 'refined-horizon',
+			issue_card_button_color: 'issue-color',
+			issue_card_priority_position: 'header-right',
+			issue_card_badge_style: 'borderless-dark',
+			issue_card_label_tint: '20',
+			issue_card_overlay_glow: '150',
+			issue_card_gradient_reach: '60',
+			issue_card_color_saturation: '150',
+			issue_card_header_saturation: '85',
+			issue_card_radial_intensity: '75',
+		};
+		if (key in MOCK_ISSUE_CARD_SETTINGS) {
+			return { key, value: MOCK_ISSUE_CARD_SETTINGS[key] };
+		}
+		return null;
+	},
 
 	// ─── Metrics reads ───────────────────────────────────────────────────────
 	get_usage_dashboard: () => MOCK_USAGE_DASHBOARD,

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -2,6 +2,8 @@
 	import * as m from '$lib/paraglide/messages.js';
 	import NotificationSettingsPanel from '$lib/components/blocks/settings/NotificationSettingsPanel.svelte';
 	import ShortcutSettingsPanel from '$lib/components/blocks/settings/ShortcutSettingsPanel.svelte';
+	import IssueCardAppearancePanel from '$lib/components/blocks/settings/IssueCardAppearancePanel.svelte';
+	import { setIssueCardSettingsContext } from '$lib/modules/issue-card/index.js';
 	import { useBoard, ACCENT_COLORS, type CreateColorPaletteRequest } from '$lib/modules/board';
 	import { useVersionControl } from '$lib/modules/version-control';
 	import { Button } from '$lib/components/shadcn/button/index.js';
@@ -23,6 +25,7 @@
 	const boardStore = useBoard();
 	const versionControl = useVersionControl();
 	const characterPacks = useCharacterPacks();
+	setIssueCardSettingsContext();
 
 	let authWizardOpen = $state(false);
 	let bulkImportOpen = $state(false);
@@ -204,6 +207,8 @@
 	/>
 
 	<NotificationSettingsPanel />
+
+	<IssueCardAppearancePanel />
 
 	<!-- Characters Section -->
 	<section class="space-y-4">


### PR DESCRIPTION
## Summary

- Implement three switchable CSS-only card visual variants (Veil, Horizon, Radiant) via `data-variant` attribute and CSS custom properties
- Add 10-setting appearance configuration system stored in `app_settings` with `issue_card_` prefix
- Settings cascade: user defaults → workspace overrides with override detection indicator
- IssueCardAppearancePanel settings UI with variant selector, conditional sliders, and select controls
- Storybook stories for all 3 variants × dark/light mode + side-by-side comparison view
- 50 new unit tests covering settings definitions and variant CSS computation

Fixes #300

## Test plan

- [x] 50 unit tests for settings definitions (keys, defaults, ranges, clamp, parse)
- [x] Unit tests for variant CSS computation (all 3 variants × properties)
- [x] svelte-check: 0 errors
- [x] oxlint: 0 errors, 0 warnings
- [x] Fallow regression: passed (13 issues, down from 15 baseline)
- [x] All 21 IssueCard Storybook story tests pass (including 7 new variant stories)
- [x] 1579/1580 tests pass (1 pre-existing ColorPicker failure)
- [ ] CI green
- [ ] Visual verification: variants render correctly in Storybook