### PR TITLE
#307 feat(ui): adopt Collapsible component from shadcn

### DIFF
--- a/src/lib/components/blocks/character/BulkImportWizard.svelte
+++ b/src/lib/components/blocks/character/BulkImportWizard.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import * as Collapsible from '$lib/components/shadcn/collapsible/index.js';
 	import * as Dialog from '$lib/components/shadcn/dialog/index.js';
 	import { Button } from '$lib/components/shadcn/button/index.js';
 	import { Badge } from '$lib/components/shadcn/badge/index.js';
@@ -156,14 +157,6 @@
 			selectedCharacters.add(folderPath);
 		} else {
 			selectedCharacters.delete(folderPath);
-		}
-	}
-
-	function handleToggleFaction(faction: string) {
-		if (expandedFactions.has(faction)) {
-			expandedFactions.delete(faction);
-		} else {
-			expandedFactions.add(faction);
 		}
 	}
 
@@ -334,26 +327,39 @@
 						</div>
 
 						{#each factions as [faction, factionCharacters] (faction)}
-							<div class="mb-1">
-								<Button
-									intent="ghost"
-									size="sm"
-									class="w-full justify-start text-muted-foreground"
-									onclick={() => handleToggleFaction(faction)}
-									aria-expanded={expandedFactions.has(faction)}
-								>
-									{#if expandedFactions.has(faction)}
-										<ChevronDownIcon data-icon="inline-start" />
-									{:else}
-										<ChevronRightIcon data-icon="inline-start" />
-									{/if}
-									{faction}
-									<span class="ml-auto text-[10px]"
-										>{factionCharacters.length}</span
-									>
-								</Button>
+							<Collapsible.Root
+								class="mb-1"
+								open={expandedFactions.has(faction)}
+								onOpenChange={(value: boolean) => {
+									if (value) {
+										expandedFactions.add(faction);
+									} else {
+										expandedFactions.delete(faction);
+									}
+								}}
+							>
+								<Collapsible.Trigger>
+									{#snippet child({ props })}
+										<Button
+											{...props}
+											intent="ghost"
+											size="sm"
+											class="w-full justify-start text-muted-foreground"
+										>
+											{#if expandedFactions.has(faction)}
+												<ChevronDownIcon data-icon="inline-start" />
+											{:else}
+												<ChevronRightIcon data-icon="inline-start" />
+											{/if}
+											{faction}
+											<span class="ml-auto text-[10px]"
+												>{factionCharacters.length}</span
+											>
+										</Button>
+									{/snippet}
+								</Collapsible.Trigger>
 
-								{#if expandedFactions.has(faction)}
+								<Collapsible.Content>
 									<div class="ml-4">
 										{#each factionCharacters as char (char.folder_path)}
 											{@const quality = getCharacterQuality(char)}
@@ -406,8 +412,8 @@
 											</button>
 										{/each}
 									</div>
-								{/if}
-							</div>
+								</Collapsible.Content>
+							</Collapsible.Root>
 						{/each}
 					</div>
 

--- a/src/lib/components/blocks/chat/ToolCardGroup.svelte
+++ b/src/lib/components/blocks/chat/ToolCardGroup.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
 	import type { ChatMessage as ChatMessageType } from '$lib/modules/chat/index.js';
+	import * as Collapsible from '$lib/components/shadcn/collapsible/index.js';
 	import ChevronRightIcon from '@lucide/svelte/icons/chevron-right';
 	import ToolCardCompact from './ToolCardCompact.svelte';
+	import { cn } from '$lib/utils.js';
 
 	interface Props {
 		messages: ChatMessageType[];
@@ -14,17 +16,19 @@
 	let expanded = $state(false);
 </script>
 
-{#if expanded}
-	<div class="flex flex-col gap-1.5">
-		<button
-			class="flex cursor-pointer items-center gap-1.5 px-2.5 py-1 text-[11px] font-medium text-foreground-subtle"
-			onclick={() => (expanded = false)}
-			type="button"
-		>
-			<ChevronRightIcon size={12} strokeWidth={2} class="rotate-90 transition-transform" />
-			<span>{messages.length} tool calls</span>
-			<div class="h-px flex-1 bg-border"></div>
-		</button>
+<Collapsible.Root bind:open={expanded} class="flex flex-col gap-1.5">
+	<Collapsible.Trigger
+		class="flex w-full cursor-pointer items-center gap-1.5 px-2.5 py-1 text-[11px] font-medium text-foreground-subtle"
+	>
+		<ChevronRightIcon
+			size={12}
+			strokeWidth={2}
+			class={cn('transition-transform', expanded && 'rotate-90')}
+		/>
+		<span>{messages.length} tool calls</span>
+		<div class="h-px flex-1 bg-border"></div>
+	</Collapsible.Trigger>
+	<Collapsible.Content>
 		{#each messages as message (message.id)}
 			{#if renderCard}
 				{@render renderCard(message)}
@@ -32,15 +36,5 @@
 				<ToolCardCompact {message} />
 			{/if}
 		{/each}
-	</div>
-{:else}
-	<button
-		class="flex cursor-pointer items-center gap-1.5 px-2.5 py-1 text-[11px] font-medium text-foreground-subtle"
-		onclick={() => (expanded = true)}
-		type="button"
-	>
-		<ChevronRightIcon size={12} strokeWidth={2} />
-		<span>{messages.length} tool calls</span>
-		<div class="h-px flex-1 bg-border"></div>
-	</button>
-{/if}
+	</Collapsible.Content>
+</Collapsible.Root>

--- a/src/lib/components/blocks/issue/AssignedIssuesPanel.svelte
+++ b/src/lib/components/blocks/issue/AssignedIssuesPanel.svelte
@@ -21,6 +21,7 @@
 	import { SvelteSet } from 'svelte/reactivity';
 	import { openUrl } from '$lib/opener.js';
 	import { Persisted, jsonSerde } from '$lib/reactivity/persisted.svelte.js';
+	import * as Collapsible from '$lib/components/shadcn/collapsible/index.js';
 	import { Badge } from '$lib/components/shadcn/badge/index.js';
 	import { Button } from '$lib/components/shadcn/button/index.js';
 	import { SimpleTooltip } from '$lib/components/shadcn/tooltip/index.js';
@@ -347,10 +348,15 @@
 		</div>
 
 		<!-- Unlinked Section -->
-		<div class="mt-1">
-			<button
+		<Collapsible.Root
+			class="mt-1"
+			open={!unlinkedCollapsed.current}
+			onOpenChange={(value: boolean) => {
+				unlinkedCollapsed.current = !value;
+			}}
+		>
+			<Collapsible.Trigger
 				class="flex w-full items-center gap-1 px-1 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60 hover:text-muted-foreground"
-				onclick={() => (unlinkedCollapsed.current = !unlinkedCollapsed.current)}
 			>
 				{#if unlinkedCollapsed.current}
 					<ChevronRight size={12} />
@@ -358,9 +364,9 @@
 					<ChevronDown size={12} />
 				{/if}
 				Unlinked ({filteredUnlinked.length})
-			</button>
+			</Collapsible.Trigger>
 
-			{#if !unlinkedCollapsed.current}
+			<Collapsible.Content>
 				{#each filteredUnlinked as issue (issue.number)}
 					<div
 						class={cn(
@@ -468,15 +474,20 @@
 						</div>
 					</div>
 				{/each}
-			{/if}
-		</div>
+			</Collapsible.Content>
+		</Collapsible.Root>
 
 		<!-- Linked Section -->
 		{#if filteredLinked.length > 0}
-			<div class="mt-2">
-				<button
+			<Collapsible.Root
+				class="mt-2"
+				open={!linkedCollapsed.current}
+				onOpenChange={(value: boolean) => {
+					linkedCollapsed.current = !value;
+				}}
+			>
+				<Collapsible.Trigger
 					class="flex w-full items-center gap-1 px-1 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60 hover:text-muted-foreground"
-					onclick={() => (linkedCollapsed.current = !linkedCollapsed.current)}
 				>
 					{#if linkedCollapsed.current}
 						<ChevronRight size={12} />
@@ -484,9 +495,9 @@
 						<ChevronDown size={12} />
 					{/if}
 					Linked ({filteredLinked.length})
-				</button>
+				</Collapsible.Trigger>
 
-				{#if !linkedCollapsed.current}
+				<Collapsible.Content>
 					{#each filteredLinked as issue (issue.number)}
 						<div
 							class="assigned-table-grid items-center border-b border-border/40 text-xs opacity-45"
@@ -558,8 +569,8 @@
 							</div>
 						</div>
 					{/each}
-				{/if}
-			</div>
+				</Collapsible.Content>
+			</Collapsible.Root>
 		{/if}
 
 		<!-- Load More -->

--- a/src/lib/components/blocks/session/FloatingInputPanel.svelte
+++ b/src/lib/components/blocks/session/FloatingInputPanel.svelte
@@ -4,8 +4,10 @@
 	import ChevronDownIcon from '@lucide/svelte/icons/chevron-down';
 	import PaperclipIcon from '@lucide/svelte/icons/paperclip';
 	import XIcon from '@lucide/svelte/icons/x';
+	import * as Collapsible from '$lib/components/shadcn/collapsible/index.js';
 	import { Button } from '$lib/components/shadcn/button/index.js';
 	import { Textarea } from '$lib/components/shadcn/textarea/index.js';
+	import { cn } from '$lib/utils.js';
 	import SkillChipsRow from './SkillChipsRow.svelte';
 	import SendStopButton from './SendStopButton.svelte';
 	import { getProviderConfig } from './session_theme_utils.js';
@@ -42,41 +44,54 @@
 
 <div class="pointer-events-none absolute bottom-4 left-1/2 z-15 w-full max-w-225 -translate-x-1/2">
 	<div class="pointer-events-auto rounded-3.5 border border-border bg-surface shadow-lg">
-		<!-- Image carousel (collapsed strip) -->
-		{#if !showImages && imageCount > 0}
-			<button
-				class="flex w-full cursor-pointer items-center gap-1 border-b border-border px-3 py-1"
-				onclick={() => (showImages = true)}
-			>
-				<PaperclipIcon size={11} strokeWidth={1.8} class="text-foreground-subtle" />
-				<span class="text-[11px] text-foreground-subtle">{imageCount} images</span>
-				<ChevronDownIcon size={10} strokeWidth={2} class="text-foreground-subtle" />
-			</button>
-		{/if}
-
-		<!-- Image carousel (expanded) -->
-		{#if showImages && imageCount > 0}
-			<div class="flex items-center gap-1.5 overflow-x-auto border-b border-border px-3 py-2">
-				{#each Array.from({ length: imageCount }, (_, idx) => idx) as i (i)}
+		<!-- Image carousel -->
+		{#if imageCount > 0}
+			<Collapsible.Root bind:open={showImages}>
+				<Collapsible.Trigger
+					class={cn(
+						'flex w-full cursor-pointer items-center gap-1 px-3 py-1',
+						!showImages && 'border-b border-border',
+					)}
+				>
+					<PaperclipIcon size={11} strokeWidth={1.8} class="text-foreground-subtle" />
+					<span class="text-[11px] text-foreground-subtle">{imageCount} images</span>
+					<ChevronDownIcon
+						size={10}
+						strokeWidth={2}
+						class={cn(
+							'text-foreground-subtle transition-transform',
+							showImages && 'rotate-180',
+						)}
+					/>
+				</Collapsible.Trigger>
+				<Collapsible.Content>
 					<div
-						class="relative flex size-11 w-16 shrink-0 items-center justify-center overflow-hidden rounded-md border border-border bg-surface-3"
+						class="flex items-center gap-1.5 overflow-x-auto border-b border-border px-3 py-2"
 					>
-						<span class="font-mono text-[10px] font-semibold text-foreground-muted">
-							#{i + 1}
-						</span>
-						<button
-							class="absolute top-0.5 right-0.5 flex size-3.5 cursor-pointer items-center justify-center rounded-0.75 border-none bg-black/40 p-0 text-white"
-							onclick={() => imageCount--}
-						>
-							<XIcon size={8} strokeWidth={2.5} />
-						</button>
+						{#each Array.from({ length: imageCount }, (_, idx) => idx) as i (i)}
+							<div
+								class="relative flex size-11 w-16 shrink-0 items-center justify-center overflow-hidden rounded-md border border-border bg-surface-3"
+							>
+								<span
+									class="font-mono text-[10px] font-semibold text-foreground-muted"
+								>
+									#{i + 1}
+								</span>
+								<button
+									class="absolute top-0.5 right-0.5 flex size-3.5 cursor-pointer items-center justify-center rounded-0.75 border-none bg-black/40 p-0 text-white"
+									onclick={() => imageCount--}
+								>
+									<XIcon size={8} strokeWidth={2.5} />
+								</button>
+							</div>
+						{/each}
+						<Button intent="ghost" size="sm" class="shrink-0 px-2 text-[10px]">
+							<PlusIcon strokeWidth={2} data-icon="inline-start" />
+							Add
+						</Button>
 					</div>
-				{/each}
-				<Button intent="ghost" size="sm" class="shrink-0 px-2 text-[10px]">
-					<PlusIcon strokeWidth={2} data-icon="inline-start" />
-					Add
-				</Button>
-			</div>
+				</Collapsible.Content>
+			</Collapsible.Root>
 		{/if}
 
 		<!-- Skill chips -->

--- a/src/lib/components/shadcn/collapsible/Collapsible.stories.svelte
+++ b/src/lib/components/shadcn/collapsible/Collapsible.stories.svelte
@@ -1,0 +1,157 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import { expect, userEvent, waitFor } from 'storybook/test';
+	import * as Collapsible from './index.js';
+
+	const { Story } = defineMeta({
+		title: 'Base/Collapsible',
+		component: Collapsible.Root,
+		tags: ['autodocs'],
+	});
+
+	function getTrigger(canvasElement: HTMLElement): HTMLElement {
+		const trigger = canvasElement.querySelector('[data-slot="collapsible-trigger"]');
+		if (!trigger) {
+			throw new Error('Collapsible trigger not found');
+		}
+		return trigger as HTMLElement;
+	}
+
+	function getContent(canvasElement: HTMLElement): HTMLElement | null {
+		return canvasElement.querySelector('[data-slot="collapsible-content"]');
+	}
+
+	const playClickOpens = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+		const trigger = getTrigger(canvasElement);
+
+		await expect(trigger).toHaveAttribute('data-state', 'closed');
+		await expect(getContent(canvasElement)).toHaveAttribute('data-state', 'closed');
+
+		await userEvent.click(trigger);
+
+		await waitFor(() => {
+			expect(trigger).toHaveAttribute('data-state', 'open');
+			expect(getContent(canvasElement)).toHaveAttribute('data-state', 'open');
+		});
+	};
+
+	const playClickCloses = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+		const trigger = getTrigger(canvasElement);
+
+		await expect(trigger).toHaveAttribute('data-state', 'open');
+		await expect(getContent(canvasElement)).toBeInTheDocument();
+
+		await userEvent.click(trigger);
+
+		await waitFor(() => {
+			expect(trigger).toHaveAttribute('data-state', 'closed');
+		});
+	};
+
+	const playDisabledNoChange = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+		const trigger = getTrigger(canvasElement);
+
+		await expect(trigger).toHaveAttribute('data-state', 'closed');
+		await expect(trigger).toBeDisabled();
+
+		trigger.click();
+
+		await waitFor(() => {
+			expect(trigger).toHaveAttribute('data-state', 'closed');
+			expect(getContent(canvasElement)).toHaveAttribute('data-state', 'closed');
+		});
+	};
+
+	const playKeyboardToggle = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+		const trigger = getTrigger(canvasElement);
+
+		await expect(trigger).toHaveAttribute('data-state', 'closed');
+
+		(trigger as HTMLButtonElement).focus();
+		await userEvent.keyboard('{Enter}');
+
+		await waitFor(() => {
+			expect(trigger).toHaveAttribute('data-state', 'open');
+		});
+
+		await userEvent.keyboard(' ');
+
+		await waitFor(() => {
+			expect(trigger).toHaveAttribute('data-state', 'closed');
+		});
+	};
+</script>
+
+<Story name="Default Closed" play={playClickOpens}>
+	{#snippet template()}
+		<div class="w-80">
+			<Collapsible.Root>
+				<Collapsible.Trigger
+					class="flex w-full items-center justify-between rounded-md px-4 py-2 text-sm font-medium hover:bg-accent"
+				>
+					Toggle Section
+				</Collapsible.Trigger>
+				<Collapsible.Content>
+					<div class="px-4 py-2 text-sm">
+						This content is revealed when the collapsible is opened.
+					</div>
+				</Collapsible.Content>
+			</Collapsible.Root>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Default Open" play={playClickCloses}>
+	{#snippet template()}
+		<div class="w-80">
+			<Collapsible.Root open={true}>
+				<Collapsible.Trigger
+					class="flex w-full items-center justify-between rounded-md px-4 py-2 text-sm font-medium hover:bg-accent"
+				>
+					Toggle Section
+				</Collapsible.Trigger>
+				<Collapsible.Content>
+					<div class="px-4 py-2 text-sm">
+						This content starts visible and can be collapsed.
+					</div>
+				</Collapsible.Content>
+			</Collapsible.Root>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Disabled" play={playDisabledNoChange}>
+	{#snippet template()}
+		<div class="w-80">
+			<Collapsible.Root disabled>
+				<Collapsible.Trigger
+					class="flex w-full items-center justify-between rounded-md px-4 py-2 text-sm font-medium opacity-50"
+				>
+					Disabled Section
+				</Collapsible.Trigger>
+				<Collapsible.Content>
+					<div class="px-4 py-2 text-sm">This content should not be reachable.</div>
+				</Collapsible.Content>
+			</Collapsible.Root>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Keyboard Navigation" play={playKeyboardToggle}>
+	{#snippet template()}
+		<div class="w-80">
+			<Collapsible.Root>
+				<Collapsible.Trigger
+					class="flex w-full items-center justify-between rounded-md px-4 py-2 text-sm font-medium hover:bg-accent"
+				>
+					Keyboard Toggle
+				</Collapsible.Trigger>
+				<Collapsible.Content>
+					<div class="px-4 py-2 text-sm">
+						Press Enter or Space on the trigger to toggle this content.
+					</div>
+				</Collapsible.Content>
+			</Collapsible.Root>
+		</div>
+	{/snippet}
+</Story>

--- a/src/lib/components/shadcn/collapsible/collapsible-content.svelte
+++ b/src/lib/components/shadcn/collapsible/collapsible-content.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import { Collapsible as CollapsiblePrimitive } from 'bits-ui';
+	import { cn, type WithoutChild } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithoutChild<CollapsiblePrimitive.ContentProps> = $props();
+</script>
+
+<CollapsiblePrimitive.Content
+	bind:ref
+	data-slot="collapsible-content"
+	class={cn(
+		'data-open:animate-accordion-down data-closed:animate-accordion-up overflow-hidden',
+		className,
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</CollapsiblePrimitive.Content>

--- a/src/lib/components/shadcn/collapsible/collapsible-trigger.svelte
+++ b/src/lib/components/shadcn/collapsible/collapsible-trigger.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { Collapsible as CollapsiblePrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: CollapsiblePrimitive.TriggerProps = $props();
+</script>
+
+<CollapsiblePrimitive.Trigger
+	bind:ref
+	data-slot="collapsible-trigger"
+	class={cn(className)}
+	{...restProps}
+/>

--- a/src/lib/components/shadcn/collapsible/collapsible.svelte
+++ b/src/lib/components/shadcn/collapsible/collapsible.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import { Collapsible as CollapsiblePrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		open = $bindable(false),
+		class: className,
+		...restProps
+	}: CollapsiblePrimitive.RootProps = $props();
+</script>
+
+<CollapsiblePrimitive.Root
+	bind:ref
+	bind:open
+	data-slot="collapsible"
+	class={cn(className)}
+	{...restProps}
+/>

--- a/src/lib/components/shadcn/collapsible/index.ts
+++ b/src/lib/components/shadcn/collapsible/index.ts
@@ -1,0 +1,13 @@
+import Root from './collapsible.svelte';
+import Content from './collapsible-content.svelte';
+import Trigger from './collapsible-trigger.svelte';
+
+export {
+	Root,
+	Content,
+	Trigger,
+	//
+	Root as Collapsible,
+	Content as CollapsibleContent,
+	Trigger as CollapsibleTrigger,
+};

--- a/src/lib/modules/ai-config/components/SourcesSection.svelte
+++ b/src/lib/modules/ai-config/components/SourcesSection.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { Button } from '$lib/components/shadcn/button/index.js';
+	import * as Collapsible from '$lib/components/shadcn/collapsible/index.js';
 	import * as Dialog from '$lib/components/shadcn/dialog/index.js';
 	import { Input } from '$lib/components/shadcn/input/index.js';
 	import ChevronRightIcon from '@lucide/svelte/icons/chevron-right';
@@ -112,25 +113,31 @@
 	}
 </script>
 
-<div class="flex flex-col gap-2">
-	<!-- Toggle row -->
-	<Button
-		intent="ghost"
-		size="sm"
-		class="text-foreground-muted hover:text-foreground"
-		onclick={() => {
-			aiConfig.sourcesExpanded = !aiConfig.sourcesExpanded;
-		}}
-	>
-		<ChevronRightIcon
-			data-icon="inline-start"
-			class={cn('transition-transform', aiConfig.sourcesExpanded && 'rotate-90')}
-		/>
-		Sources ({sourcesCount})
-	</Button>
+<Collapsible.Root
+	class="flex flex-col gap-2"
+	open={aiConfig.sourcesExpanded}
+	onOpenChange={(value) => {
+		aiConfig.sourcesExpanded = value;
+	}}
+>
+	<Collapsible.Trigger>
+		{#snippet child({ props })}
+			<Button
+				{...props}
+				intent="ghost"
+				size="sm"
+				class="text-foreground-muted hover:text-foreground"
+			>
+				<ChevronRightIcon
+					data-icon="inline-start"
+					class={cn('transition-transform', aiConfig.sourcesExpanded && 'rotate-90')}
+				/>
+				Sources ({sourcesCount})
+			</Button>
+		{/snippet}
+	</Collapsible.Trigger>
 
-	<!-- Expanded pill row -->
-	{#if aiConfig.sourcesExpanded}
+	<Collapsible.Content>
 		<div class="flex flex-wrap items-center gap-1.5">
 			{#each providerSources as source (source.path)}
 				{@const count = itemCountForSource(source.path)}
@@ -183,8 +190,8 @@
 				Add source
 			</Button>
 		</div>
-	{/if}
-</div>
+	</Collapsible.Content>
+</Collapsible.Root>
 
 <!-- Add source dialog -->
 <Dialog.Root bind:open={addDialogOpen}>


### PR DESCRIPTION
## Description

- Added new Collapsible component (Root, Trigger, Content) wrapping bits-ui primitive with consistent styling and animation support
- Created full Storybook documentation with autodocs and 4 interaction play tests (open/close, disabled state, keyboard navigation)
- Migrated 5 components from manual expand/collapse patterns to the new Collapsible:
  - SourcesSection (Sources pill row toggle)
  - BulkImportWizard (Faction expand/collapse in import wizard)
  - ToolCardGroup (Tool call group expand/collapse in chat)
  - AssignedIssuesPanel (Unlinked/Linked section collapse - 2 sections)
  - FloatingInputPanel (Image strip toggle)
- All migrations preserve existing behavior while gaining built-in a11y (aria-expanded, aria-controls) and animation support
- ToolCardExpanded intentionally not migrated (view-mode toggle, not disclosure pattern)

## Resolves

Closes #307

## Testing

- [ ] Verify Storybook stories for Collapsible component run without errors
- [ ] Test open/close interactions work in migrated components
- [ ] Verify keyboard navigation (Space/Enter to toggle) works correctly
- [ ] Confirm existing UI behavior unchanged across all 5 migrated components