### PR TITLE
feat(ui): adopt Toggle and ToggleGroup components from shadcn-svelte

### DIFF
--- a/src/lib/components/blocks/dependency-graph/DependencyGraphFilterBar.svelte
+++ b/src/lib/components/blocks/dependency-graph/DependencyGraphFilterBar.svelte
@@ -4,6 +4,7 @@
 		type DependencyFilter,
 	} from '$lib/modules/dependency-graph';
 	import { Button } from '$lib/components/shadcn/button/index.js';
+	import { Toggle } from '$lib/components/shadcn/toggle/index.js';
 	import { Select } from '$lib/components/shadcn/select/index.js';
 	import EyeIcon from '@lucide/svelte/icons/eye';
 	import EyeOffIcon from '@lucide/svelte/icons/eye-off';
@@ -35,12 +36,12 @@
 </script>
 
 <div class="filter-bar">
-	<Button
-		intent={filter.showClosed ? 'primary' : 'secondary'}
+	<Toggle
+		intent="outline"
 		size="sm"
 		class="h-6.5 text-[11px] font-semibold"
-		onclick={() => update({ showClosed: !filter.showClosed })}
-		aria-pressed={filter.showClosed}
+		pressed={filter.showClosed}
+		onPressedChange={(pressed) => update({ showClosed: pressed })}
 		title={filter.showClosed ? 'Hide closed issues' : 'Show closed issues'}
 	>
 		{#if filter.showClosed}
@@ -49,29 +50,29 @@
 			<EyeOffIcon data-icon="inline-start" />
 		{/if}
 		Closed
-	</Button>
+	</Toggle>
 
-	<Button
-		intent={filter.afkOnly ? 'primary' : 'secondary'}
+	<Toggle
+		intent="outline"
 		size="sm"
 		class="h-6.5 text-[11px] font-semibold"
-		onclick={() => update({ afkOnly: !filter.afkOnly, hitlOnly: false })}
-		aria-pressed={filter.afkOnly}
+		pressed={filter.afkOnly}
+		onPressedChange={(pressed) => update({ afkOnly: pressed, hitlOnly: false })}
 		title="Show only AFK"
 	>
 		AFK
-	</Button>
+	</Toggle>
 
-	<Button
-		intent={filter.hitlOnly ? 'primary' : 'secondary'}
+	<Toggle
+		intent="outline"
 		size="sm"
 		class="h-6.5 text-[11px] font-semibold"
-		onclick={() => update({ hitlOnly: !filter.hitlOnly, afkOnly: false })}
-		aria-pressed={filter.hitlOnly}
+		pressed={filter.hitlOnly}
+		onPressedChange={(pressed) => update({ hitlOnly: pressed, afkOnly: false })}
 		title="Show only HITL"
 	>
 		HITL
-	</Button>
+	</Toggle>
 
 	{#if areaOptions.length > 0}
 		<Select

--- a/src/lib/components/blocks/workspace/DashboardCreateDialog.svelte
+++ b/src/lib/components/blocks/workspace/DashboardCreateDialog.svelte
@@ -4,6 +4,7 @@
 	import type { Dashboard } from '$lib/types/generated';
 	import * as Dialog from '$lib/components/shadcn/dialog/index.js';
 	import { Button } from '$lib/components/shadcn/button/index.js';
+	import * as ToggleGroup from '$lib/components/shadcn/toggle-group/index.js';
 	import { Input } from '$lib/components/shadcn/input/index.js';
 	import { Label } from '$lib/components/shadcn/label/index.js';
 	import { Checkbox } from '$lib/components/shadcn/checkbox/index.js';
@@ -82,26 +83,25 @@
 
 			<Dialog.Body class="flex flex-col gap-4">
 				<!-- Type selector -->
-				<div class="flex gap-2">
-					<Button
-						type="button"
-						intent={dashboardType === 'repo' ? 'primary' : 'secondary'}
-						size="sm"
-						class="flex-1"
-						onclick={() => (dashboardType = 'repo')}
-					>
+				<ToggleGroup.Root
+					type="single"
+					value={dashboardType}
+					onValueChange={(value: string) => {
+						if (value) {
+							dashboardType = value as 'repo' | 'portfolio';
+						}
+					}}
+					intent="outline"
+					size="sm"
+					class="flex gap-2"
+				>
+					<ToggleGroup.Item value="repo" class="flex-1">
 						◆ {m.dashboard_type_repo()}
-					</Button>
-					<Button
-						type="button"
-						intent={dashboardType === 'portfolio' ? 'primary' : 'secondary'}
-						size="sm"
-						class="flex-1"
-						onclick={() => (dashboardType = 'portfolio')}
-					>
+					</ToggleGroup.Item>
+					<ToggleGroup.Item value="portfolio" class="flex-1">
 						◇ {m.dashboard_type_portfolio()}
-					</Button>
-				</div>
+					</ToggleGroup.Item>
+				</ToggleGroup.Root>
 
 				<!-- Name -->
 				<div class="flex flex-col gap-1.5">

--- a/src/lib/components/shadcn/toggle-group/ToggleGroup.stories.svelte
+++ b/src/lib/components/shadcn/toggle-group/ToggleGroup.stories.svelte
@@ -1,0 +1,260 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import { expect, userEvent, waitFor, within } from 'storybook/test';
+	import * as ToggleGroup from './index.js';
+	import { TOGGLE_INTENTS, TOGGLE_SIZES } from '../toggle/index.js';
+
+	const { Story } = defineMeta({
+		title: 'Base/ToggleGroup',
+		component: ToggleGroup.Root,
+		tags: ['autodocs'],
+		argTypes: {
+			intent: { control: 'select', options: TOGGLE_INTENTS },
+			size: { control: 'select', options: TOGGLE_SIZES },
+		},
+	});
+
+	const playSingleSelect = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+		const canvas = within(canvasElement);
+		const items = canvas.getAllByRole('radio');
+
+		await expect(items[0]).toHaveAttribute('aria-checked', 'true');
+		await expect(items[1]).toHaveAttribute('aria-checked', 'false');
+		await expect(items[2]).toHaveAttribute('aria-checked', 'false');
+
+		items[1].click();
+		await waitFor(() => {
+			expect(items[0]).toHaveAttribute('aria-checked', 'false');
+			expect(items[1]).toHaveAttribute('aria-checked', 'true');
+		});
+	};
+
+	const playMultipleSelect = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+		const canvas = within(canvasElement);
+		const group = canvas.getByRole('group');
+		const groupCanvas = within(group);
+		const items = groupCanvas.getAllByRole('button');
+
+		items[0].click();
+		await waitFor(() => {
+			expect(items[0]).toHaveAttribute('data-state', 'on');
+		});
+
+		items[1].click();
+		await waitFor(() => {
+			expect(items[0]).toHaveAttribute('data-state', 'on');
+			expect(items[1]).toHaveAttribute('data-state', 'on');
+		});
+
+		items[0].click();
+		await waitFor(() => {
+			expect(items[0]).toHaveAttribute('data-state', 'off');
+			expect(items[1]).toHaveAttribute('data-state', 'on');
+		});
+	};
+
+	const playDisabledItemIgnored = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+		const canvas = within(canvasElement);
+		const items = canvas.getAllByRole('radio');
+
+		const disabledItem = items[2];
+		await expect(disabledItem).toHaveAttribute('data-disabled', '');
+		disabledItem.click();
+		await expect(disabledItem).toHaveAttribute('aria-checked', 'false');
+	};
+
+	const playKeyboardNavigation = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+		const canvas = within(canvasElement);
+		const items = canvas.getAllByRole('radio');
+
+		items[0].focus();
+		await expect(items[0]).toHaveFocus();
+
+		await userEvent.keyboard('{ArrowRight}');
+		await waitFor(() => {
+			expect(items[1]).toHaveFocus();
+		});
+
+		await userEvent.keyboard('{ArrowRight}');
+		await waitFor(() => {
+			expect(items[2]).toHaveFocus();
+		});
+
+		// Loop back to first
+		await userEvent.keyboard('{ArrowRight}');
+		await waitFor(() => {
+			expect(items[0]).toHaveFocus();
+		});
+	};
+</script>
+
+<script lang="ts">
+	import BoldIcon from '@lucide/svelte/icons/bold';
+	import ItalicIcon from '@lucide/svelte/icons/italic';
+	import UnderlineIcon from '@lucide/svelte/icons/underline';
+	import AlignLeftIcon from '@lucide/svelte/icons/align-left';
+	import AlignCenterIcon from '@lucide/svelte/icons/align-center';
+	import AlignRightIcon from '@lucide/svelte/icons/align-right';
+</script>
+
+<Story name="Single Select" play={playSingleSelect}>
+	{#snippet template(args: Record<string, unknown>)}
+		<ToggleGroup.Root type="single" value="left" {...args}>
+			<ToggleGroup.Item value="left" aria-label="Align left">
+				<AlignLeftIcon data-icon="inline-start" />
+				Left
+			</ToggleGroup.Item>
+			<ToggleGroup.Item value="center" aria-label="Align center">
+				<AlignCenterIcon data-icon="inline-start" />
+				Center
+			</ToggleGroup.Item>
+			<ToggleGroup.Item value="right" aria-label="Align right">
+				<AlignRightIcon data-icon="inline-start" />
+				Right
+			</ToggleGroup.Item>
+		</ToggleGroup.Root>
+	{/snippet}
+</Story>
+
+<Story name="Multiple Select" play={playMultipleSelect}>
+	{#snippet template(args: Record<string, unknown>)}
+		<ToggleGroup.Root type="multiple" {...args}>
+			<ToggleGroup.Item value="bold" aria-label="Bold">
+				<BoldIcon data-icon="inline-start" />
+				Bold
+			</ToggleGroup.Item>
+			<ToggleGroup.Item value="italic" aria-label="Italic">
+				<ItalicIcon data-icon="inline-start" />
+				Italic
+			</ToggleGroup.Item>
+			<ToggleGroup.Item value="underline" aria-label="Underline">
+				<UnderlineIcon data-icon="inline-start" />
+				Underline
+			</ToggleGroup.Item>
+		</ToggleGroup.Root>
+	{/snippet}
+</Story>
+
+<Story name="Outline Intent">
+	{#snippet template(args: Record<string, unknown>)}
+		<ToggleGroup.Root type="single" value="center" intent="outline" {...args}>
+			<ToggleGroup.Item value="left" aria-label="Align left">
+				<AlignLeftIcon data-icon="inline-start" />
+				Left
+			</ToggleGroup.Item>
+			<ToggleGroup.Item value="center" aria-label="Align center">
+				<AlignCenterIcon data-icon="inline-start" />
+				Center
+			</ToggleGroup.Item>
+			<ToggleGroup.Item value="right" aria-label="Align right">
+				<AlignRightIcon data-icon="inline-start" />
+				Right
+			</ToggleGroup.Item>
+		</ToggleGroup.Root>
+	{/snippet}
+</Story>
+
+<Story name="Disabled Item" play={playDisabledItemIgnored}>
+	{#snippet template(args: Record<string, unknown>)}
+		<ToggleGroup.Root type="single" value="left" {...args}>
+			<ToggleGroup.Item value="left" aria-label="Align left">
+				<AlignLeftIcon data-icon="inline-start" />
+				Left
+			</ToggleGroup.Item>
+			<ToggleGroup.Item value="center" aria-label="Align center">
+				<AlignCenterIcon data-icon="inline-start" />
+				Center
+			</ToggleGroup.Item>
+			<ToggleGroup.Item value="right" aria-label="Align right" disabled>
+				<AlignRightIcon data-icon="inline-start" />
+				Right
+			</ToggleGroup.Item>
+		</ToggleGroup.Root>
+	{/snippet}
+</Story>
+
+<Story name="Keyboard Navigation" play={playKeyboardNavigation}>
+	{#snippet template(args: Record<string, unknown>)}
+		<ToggleGroup.Root type="single" value="left" {...args}>
+			<ToggleGroup.Item value="left" aria-label="Align left">
+				<AlignLeftIcon data-icon="inline-start" />
+				Left
+			</ToggleGroup.Item>
+			<ToggleGroup.Item value="center" aria-label="Align center">
+				<AlignCenterIcon data-icon="inline-start" />
+				Center
+			</ToggleGroup.Item>
+			<ToggleGroup.Item value="right" aria-label="Align right">
+				<AlignRightIcon data-icon="inline-start" />
+				Right
+			</ToggleGroup.Item>
+		</ToggleGroup.Root>
+	{/snippet}
+</Story>
+
+<Story name="Icon Only">
+	{#snippet template(args: Record<string, unknown>)}
+		<ToggleGroup.Root type="single" value="left" size="icon" {...args}>
+			<ToggleGroup.Item value="left" aria-label="Align left">
+				<AlignLeftIcon />
+			</ToggleGroup.Item>
+			<ToggleGroup.Item value="center" aria-label="Align center">
+				<AlignCenterIcon />
+			</ToggleGroup.Item>
+			<ToggleGroup.Item value="right" aria-label="Align right">
+				<AlignRightIcon />
+			</ToggleGroup.Item>
+		</ToggleGroup.Root>
+	{/snippet}
+</Story>
+
+<Story name="All Variants">
+	{#snippet template(args: Record<string, unknown>)}
+		<div class="flex flex-col gap-6">
+			{#each TOGGLE_INTENTS as intent (intent)}
+				<div class="flex flex-col gap-2">
+					<span class="text-xs font-medium text-foreground-subtle">{intent}</span>
+					<div class="flex flex-col gap-3">
+						{#each TOGGLE_SIZES as size (size)}
+							<div class="flex items-center gap-2">
+								<span class="w-12 text-[10px] text-foreground-subtle">{size}</span>
+								<ToggleGroup.Root
+									{...args}
+									type="single"
+									value="center"
+									{intent}
+									{size}
+								>
+									<ToggleGroup.Item value="left" aria-label="Align left">
+										{#if size === 'icon' || size === 'icon-sm'}
+											<AlignLeftIcon />
+										{:else}
+											<AlignLeftIcon data-icon="inline-start" />
+											Left
+										{/if}
+									</ToggleGroup.Item>
+									<ToggleGroup.Item value="center" aria-label="Align center">
+										{#if size === 'icon' || size === 'icon-sm'}
+											<AlignCenterIcon />
+										{:else}
+											<AlignCenterIcon data-icon="inline-start" />
+											Center
+										{/if}
+									</ToggleGroup.Item>
+									<ToggleGroup.Item value="right" aria-label="Align right">
+										{#if size === 'icon' || size === 'icon-sm'}
+											<AlignRightIcon />
+										{:else}
+											<AlignRightIcon data-icon="inline-start" />
+											Right
+										{/if}
+									</ToggleGroup.Item>
+								</ToggleGroup.Root>
+							</div>
+						{/each}
+					</div>
+				</div>
+			{/each}
+		</div>
+	{/snippet}
+</Story>

--- a/src/lib/components/shadcn/toggle-group/ToggleGroup.svelte
+++ b/src/lib/components/shadcn/toggle-group/ToggleGroup.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+	import { ToggleGroup as ToggleGroupPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+	import { setContext } from 'svelte';
+	import type { ToggleGroupProps } from './toggle-group-variants.js';
+	import type { ToggleIntent, ToggleSize } from '../toggle/toggle-variants.js';
+
+	let {
+		class: className,
+		intent = 'default',
+		size = 'md',
+		children,
+		ref = $bindable(null),
+		...restProps
+	}: ToggleGroupProps = $props();
+
+	setContext<{ intent: ToggleIntent; size: ToggleSize }>('toggle-group', {
+		get intent() {
+			return intent;
+		},
+		get size() {
+			return size;
+		},
+	});
+</script>
+
+<ToggleGroupPrimitive.Root
+	bind:ref
+	data-slot="toggle-group"
+	class={cn('flex items-center gap-0.5', className)}
+	{...restProps}
+>
+	{@render children?.()}
+</ToggleGroupPrimitive.Root>

--- a/src/lib/components/shadcn/toggle-group/ToggleGroupItem.svelte
+++ b/src/lib/components/shadcn/toggle-group/ToggleGroupItem.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+	import { ToggleGroup as ToggleGroupPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+	import { getContext } from 'svelte';
+	import { toggleVariants } from '../toggle/toggle-variants.js';
+	import type { ToggleIntent, ToggleSize } from '../toggle/toggle-variants.js';
+	import type { ToggleGroupItemProps } from './toggle-group-variants.js';
+
+	let {
+		class: className,
+		intent,
+		size,
+		children,
+		ref = $bindable(null),
+		...restProps
+	}: ToggleGroupItemProps = $props();
+
+	const groupContext = getContext<{ intent: ToggleIntent; size: ToggleSize }>('toggle-group');
+
+	const resolvedIntent = $derived(intent ?? groupContext.intent);
+	const resolvedSize = $derived(size ?? groupContext.size);
+</script>
+
+<ToggleGroupPrimitive.Item
+	bind:ref
+	class={cn(toggleVariants({ intent: resolvedIntent, size: resolvedSize }), className)}
+	{...restProps}
+>
+	{#snippet child({ props })}
+		<button {...props} data-slot="toggle-group-item">
+			{@render children?.()}
+		</button>
+	{/snippet}
+</ToggleGroupPrimitive.Item>

--- a/src/lib/components/shadcn/toggle-group/index.ts
+++ b/src/lib/components/shadcn/toggle-group/index.ts
@@ -1,0 +1,5 @@
+import Root from './ToggleGroup.svelte';
+import Item from './ToggleGroupItem.svelte';
+
+export { Root, Root as ToggleGroup, Item, Item as ToggleGroupItem };
+export { type ToggleGroupProps, type ToggleGroupItemProps } from './toggle-group-variants.js';

--- a/src/lib/components/shadcn/toggle-group/toggle-group-variants.ts
+++ b/src/lib/components/shadcn/toggle-group/toggle-group-variants.ts
@@ -1,0 +1,15 @@
+import type { ToggleGroup as ToggleGroupPrimitive } from 'bits-ui';
+import type { WithoutChildrenOrChild } from '$lib/utils.js';
+import type { Snippet } from 'svelte';
+import type { ToggleIntent, ToggleSize } from '../toggle/toggle-variants.js';
+
+export type ToggleGroupProps = ToggleGroupPrimitive.RootProps & {
+	intent?: ToggleIntent;
+	size?: ToggleSize;
+};
+
+export type ToggleGroupItemProps = WithoutChildrenOrChild<ToggleGroupPrimitive.ItemProps> & {
+	intent?: ToggleIntent;
+	size?: ToggleSize;
+	children?: Snippet;
+};

--- a/src/lib/components/shadcn/toggle/Toggle.stories.svelte
+++ b/src/lib/components/shadcn/toggle/Toggle.stories.svelte
@@ -1,0 +1,139 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import { expect, userEvent, waitFor, within } from 'storybook/test';
+	import { Toggle, TOGGLE_INTENTS, TOGGLE_SIZES } from './index.js';
+
+	const { Story } = defineMeta({
+		title: 'Base/Toggle',
+		component: Toggle,
+		tags: ['autodocs'],
+		argTypes: {
+			intent: { control: 'select', options: TOGGLE_INTENTS },
+			size: { control: 'select', options: TOGGLE_SIZES },
+			disabled: { control: 'boolean' },
+		},
+	});
+
+	const playClickTogglesOn = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+		const canvas = within(canvasElement);
+		const toggle = canvas.getByRole('button', { name: /toggle bold/i });
+		await expect(toggle).toHaveAttribute('aria-pressed', 'false');
+		await expect(toggle).toHaveAttribute('data-state', 'off');
+		toggle.click();
+		await waitFor(() => {
+			expect(toggle).toHaveAttribute('aria-pressed', 'true');
+			expect(toggle).toHaveAttribute('data-state', 'on');
+		});
+	};
+
+	const playClickTogglesOff = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+		const canvas = within(canvasElement);
+		const toggle = canvas.getByRole('button', { name: /toggle bold/i });
+		await expect(toggle).toHaveAttribute('aria-pressed', 'true');
+		toggle.click();
+		await waitFor(() => {
+			expect(toggle).toHaveAttribute('aria-pressed', 'false');
+			expect(toggle).toHaveAttribute('data-state', 'off');
+		});
+	};
+
+	const playDisabledIgnoresClick = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+		const canvas = within(canvasElement);
+		const toggle = canvas.getByRole('button', { name: /toggle bold/i });
+		await expect(toggle).toHaveAttribute('aria-pressed', 'false');
+		toggle.click();
+		await expect(toggle).toHaveAttribute('aria-pressed', 'false');
+	};
+
+	const playSpaceKeyToggles = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+		const canvas = within(canvasElement);
+		const toggle = canvas.getByRole('button', { name: /toggle bold/i });
+		await expect(toggle).toHaveAttribute('aria-pressed', 'false');
+		toggle.focus();
+		await userEvent.keyboard(' ');
+		await waitFor(() => {
+			expect(toggle).toHaveAttribute('aria-pressed', 'true');
+		});
+		await userEvent.keyboard(' ');
+		await waitFor(() => {
+			expect(toggle).toHaveAttribute('aria-pressed', 'false');
+		});
+	};
+</script>
+
+<script lang="ts">
+	import type { ToggleProps } from './toggle-variants.js';
+	import BoldIcon from '@lucide/svelte/icons/bold';
+	import ItalicIcon from '@lucide/svelte/icons/italic';
+</script>
+
+<Story name="Off" play={playClickTogglesOn}>
+	{#snippet template(args: ToggleProps)}
+		<Toggle {...args} aria-label="Toggle bold">
+			<BoldIcon data-icon="inline-start" />
+			Bold
+		</Toggle>
+	{/snippet}
+</Story>
+
+<Story name="On" play={playClickTogglesOff}>
+	{#snippet template(args: ToggleProps)}
+		<Toggle {...args} pressed aria-label="Toggle bold">
+			<BoldIcon data-icon="inline-start" />
+			Bold
+		</Toggle>
+	{/snippet}
+</Story>
+
+<Story name="Disabled" play={playDisabledIgnoresClick}>
+	{#snippet template(args: ToggleProps)}
+		<Toggle {...args} disabled aria-label="Toggle bold">
+			<BoldIcon data-icon="inline-start" />
+			Bold
+		</Toggle>
+	{/snippet}
+</Story>
+
+<Story name="Space Key Toggles" play={playSpaceKeyToggles}>
+	{#snippet template(args: ToggleProps)}
+		<Toggle {...args} aria-label="Toggle bold">
+			<BoldIcon data-icon="inline-start" />
+			Bold
+		</Toggle>
+	{/snippet}
+</Story>
+
+<Story name="Icon Only">
+	{#snippet template(args: ToggleProps)}
+		<Toggle {...args} size="icon" aria-label="Toggle italic">
+			<ItalicIcon />
+		</Toggle>
+	{/snippet}
+</Story>
+
+<Story name="All Variants">
+	{#snippet template(args: ToggleProps)}
+		<div class="flex flex-col gap-6">
+			{#each TOGGLE_INTENTS as intent (intent)}
+				<div class="flex flex-col gap-2">
+					<span class="text-xs font-medium text-foreground-subtle">{intent}</span>
+					<div class="flex items-center gap-3">
+						{#each TOGGLE_SIZES as size (size)}
+							<div class="flex flex-col items-center gap-1">
+								<span class="text-[10px] text-foreground-subtle">{size}</span>
+								<Toggle {...args} {intent} {size} aria-label="Bold">
+									{#if size === 'icon' || size === 'icon-sm'}
+										<BoldIcon />
+									{:else}
+										<BoldIcon data-icon="inline-start" />
+										Bold
+									{/if}
+								</Toggle>
+							</div>
+						{/each}
+					</div>
+				</div>
+			{/each}
+		</div>
+	{/snippet}
+</Story>

--- a/src/lib/components/shadcn/toggle/Toggle.svelte
+++ b/src/lib/components/shadcn/toggle/Toggle.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	import { Toggle as TogglePrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+	import { toggleVariants, type ToggleProps } from './toggle-variants.js';
+
+	let {
+		class: className,
+		intent = 'default',
+		size = 'md',
+		ref = $bindable(null),
+		children,
+		...restProps
+	}: ToggleProps = $props();
+</script>
+
+<TogglePrimitive.Root
+	bind:ref
+	class={cn(toggleVariants({ intent, size }), className)}
+	{...restProps}
+>
+	{#snippet child({ props })}
+		<button {...props} data-slot="toggle">
+			{@render children?.()}
+		</button>
+	{/snippet}
+</TogglePrimitive.Root>

--- a/src/lib/components/shadcn/toggle/index.ts
+++ b/src/lib/components/shadcn/toggle/index.ts
@@ -1,0 +1,11 @@
+import Root from './Toggle.svelte';
+
+export { Root, Root as Toggle };
+export {
+	toggleVariants,
+	type ToggleProps,
+	type ToggleIntent,
+	type ToggleSize,
+	TOGGLE_INTENTS,
+	TOGGLE_SIZES,
+} from './toggle-variants.js';

--- a/src/lib/components/shadcn/toggle/toggle-variants.ts
+++ b/src/lib/components/shadcn/toggle/toggle-variants.ts
@@ -1,0 +1,39 @@
+import type { Toggle as TogglePrimitive } from 'bits-ui';
+import type { WithoutChildrenOrChild } from '$lib/utils.js';
+import type { Snippet } from 'svelte';
+import { tv } from 'tailwind-variants';
+
+export const toggleVariants = tv({
+	base: 'inline-flex shrink-0 items-center justify-center gap-1.5 whitespace-nowrap rounded-md border border-transparent font-medium leading-none outline-none select-none transition-[background,border-color,color,transform,filter,box-shadow] duration-120 ease-[ease] active:scale-[0.96] focus-visible:outline-2 focus-visible:outline-solid focus-visible:outline-offset-2 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-45 [&_[data-icon]]:pointer-events-none [&_[data-icon]]:shrink-0',
+	variants: {
+		intent: {
+			default:
+				'bg-transparent text-foreground-muted hover:bg-surface-2 hover:text-foreground data-[state=on]:bg-surface-2 data-[state=on]:text-foreground',
+			outline:
+				'border-border bg-surface-2 text-foreground hover:bg-surface-3 hover:border-border-strong data-[state=on]:bg-primary data-[state=on]:text-primary-foreground data-[state=on]:border-transparent',
+		},
+		size: {
+			sm: 'h-(--size-control-sm) px-2.25 text-(length:--text-sm) rounded-sm [&_[data-icon]]:size-3.5',
+			md: 'h-(--size-control-md) px-3 text-(length:--text-md) [&_[data-icon]]:size-4',
+			lg: 'h-(--size-control-lg) px-4 text-(length:--text-base) [&_[data-icon]]:size-4',
+			icon: 'size-(--size-control-md) p-0 [&_[data-icon]]:size-4',
+			'icon-sm': 'size-(--size-control-sm) p-0 [&_[data-icon]]:size-3.5',
+		},
+	},
+	defaultVariants: {
+		intent: 'default',
+		size: 'md',
+	},
+});
+
+export type ToggleIntent = keyof typeof toggleVariants.variants.intent;
+export type ToggleSize = keyof typeof toggleVariants.variants.size;
+
+export const TOGGLE_INTENTS = Object.keys(toggleVariants.variants.intent) as ToggleIntent[];
+export const TOGGLE_SIZES = Object.keys(toggleVariants.variants.size) as ToggleSize[];
+
+export type ToggleProps = WithoutChildrenOrChild<TogglePrimitive.RootProps> & {
+	intent?: ToggleIntent;
+	size?: ToggleSize;
+	children?: Snippet;
+};

--- a/src/lib/modules/ai-config/components/ProviderSwitcher.svelte
+++ b/src/lib/modules/ai-config/components/ProviderSwitcher.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { useAiConfig } from '../ai_config.context.svelte.js';
-	import { Button } from '$lib/components/shadcn/button/index.js';
+	import * as ToggleGroup from '$lib/components/shadcn/toggle-group/index.js';
 	import { SimpleTooltip } from '$lib/components/shadcn/tooltip/index.js';
 	import type { ProviderKind } from '$lib/types/generated';
 	import type { InstalledProvider } from '$lib/types/generated';
@@ -21,34 +21,35 @@
 	const providerKinds: ProviderKind[] = ['claude-code', 'open-code', 'codex', 'cursor'];
 </script>
 
-<div class="flex items-center gap-1 rounded-lg border border-border bg-surface-2 p-1">
+<ToggleGroup.Root
+	type="single"
+	value={aiConfig.provider}
+	onValueChange={(value: string) => {
+		if (value) {
+			aiConfig.setProvider(value as ProviderKind);
+		}
+	}}
+	size="sm"
+	class="rounded-lg border border-border bg-surface-2 p-1"
+>
 	{#each providerKinds as kind (kind)}
 		{@const installed = getInstalled(kind)}
 		{@const isInstalled = installed?.installed ?? false}
-		{@const isActive = aiConfig.provider === kind}
 
 		{#if isInstalled}
-			<Button
-				intent={isActive ? 'secondary' : 'ghost'}
-				size="sm"
-				aria-pressed={isActive}
-				onclick={() => aiConfig.setProvider(kind)}
-				class="h-7 px-3 text-xs font-medium"
-			>
+			<ToggleGroup.Item value={kind} class="h-7 px-3 text-xs font-medium">
 				{PROVIDER_LABELS[kind]}
-			</Button>
+			</ToggleGroup.Item>
 		{:else}
 			<SimpleTooltip text="Not installed">
-				<Button
-					intent="ghost"
-					size="sm"
+				<ToggleGroup.Item
+					value={kind}
 					disabled
-					aria-pressed={false}
 					class="h-7 cursor-not-allowed px-3 text-xs font-medium opacity-40"
 				>
 					{PROVIDER_LABELS[kind]}
-				</Button>
+				</ToggleGroup.Item>
 			</SimpleTooltip>
 		{/if}
 	{/each}
-</div>
+</ToggleGroup.Root>

--- a/src/lib/modules/ai-config/components/SettingsPanel.svelte
+++ b/src/lib/modules/ai-config/components/SettingsPanel.svelte
@@ -4,7 +4,7 @@
 	import { useAiConfig } from '../ai_config.context.svelte.js';
 	import { SETTINGS_BY_PROVIDER, type SettingDefinition } from './settings_definitions.js';
 	import * as Alert from '$lib/components/shadcn/alert/index.js';
-	import { Button } from '$lib/components/shadcn/button/index.js';
+	import * as ToggleGroup from '$lib/components/shadcn/toggle-group/index.js';
 	import { Input } from '$lib/components/shadcn/input/index.js';
 	import { Switch } from '$lib/components/shadcn/switch/index.js';
 	import { Select } from '$lib/components/shadcn/select/index.js';
@@ -128,26 +128,20 @@
 <div class="flex flex-col gap-4">
 	<div class="flex items-center gap-2">
 		<span class="text-xs font-medium text-foreground-subtle">Scope</span>
-		<div class="inline-flex rounded-md border border-border bg-surface-2 p-0.5">
-			<Button
-				intent={scope === 'user' ? 'secondary' : 'ghost'}
-				size="sm"
-				class="h-7 px-3 text-xs"
-				aria-pressed={scope === 'user'}
-				onclick={() => (scope = 'user')}
-			>
-				User
-			</Button>
-			<Button
-				intent={scope === 'project' ? 'secondary' : 'ghost'}
-				size="sm"
-				class="h-7 px-3 text-xs"
-				aria-pressed={scope === 'project'}
-				onclick={() => (scope = 'project')}
-			>
-				Project
-			</Button>
-		</div>
+		<ToggleGroup.Root
+			type="single"
+			value={scope}
+			onValueChange={(value: string) => {
+				if (value) {
+					scope = value as SettingsScope;
+				}
+			}}
+			size="sm"
+			class="rounded-md border border-border bg-surface-2 p-0.5"
+		>
+			<ToggleGroup.Item value="user" class="h-7 px-3 text-xs">User</ToggleGroup.Item>
+			<ToggleGroup.Item value="project" class="h-7 px-3 text-xs">Project</ToggleGroup.Item>
+		</ToggleGroup.Root>
 	</div>
 
 	<Alert.Root>
@@ -257,23 +251,23 @@
 								{/each}
 							</Select>
 						{:else if def.control.type === 'segmented'}
-							<div
-								class="inline-flex rounded-md border border-border bg-surface-2 p-0.5"
+							<ToggleGroup.Root
+								type="single"
+								value={valueAsString(current)}
+								onValueChange={(value: string) => {
+									if (value) {
+										void save(def.key, value);
+									}
+								}}
+								size="sm"
+								class="rounded-md border border-border bg-surface-2 p-0.5"
 							>
 								{#each def.control.options as option (option.value)}
-									<Button
-										intent={valueAsString(current) === option.value
-											? 'secondary'
-											: 'ghost'}
-										size="sm"
-										class="h-7 px-2 text-xs"
-										aria-pressed={valueAsString(current) === option.value}
-										onclick={() => save(def.key, option.value)}
-									>
+									<ToggleGroup.Item value={option.value} class="h-7 px-2 text-xs">
 										{option.label}
-									</Button>
+									</ToggleGroup.Item>
 								{/each}
-							</div>
+							</ToggleGroup.Root>
 						{/if}
 					</div>
 				</div>

--- a/src/lib/modules/ai-config/components/ViewModeToggle.svelte
+++ b/src/lib/modules/ai-config/components/ViewModeToggle.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import LayoutGridIcon from '@lucide/svelte/icons/layout-grid';
 	import ListIcon from '@lucide/svelte/icons/list';
-	import { Button } from '$lib/components/shadcn/button/index.js';
+	import * as ToggleGroup from '$lib/components/shadcn/toggle-group/index.js';
 	import { useAiConfig } from '../ai_config.context.svelte.js';
 	import type { AiConfigTab } from '../ai_config.context.svelte.js';
 
@@ -14,25 +14,20 @@
 	const aiConfig = useAiConfig();
 </script>
 
-<div class="flex items-center gap-0.5">
-	<Button
-		intent="ghost"
-		size="icon-sm"
-		aria-pressed={aiConfig.viewModeFor(tab) === 'card'}
-		aria-label="Card view"
-		onclick={() => aiConfig.setViewModeFor(tab, 'card')}
-		class={aiConfig.viewModeFor(tab) === 'card' ? 'bg-surface-2 text-foreground' : ''}
-	>
-		<LayoutGridIcon data-icon="inline-end" />
-	</Button>
-	<Button
-		intent="ghost"
-		size="icon-sm"
-		aria-pressed={aiConfig.viewModeFor(tab) === 'list'}
-		aria-label="List view"
-		onclick={() => aiConfig.setViewModeFor(tab, 'list')}
-		class={aiConfig.viewModeFor(tab) === 'list' ? 'bg-surface-2 text-foreground' : ''}
-	>
-		<ListIcon data-icon="inline-end" />
-	</Button>
-</div>
+<ToggleGroup.Root
+	type="single"
+	value={aiConfig.viewModeFor(tab)}
+	onValueChange={(value: string) => {
+		if (value) {
+			aiConfig.setViewModeFor(tab, value as 'card' | 'list');
+		}
+	}}
+	size="icon-sm"
+>
+	<ToggleGroup.Item value="card" aria-label="Card view">
+		<LayoutGridIcon />
+	</ToggleGroup.Item>
+	<ToggleGroup.Item value="list" aria-label="List view">
+		<ListIcon />
+	</ToggleGroup.Item>
+</ToggleGroup.Root>

--- a/src/routes/overview/+page.svelte
+++ b/src/routes/overview/+page.svelte
@@ -11,6 +11,7 @@
 	import GitHubAuthWizard from '$lib/components/blocks/github-auth/GitHubAuthWizard.svelte';
 	import * as Popover from '$lib/components/shadcn/popover/index.js';
 	import { Button } from '$lib/components/shadcn/button/index.js';
+	import { Toggle } from '$lib/components/shadcn/toggle/index.js';
 	import GithubIcon from '$lib/components/derived/icons/GithubIcon.svelte';
 	import ArchiveIcon from '@lucide/svelte/icons/archive';
 	import type { OverviewWorkspaceData } from '$lib/types/generated';
@@ -70,15 +71,15 @@
 			<p class="text-sm text-muted-foreground">{m.overview_subtitle()}</p>
 		</div>
 		<div class="flex items-center gap-2">
-			<Button
-				intent={showArchived ? 'primary' : 'secondary'}
+			<Toggle
+				intent="outline"
 				size="icon"
-				onclick={() => (showArchived = !showArchived)}
+				pressed={showArchived}
+				onPressedChange={(pressed) => (showArchived = pressed)}
 				aria-label="Toggle archived workspaces"
-				aria-pressed={showArchived}
 			>
-				<ArchiveIcon data-icon="inline-end" />
-			</Button>
+				<ArchiveIcon />
+			</Toggle>
 			<Popover.Root>
 				<Popover.Trigger>
 					{#snippet child({ props })}


### PR DESCRIPTION
## Summary

- Add `Toggle` and `ToggleGroup` shadcn components backed by bits-ui primitives with custom variants matching Grovekeeper design tokens (default/outline intents, sm/md/lg/icon/icon-sm sizes)
- Migrate 7 existing toggle-like button patterns (DependencyGraphFilterBar, ViewModeToggle, SettingsPanel scope + segmented, ProviderSwitcher, DashboardCreateDialog, overview archive toggle)
- Add Storybook pages with autodocs + 19 play tests covering pressed state, disabled, keyboard navigation, and variant grids

## Test plan

- [x] All 19 Toggle/ToggleGroup play tests pass (click, disabled, space key, keyboard nav, single/multiple select)
- [x] Existing DependencyGraphView play tests still pass (aria-pressed queries on filter toggles)
- [x] Full test suite: 1535/1536 pass (1 pre-existing flaky timeout in color_picker)
- [x] `pnpm check:all` passes (format + oxlint + fallow + svelte-check + eslint)
- [x] ThemeDecorator intentionally NOT migrated — adds role="radio" that interferes with other story play tests

Fixes #306