### PR TITLE
#308 feat(ui): adopt Command component from shadcn-svelte

### DIFF
--- a/messages/cs.json
+++ b/messages/cs.json
@@ -293,7 +293,6 @@
 	"command_palette_navigate": "navigovat",
 	"command_palette_select": "vybrat",
 	"command_palette_close": "zavřít",
-	"command_palette_results": "{count} výsledků",
 	"command_palette_no_results": "Žádné výsledky",
 
 	"shortcuts_title": "Keyboard Shortcuts",

--- a/messages/en.json
+++ b/messages/en.json
@@ -310,7 +310,6 @@
 	"command_palette_navigate": "navigate",
 	"command_palette_select": "select",
 	"command_palette_close": "close",
-	"command_palette_results": "{count} results",
 	"command_palette_no_results": "No results found",
 
 	"shortcuts_title": "Keyboard Shortcuts",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
 	},
 	"devDependencies": {
 		"@chromatic-com/storybook": "^5.1.1",
-		"@lucide/svelte": "^1.14.0",
+		"@lucide/svelte": "^1.16.0",
 		"@playwright/test": "^1.58.2",
 		"@storybook/addon-a11y": "^10.3.3",
 		"@storybook/addon-docs": "^10.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,8 +63,8 @@ importers:
                 specifier: ^5.1.1
                 version: 5.1.1(storybook@10.3.3(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
             '@lucide/svelte':
-                specifier: ^1.14.0
-                version: 1.14.0(svelte@5.55.0)
+                specifier: ^1.16.0
+                version: 1.16.0(svelte@5.55.0)
             '@playwright/test':
                 specifier: ^1.58.2
                 version: 1.58.2
@@ -1220,10 +1220,10 @@ packages:
                 integrity: sha512-jBeALB6prAbtr5q4vTuxnRZZv1M2rKe8iNqRQhFJ4Tv7150unEa0vKyz0hs8Gl3fUGsWaNJBh3J8++fpbrpRBQ==,
             }
 
-    '@lucide/svelte@1.14.0':
+    '@lucide/svelte@1.16.0':
         resolution:
             {
-                integrity: sha512-MVuP5VRCBQa2OaIpaRbuEV4k5OV2dy9MyxA6Tf4Sz/IN0v3zzUU72ObHc9r2Zn/wSMXDg6lLrHrczqI7w7gCzQ==,
+                integrity: sha512-AvvPJnaWxeiNkAljI5MsSEc84yHPLMaWQIAJOcbX7k9au/f9ITS7cxTTQiautDiOFKVOXiYdZ+d6mtl88J+Kbg==,
             }
         peerDependencies:
             svelte: ^5
@@ -6155,7 +6155,7 @@ snapshots:
 
     '@lix-js/server-protocol-schema@0.1.1': {}
 
-    '@lucide/svelte@1.14.0(svelte@5.55.0)':
+    '@lucide/svelte@1.16.0(svelte@5.55.0)':
         dependencies:
             svelte: 5.55.0
 

--- a/src/lib/components/blocks/command-palette/CommandPalette.stories.svelte
+++ b/src/lib/components/blocks/command-palette/CommandPalette.stories.svelte
@@ -17,7 +17,6 @@
 		return document.querySelector('[role="dialog"]') as HTMLElement | null;
 	}
 
-	/** Wait for the portaled dialog to appear in the DOM. */
 	async function waitForDialog(): Promise<HTMLElement> {
 		let dialog: HTMLElement | null = null;
 		await waitFor(() => {
@@ -29,20 +28,19 @@
 		return dialog!;
 	}
 
-	function getSearchInput() {
+	function getCommandInput() {
 		const dialog = getDialog();
-		return dialog?.querySelector('input') as HTMLInputElement | null;
+		return dialog?.querySelector('[data-command-input]') as HTMLInputElement | null;
 	}
 
-	function getResultOptions() {
+	function getCommandItems() {
 		const dialog = getDialog();
 		if (!dialog) {
 			return [];
 		}
-		return [...dialog.querySelectorAll('[role="option"]')] as HTMLElement[];
+		return [...dialog.querySelectorAll('[data-command-item]')] as HTMLElement[];
 	}
 
-	/** Assert dialog is closed (either absent or data-state="closed"). */
 	async function expectDialogClosed() {
 		const dialog = getDialog();
 		if (dialog) {
@@ -58,7 +56,7 @@
 	const playSearchInputFocused = async () => {
 		await waitForDialog();
 
-		const searchInput = getSearchInput();
+		const searchInput = getCommandInput();
 		await expect(searchInput).toBeInTheDocument();
 		await waitFor(() => expect(searchInput).toHaveFocus());
 	};
@@ -66,85 +64,75 @@
 	const playFilterResults = async () => {
 		await waitForDialog();
 
-		const searchInput = getSearchInput()!;
-		const optionsBefore = getResultOptions();
-		await expect(optionsBefore.length).toBeGreaterThan(1);
+		const searchInput = getCommandInput()!;
+		await waitFor(() => {
+			const items = getCommandItems();
+			expect(items.length).toBeGreaterThan(1);
+		});
 
-		// Type "settings" — should filter to "Go to Settings"
 		await userEvent.clear(searchInput);
 		await userEvent.type(searchInput, 'settings');
 
-		const optionsAfter = getResultOptions();
-		await expect(optionsAfter.length).toBe(1);
-		await expect(optionsAfter[0]).toHaveTextContent(/go to settings/i);
+		await waitFor(() => {
+			const optionsAfter = getCommandItems();
+			expect(optionsAfter.length).toBe(1);
+			expect(optionsAfter[0]).toHaveTextContent(/go to settings/i);
+		});
 	};
 
 	const playArrowDownHighlights = async () => {
 		await waitForDialog();
 
-		// Wait for search input to be focused (rAF-deferred) — keyboard events
-		// dispatch on activeElement so focus must be inside Dialog.Content for
-		// the keydown handler to fire.
-		const searchInput = getSearchInput()!;
+		const searchInput = getCommandInput()!;
 		await waitFor(() => expect(searchInput).toHaveFocus());
 
-		// Wait for options to render and first item to be selected (async Svelte state)
 		await waitFor(() => {
-			const options = getResultOptions();
-			expect(options.length).toBeGreaterThan(1);
-			expect(options[0]).toHaveAttribute('aria-selected', 'true');
+			const items = getCommandItems();
+			expect(items.length).toBeGreaterThan(1);
+			expect(items[0]).toHaveAttribute('data-selected');
 		});
 
-		// ArrowDown → second item highlighted (waitFor: Svelte reactive update is async)
 		await userEvent.keyboard('{ArrowDown}');
 		await waitFor(() => {
-			const optionsAfterArrow = getResultOptions();
-			expect(optionsAfterArrow[1]).toHaveAttribute('aria-selected', 'true');
-			expect(optionsAfterArrow[0]).toHaveAttribute('aria-selected', 'false');
+			const items = getCommandItems();
+			expect(items[1]).toHaveAttribute('data-selected');
+			expect(items[0]).not.toHaveAttribute('data-selected');
 		});
 	};
 
 	const playEnterExecutesAndCloses = async () => {
 		await waitForDialog();
 
-		const options = getResultOptions();
-		await expect(options.length).toBeGreaterThan(0);
+		await waitFor(() => {
+			const items = getCommandItems();
+			expect(items.length).toBeGreaterThan(0);
+		});
 
-		// Click first option directly to execute and close
-		await userEvent.click(options[0]);
+		const items = getCommandItems();
+		items[0].click();
 
-		// Palette should close
 		await expectDialogClosed();
 	};
 
 	const playEscapeCloses = async () => {
 		await waitForDialog();
 
-		// Press Escape
 		await userEvent.keyboard('{Escape}');
 
-		// Palette should close
 		await expectDialogClosed();
 	};
 
 	const playEscapeContainment = async () => {
 		await waitForDialog();
 
-		// Attach a document-level keydown spy BEFORE pressing Escape
 		const documentKeydownSpy = fn();
 		document.addEventListener('keydown', documentKeydownSpy);
 
 		try {
-			// Reset spy
 			documentKeydownSpy.mockClear();
 
-			// Press Escape — should close palette
 			await userEvent.keyboard('{Escape}');
 			await expectDialogClosed();
-
-			// The Escape keydown reaches document (bits-ui behavior), but the dialog
-			// intercepted and closed itself. We verify at minimum the dialog closed
-			// before any page-level handler could act on it.
 		} finally {
 			document.removeEventListener('keydown', documentKeydownSpy);
 		}

--- a/src/lib/components/blocks/command-palette/CommandPalette.svelte
+++ b/src/lib/components/blocks/command-palette/CommandPalette.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
+	import { tick } from 'svelte';
 	import ArrowDownIcon from '@lucide/svelte/icons/arrow-down';
 	import ArrowUpIcon from '@lucide/svelte/icons/arrow-up';
 	import CornerDownLeftIcon from '@lucide/svelte/icons/corner-down-left';
@@ -24,7 +25,7 @@
 	function handleDialogOpenChange(isOpen: boolean) {
 		paletteCtx.open = isOpen;
 		if (isOpen) {
-			requestAnimationFrame(() => {
+			void tick().then(() => {
 				const input = document.querySelector<HTMLInputElement>('[data-command-input]');
 				input?.focus();
 			});

--- a/src/lib/components/blocks/command-palette/CommandPalette.svelte
+++ b/src/lib/components/blocks/command-palette/CommandPalette.svelte
@@ -32,14 +32,19 @@
 
 	function handleDialogOpenChange(isOpen: boolean) {
 		paletteCtx.open = isOpen;
-		if (isOpen) {
-			requestAnimationFrame(focusCommandInput);
-		}
+	}
+
+	function handleOpenAutoFocus(event: Event) {
+		event.preventDefault();
+		focusCommandInput();
 	}
 </script>
 
 <Dialog.Root open={paletteCtx.open} onOpenChange={handleDialogOpenChange}>
-	<Dialog.Content class="top-[20%] translate-y-0 max-w-135 overflow-hidden p-0">
+	<Dialog.Content
+		class="top-[20%] translate-y-0 max-w-135 overflow-hidden p-0"
+		onOpenAutoFocus={handleOpenAutoFocus}
+	>
 		<Dialog.Title class="sr-only">{m.command_palette_title()}</Dialog.Title>
 
 		<Command.Root loop>

--- a/src/lib/components/blocks/command-palette/CommandPalette.svelte
+++ b/src/lib/components/blocks/command-palette/CommandPalette.svelte
@@ -3,10 +3,8 @@
 	import ArrowDownIcon from '@lucide/svelte/icons/arrow-down';
 	import ArrowUpIcon from '@lucide/svelte/icons/arrow-up';
 	import CornerDownLeftIcon from '@lucide/svelte/icons/corner-down-left';
-	import SearchIcon from '@lucide/svelte/icons/search';
 	import * as Dialog from '$lib/components/shadcn/dialog/index.js';
-	import * as Popover from '$lib/components/shadcn/popover/index.js';
-	import { Input } from '$lib/components/shadcn/input/index.js';
+	import * as Command from '$lib/components/shadcn/command/index.js';
 	import { Kbd } from '$lib/components/shadcn/kbd/index.js';
 	import { Badge } from '$lib/components/shadcn/badge/index.js';
 	import {
@@ -17,7 +15,7 @@
 
 	const paletteCtx = useCommandPalette();
 
-	let searchInputElement = $state<HTMLInputElement | null>(null);
+	let searchInputRef = $state<HTMLInputElement | null>(null);
 
 	const CATEGORY_LABELS: Record<CommandPaletteCategory, () => string> = {
 		[COMMAND_PALETTE_CATEGORIES.actions]: () => m.command_palette_actions(),
@@ -25,109 +23,71 @@
 		[COMMAND_PALETTE_CATEGORIES.issues]: () => m.command_palette_issues(),
 	};
 
-	function handleKeydown(event: KeyboardEvent) {
-		if (event.key === 'ArrowDown') {
-			event.preventDefault();
-			paletteCtx.selectNext();
-		} else if (event.key === 'ArrowUp') {
-			event.preventDefault();
-			paletteCtx.selectPrevious();
-		} else if (event.key === 'Enter') {
-			event.preventDefault();
-			paletteCtx.executeSelected();
-		}
-	}
-
 	function handleDialogOpenChange(isOpen: boolean) {
 		paletteCtx.open = isOpen;
 		if (isOpen) {
 			requestAnimationFrame(() => {
-				searchInputElement?.focus();
+				searchInputRef?.focus();
 			});
 		}
 	}
 </script>
 
 <Dialog.Root open={paletteCtx.open} onOpenChange={handleDialogOpenChange}>
-	<Dialog.Content
-		class="top-[20%] translate-y-0 max-w-135 overflow-hidden p-0"
-		onkeydown={handleKeydown}
-	>
+	<Dialog.Content class="top-[20%] translate-y-0 max-w-135 overflow-hidden p-0">
 		<Dialog.Title class="sr-only">{m.command_palette_title()}</Dialog.Title>
 
-		<!-- Search row -->
-		<div class="flex items-center gap-2.5 border-b border-border px-3.5 py-3">
-			<SearchIcon size={14} class="shrink-0 text-foreground-subtle" />
-			<Input
-				bind:ref={searchInputElement}
-				class="h-6 flex-1 border-none bg-transparent py-0 pl-2 text-sm shadow-none outline-none focus-visible:shadow-none placeholder:text-foreground-subtle"
-				placeholder={m.command_palette_placeholder()}
-				value={paletteCtx.query}
-				oninput={(event) => {
-					paletteCtx.query = event.currentTarget.value;
-				}}
-			/>
-			<Kbd>Esc</Kbd>
-		</div>
+		<Command.Root loop>
+			<div class="border-b border-border">
+				<Command.Input
+					bind:ref={searchInputRef}
+					placeholder={m.command_palette_placeholder()}
+				/>
+			</div>
 
-		<!-- Results area -->
-		<div class="max-h-80 overflow-y-auto p-1.5">
-			{#each [...paletteCtx.groupedResults] as [category, items], groupIndex (category)}
-				{#if groupIndex > 0}
-					<Popover.Divider />
-				{/if}
-
-				<Popover.Label>{CATEGORY_LABELS[category]()}</Popover.Label>
-
-				{#each items as item (item.id)}
-					{@const flatIdx = paletteCtx.flatIndexByItemId.get(item.id) ?? -1}
-					{@const isSelected = flatIdx === paletteCtx.selectedIndex}
-					<Popover.Item
-						active={isSelected}
-						role="option"
-						aria-selected={isSelected}
-						tabindex={-1}
-						class="data-[state=active]:bg-surface-2"
-						onclick={() => paletteCtx.executeItem(item)}
-						onkeydown={(event) => {
-							if (event.key === 'Enter') {
-								event.preventDefault();
-								paletteCtx.executeItem(item);
-							}
-						}}
-						onmouseenter={() => {
-							paletteCtx.selectedIndex = flatIdx;
-						}}
-					>
-						<span class="truncate">{item.label}</span>
-						<span class="ml-auto flex shrink-0 items-center gap-1.5">
-							{#if item.shortcut}
-								<Kbd format="mono">{item.shortcut}</Kbd>
-							{/if}
-							{#if item.description}
-								{#if item.category === COMMAND_PALETTE_CATEGORIES.issues}
-									<Badge
-										tone={item.description === 'active' ? 'success' : 'neutral'}
-									>
-										{item.description}
-									</Badge>
-								{:else}
-									<span class="text-(length:--text-2xs) text-foreground-subtle">
-										{item.description}
-									</span>
-								{/if}
-							{/if}
-						</span>
-					</Popover.Item>
+			<Command.List class="max-h-80 p-1.5">
+				{#each [...paletteCtx.groupedResults] as [category, items] (category)}
+					<Command.Group heading={CATEGORY_LABELS[category]()}>
+						{#each items as item (item.id)}
+							<Command.Item
+								value={item.label}
+								onSelect={() => paletteCtx.executeItem(item)}
+							>
+								<span class="truncate">{item.label}</span>
+								<span class="ml-auto flex shrink-0 items-center gap-1.5">
+									{#if item.shortcut}
+										<Command.Shortcut>
+											<Kbd format="mono">{item.shortcut}</Kbd>
+										</Command.Shortcut>
+									{/if}
+									{#if item.description}
+										{#if item.category === COMMAND_PALETTE_CATEGORIES.issues}
+											<Badge
+												tone={item.description === 'active'
+													? 'success'
+													: 'neutral'}
+											>
+												{item.description}
+											</Badge>
+										{:else}
+											<span
+												class="text-(length:--text-2xs) text-foreground-subtle"
+											>
+												{item.description}
+											</span>
+										{/if}
+									{/if}
+								</span>
+							</Command.Item>
+						{/each}
+					</Command.Group>
 				{/each}
-			{/each}
 
-			{#if paletteCtx.resultCount === 0 && paletteCtx.query.trim() !== ''}
-				<div class="px-2 py-4 text-center text-sm text-foreground-subtle">
+				<Command.Empty>
 					{m.command_palette_no_results()}
-				</div>
-			{/if}
-		</div>
+				</Command.Empty>
+			</Command.List>
+		</Command.Root>
 
 		<!-- Footer -->
 		<div
@@ -144,9 +104,6 @@
 			<span class="flex items-center gap-1">
 				<Kbd>Esc</Kbd>
 				{m.command_palette_close()}
-			</span>
-			<span class="ml-auto">
-				{m.command_palette_results({ count: paletteCtx.resultCount })}
 			</span>
 		</div>
 	</Dialog.Content>

--- a/src/lib/components/blocks/command-palette/CommandPalette.svelte
+++ b/src/lib/components/blocks/command-palette/CommandPalette.svelte
@@ -15,8 +15,6 @@
 
 	const paletteCtx = useCommandPalette();
 
-	let searchInputRef = $state<HTMLInputElement | null>(null);
-
 	const CATEGORY_LABELS: Record<CommandPaletteCategory, () => string> = {
 		[COMMAND_PALETTE_CATEGORIES.actions]: () => m.command_palette_actions(),
 		[COMMAND_PALETTE_CATEGORIES.navigation]: () => m.command_palette_navigation(),
@@ -27,7 +25,8 @@
 		paletteCtx.open = isOpen;
 		if (isOpen) {
 			requestAnimationFrame(() => {
-				searchInputRef?.focus();
+				const input = document.querySelector<HTMLInputElement>('[data-command-input]');
+				input?.focus();
 			});
 		}
 	}
@@ -39,10 +38,7 @@
 
 		<Command.Root loop>
 			<div class="border-b border-border">
-				<Command.Input
-					bind:ref={searchInputRef}
-					placeholder={m.command_palette_placeholder()}
-				/>
+				<Command.Input placeholder={m.command_palette_placeholder()} />
 			</div>
 
 			<Command.List class="max-h-80 p-1.5">

--- a/src/lib/components/blocks/command-palette/CommandPalette.svelte
+++ b/src/lib/components/blocks/command-palette/CommandPalette.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
-	import { tick } from 'svelte';
 	import ArrowDownIcon from '@lucide/svelte/icons/arrow-down';
 	import ArrowUpIcon from '@lucide/svelte/icons/arrow-up';
 	import CornerDownLeftIcon from '@lucide/svelte/icons/corner-down-left';
@@ -22,13 +21,19 @@
 		[COMMAND_PALETTE_CATEGORIES.issues]: () => m.command_palette_issues(),
 	};
 
+	function focusCommandInput() {
+		const input = document.querySelector<HTMLInputElement>('[data-command-input]');
+		if (input) {
+			input.focus();
+		} else {
+			requestAnimationFrame(focusCommandInput);
+		}
+	}
+
 	function handleDialogOpenChange(isOpen: boolean) {
 		paletteCtx.open = isOpen;
 		if (isOpen) {
-			void tick().then(() => {
-				const input = document.querySelector<HTMLInputElement>('[data-command-input]');
-				input?.focus();
-			});
+			requestAnimationFrame(focusCommandInput);
 		}
 	}
 </script>

--- a/src/lib/components/blocks/creation-wizard/CreationWizard.svelte
+++ b/src/lib/components/blocks/creation-wizard/CreationWizard.svelte
@@ -120,6 +120,8 @@
 	function handleEnter(event: KeyboardEvent) {
 		switch (wizard.currentStep) {
 			case WIZARD_STEPS.GITHUB_SEARCH:
+				event.preventDefault();
+				githubSearchRef?.confirm();
 				break;
 			case WIZARD_STEPS.ISSUE_NAME:
 				event.preventDefault();

--- a/src/lib/components/blocks/creation-wizard/CreationWizard.svelte
+++ b/src/lib/components/blocks/creation-wizard/CreationWizard.svelte
@@ -93,10 +93,6 @@
 
 		switch (wizard.currentStep) {
 			case WIZARD_STEPS.GITHUB_SEARCH:
-				if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
-					event.preventDefault();
-					githubSearchRef?.handleArrow(event.key === 'ArrowDown' ? 1 : -1);
-				}
 				break;
 			case WIZARD_STEPS.WORKTREE_CHOICE:
 				if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
@@ -124,8 +120,6 @@
 	function handleEnter(event: KeyboardEvent) {
 		switch (wizard.currentStep) {
 			case WIZARD_STEPS.GITHUB_SEARCH:
-				event.preventDefault();
-				githubSearchRef?.confirm();
 				break;
 			case WIZARD_STEPS.ISSUE_NAME:
 				event.preventDefault();

--- a/src/lib/components/blocks/creation-wizard/StepGithubSearch.svelte
+++ b/src/lib/components/blocks/creation-wizard/StepGithubSearch.svelte
@@ -57,9 +57,18 @@
 		}
 		wizard.skipGithubSearch();
 	}
+
+	function handleKeydown(event: KeyboardEvent) {
+		if (event.key === 'Enter') {
+			event.preventDefault();
+			event.stopPropagation();
+			confirm();
+		}
+	}
 </script>
 
-<div class="flex flex-col gap-3">
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="flex flex-col gap-3" onkeydown={handleKeydown}>
 	<Command.Root shouldFilter={false} bind:value={commandValue} class="bg-transparent">
 		<div class="relative">
 			<Command.Input

--- a/src/lib/components/blocks/creation-wizard/StepGithubSearch.svelte
+++ b/src/lib/components/blocks/creation-wizard/StepGithubSearch.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
-	import { SearchField } from '$lib/components/base/search-field/index.js';
-	import { onMount, untrack } from 'svelte';
+	import * as Command from '$lib/components/shadcn/command/index.js';
+	import { onMount } from 'svelte';
 	import { useCreationWizard } from '$lib/modules/creation-wizard';
 	import type { AssignedIssue, SearchedGithubIssue } from '$lib/types/generated';
 	import CircleDot from '@lucide/svelte/icons/circle-dot';
@@ -16,38 +16,14 @@
 
 	const wizard = useCreationWizard();
 
-	let selectedIndex = $state(-1);
-	let arrowDisplayValue = $state('');
-	let isArrowSelecting = $state(false);
+	let commandValue = $state('');
 	let inputElement = $state<HTMLInputElement | null>(null);
-	let listElement = $state<HTMLDivElement | null>(null);
 
 	const displayItems = $derived.by(() => {
 		if (wizard.searchQuery.trim() !== '') {
 			return wizard.searchResults;
 		}
 		return assignedIssues;
-	});
-
-	const inputDisplayValue = $derived(isArrowSelecting ? arrowDisplayValue : wizard.searchQuery);
-
-	$effect(() => {
-		void displayItems.length;
-		untrack(() => {
-			selectedIndex = -1;
-			isArrowSelecting = false;
-			arrowDisplayValue = '';
-		});
-	});
-
-	$effect(() => {
-		const index = selectedIndex;
-		if (listElement && index >= 0) {
-			const child = listElement.querySelector(
-				`[data-index="${index}"]`,
-			) as HTMLElement | null;
-			child?.scrollIntoView({ block: 'nearest' });
-		}
 	});
 
 	onMount(() => {
@@ -63,111 +39,81 @@
 		};
 	}
 
-	function moveSelection(delta: number) {
-		if (displayItems.length === 0) {
-			return;
-		}
-
-		if (selectedIndex === -1) {
-			selectedIndex = delta > 0 ? 0 : displayItems.length - 1;
-		} else {
-			selectedIndex = (selectedIndex + delta + displayItems.length) % displayItems.length;
-		}
-
-		const item = displayItems[selectedIndex];
-		arrowDisplayValue = `#${item.number} ${item.title}`;
-		isArrowSelecting = true;
-	}
-
-	function confirmSelection() {
-		if (selectedIndex >= 0 && selectedIndex < displayItems.length) {
-			wizard.selectGithubIssue(toSearchedIssue(displayItems[selectedIndex]));
-		} else {
-			wizard.skipGithubSearch();
+	function handleSelect(itemNumber: number) {
+		const item = displayItems.find((i) => i.number === itemNumber);
+		if (item) {
+			wizard.selectGithubIssue(toSearchedIssue(item));
 		}
 	}
 
 	export function confirm() {
-		confirmSelection();
-	}
-
-	export function handleArrow(delta: number) {
-		moveSelection(delta);
-	}
-
-	function handleKeydown(event: KeyboardEvent) {
-		if (event.key === 'ArrowDown') {
-			event.preventDefault();
-			moveSelection(1);
-		} else if (event.key === 'ArrowUp') {
-			event.preventDefault();
-			moveSelection(-1);
-		} else if (event.key === 'Enter') {
-			event.preventDefault();
-			event.stopPropagation();
-			confirmSelection();
+		if (commandValue && displayItems.length > 0) {
+			const itemNumber = Number(commandValue);
+			const item = displayItems.find((i) => i.number === itemNumber);
+			if (item) {
+				wizard.selectGithubIssue(toSearchedIssue(item));
+				return;
+			}
 		}
-	}
-
-	function handleInput(event: Event) {
-		const target = event.currentTarget as HTMLInputElement;
-		isArrowSelecting = false;
-		arrowDisplayValue = '';
-		wizard.updateSearchQuery(target.value);
+		wizard.skipGithubSearch();
 	}
 </script>
 
-<!-- svelte-ignore a11y_no_static_element_interactions -->
-<div class="flex flex-col gap-3" onkeydown={handleKeydown}>
-	<SearchField
-		bind:ref={inputElement}
-		value={inputDisplayValue}
-		oninput={handleInput}
-		placeholder={m.wizard_search_placeholder()}
-	>
-		{#if wizard.searching}
-			<Loader2
-				size={14}
-				class="absolute right-3 top-1/2 -translate-y-1/2 animate-spin text-muted-foreground"
+<div class="flex flex-col gap-3">
+	<Command.Root shouldFilter={false} bind:value={commandValue} class="bg-transparent">
+		<div class="relative">
+			<Command.Input
+				bind:ref={inputElement}
+				bind:value={wizard.searchQuery}
+				placeholder={m.wizard_search_placeholder()}
 			/>
-		{/if}
-	</SearchField>
-
-	{#if wizard.skipNotice}
-		<p class="text-center text-xs text-muted-foreground">{m.wizard_search_skipping()}</p>
-	{:else if wizard.searchQuery.trim() !== '' && !wizard.searching && wizard.searchResults.length === 0}
-		<div class="flex flex-col items-center gap-2 py-4 text-sm text-muted-foreground">
-			<p>{m.wizard_search_empty()}</p>
-		</div>
-	{:else if displayItems.length > 0}
-		<div bind:this={listElement} class="flex max-h-90 flex-col gap-0.5 overflow-y-auto">
-			{#if wizard.searchQuery.trim() === '' && assignedIssues.length > 0}
-				<p
-					class="px-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground/60"
-				>
-					{m.wizard_assigned_heading()}
-				</p>
+			{#if wizard.searching}
+				<Loader2
+					size={14}
+					class="absolute right-3 top-1/2 -translate-y-1/2 animate-spin text-muted-foreground"
+				/>
 			{/if}
-			{#each displayItems as item, index (item.number)}
-				<button
-					type="button"
-					data-index={index}
-					onclick={() => wizard.selectGithubIssue(toSearchedIssue(item))}
-					class="flex items-center gap-2 rounded px-2 py-1.5 text-left text-sm transition-colors
-						{index === selectedIndex
-						? 'bg-primary-soft text-foreground'
-						: 'text-foreground hover:bg-surface-hover'}"
-				>
-					{#if item.state === 'OPEN'}
-						<CircleDot size={14} class="shrink-0 text-gh-open" />
-					{:else}
-						<CircleCheck size={14} class="shrink-0 text-gh-closed" />
-					{/if}
-					<span class="min-w-0 truncate">#{item.number} {item.title}</span>
-				</button>
-			{/each}
 		</div>
-	{/if}
+
+		<Command.List class="max-h-90">
+			{#if wizard.skipNotice}
+				<p class="text-center text-xs text-muted-foreground">
+					{m.wizard_search_skipping()}
+				</p>
+			{:else if wizard.searchQuery.trim() !== '' && !wizard.searching && wizard.searchResults.length === 0}
+				<Command.Empty>
+					{m.wizard_search_empty()}
+				</Command.Empty>
+			{:else if displayItems.length > 0}
+				{#snippet issueItem(item: AssignedIssue | SearchedGithubIssue)}
+					<Command.Item
+						value={String(item.number)}
+						onSelect={() => handleSelect(item.number)}
+						class="gap-2"
+					>
+						{#if item.state === 'OPEN'}
+							<CircleDot class="shrink-0 text-gh-open" />
+						{:else}
+							<CircleCheck class="shrink-0 text-gh-closed" />
+						{/if}
+						<span class="min-w-0 truncate">#{item.number} {item.title}</span>
+					</Command.Item>
+				{/snippet}
+
+				{#if wizard.searchQuery.trim() === '' && assignedIssues.length > 0}
+					<Command.Group heading={m.wizard_assigned_heading()}>
+						{#each displayItems as item (item.number)}
+							{@render issueItem(item)}
+						{/each}
+					</Command.Group>
+				{:else}
+					{#each displayItems as item (item.number)}
+						{@render issueItem(item)}
+					{/each}
+				{/if}
+			{/if}
+		</Command.List>
+	</Command.Root>
 
 	<button
 		type="button"

--- a/src/lib/components/blocks/creation-wizard/creation_wizard_stories_play.ts
+++ b/src/lib/components/blocks/creation-wizard/creation_wizard_stories_play.ts
@@ -13,12 +13,17 @@ function getVisibleDialog(): HTMLElement {
 	return dialog;
 }
 
+function getCommandInput(dialog: HTMLElement): HTMLInputElement | null {
+	return dialog.querySelector('[data-command-input]') as HTMLInputElement | null;
+}
+
 export const playOpensAtStep1 = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
 	const dialog = getVisibleDialog();
 	const dialogCanvas = within(dialog);
 	await expect(dialog).toBeVisible();
 	await expect(dialogCanvas.getByText('Search GitHub Issues')).toBeVisible();
-	await expect(dialogCanvas.getByRole('searchbox')).toBeVisible();
+	const input = getCommandInput(dialog);
+	await expect(input).toBeInTheDocument();
 	await expect(canvasElement.children.length).toBeGreaterThan(0);
 };
 
@@ -34,8 +39,18 @@ export const playEnterAdvancesToStep2 = async () => {
 	const dialog = getVisibleDialog();
 	const dialogCanvas = within(dialog);
 	await expect(dialog).toBeVisible();
+
+	const input = getCommandInput(dialog);
+	await waitFor(() => expect(input).toHaveFocus());
+
+	await waitFor(() => {
+		const items = dialog.querySelectorAll('[data-command-item]');
+		expect(items.length).toBeGreaterThan(0);
+		expect(items[0]).toHaveAttribute('data-selected');
+	});
+
 	await userEvent.keyboard('{Enter}');
-	await expect(dialogCanvas.getByText('Issue Name')).toBeVisible();
+	await waitFor(() => expect(dialogCanvas.getByText('Issue Name')).toBeVisible());
 	await expect(dialogCanvas.getByPlaceholderText('Issue name')).toBeVisible();
 };
 
@@ -45,10 +60,6 @@ export const playBackspaceGoesBack = async () => {
 	await expect(dialog).toBeVisible();
 	await expect(dialogCanvas.getByText('Issue Name')).toBeVisible();
 
-	// The wizard's Backspace handler (on svelte:window) navigates back only when no
-	// text input is focused. bits-ui focus-traps the dialog asynchronously, so we must
-	// blur the input and dispatch the Backspace event synchronously in the same
-	// microtask — preventing the focus trap from restoring focus before the handler runs.
 	const input = dialogCanvas.getByPlaceholderText('Issue name') as HTMLInputElement;
 	input.blur();
 	window.dispatchEvent(

--- a/src/lib/components/derived/split-button/SplitButton.svelte
+++ b/src/lib/components/derived/split-button/SplitButton.svelte
@@ -16,7 +16,7 @@
 		onselect,
 	}: SplitButtonProps = $props();
 
-	let selectedValue = $state(defaultValue);
+	let selectedValue = $state('');
 
 	let selectedLabel = $derived(
 		options.find((option) => option.value === selectedValue)?.label ?? selectedValue,
@@ -35,6 +35,7 @@
 	}
 
 	onMount(() => {
+		selectedValue = defaultValue;
 		if (settingsKey !== undefined && settingsKey !== '') {
 			void getAppSetting(settingsKey).then((setting) => {
 				if (setting !== null && setting.value !== '') {

--- a/src/lib/components/shadcn/command/Command.stories.svelte
+++ b/src/lib/components/shadcn/command/Command.stories.svelte
@@ -13,23 +13,12 @@
 	/*  Helpers                                                            */
 	/* ------------------------------------------------------------------ */
 
-	function getCommandRoot(canvas: HTMLElement) {
-		return canvas.querySelector('[data-slot="command"]') as HTMLElement | null;
-	}
-
 	function getCommandInput(canvas: HTMLElement) {
 		return canvas.querySelector('[data-command-input]') as HTMLInputElement | null;
 	}
 
 	function getCommandItems(canvas: HTMLElement) {
 		return [...canvas.querySelectorAll('[data-command-item]')] as HTMLElement[];
-	}
-
-	function getVisibleCommandItems(canvas: HTMLElement) {
-		return getCommandItems(canvas).filter((item) => {
-			const parent = item.closest('[data-command-group]');
-			return parent ? getComputedStyle(parent).display !== 'none' : true;
-		});
 	}
 
 	function getCommandEmpty(canvas: HTMLElement) {

--- a/src/lib/components/shadcn/command/Command.stories.svelte
+++ b/src/lib/components/shadcn/command/Command.stories.svelte
@@ -1,0 +1,247 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import { expect, userEvent, waitFor } from 'storybook/test';
+	import CommandRoot from './command.svelte';
+
+	const { Story } = defineMeta({
+		title: 'Base/Command',
+		component: CommandRoot,
+		tags: ['autodocs'],
+	});
+
+	/* ------------------------------------------------------------------ */
+	/*  Helpers                                                            */
+	/* ------------------------------------------------------------------ */
+
+	function getCommandRoot(canvas: HTMLElement) {
+		return canvas.querySelector('[data-slot="command"]') as HTMLElement | null;
+	}
+
+	function getCommandInput(canvas: HTMLElement) {
+		return canvas.querySelector('[data-command-input]') as HTMLInputElement | null;
+	}
+
+	function getCommandItems(canvas: HTMLElement) {
+		return [...canvas.querySelectorAll('[data-command-item]')] as HTMLElement[];
+	}
+
+	function getVisibleCommandItems(canvas: HTMLElement) {
+		return getCommandItems(canvas).filter((item) => {
+			const parent = item.closest('[data-command-group]');
+			return parent ? getComputedStyle(parent).display !== 'none' : true;
+		});
+	}
+
+	function getCommandEmpty(canvas: HTMLElement) {
+		return canvas.querySelector('[data-command-empty]') as HTMLElement | null;
+	}
+
+	function getGroupHeadings(canvas: HTMLElement) {
+		return [...canvas.querySelectorAll('[data-command-group-heading]')] as HTMLElement[];
+	}
+
+	/* ------------------------------------------------------------------ */
+	/*  Play tests                                                        */
+	/* ------------------------------------------------------------------ */
+
+	const playKeyboardNavigation = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+		const input = getCommandInput(canvasElement)!;
+		await waitFor(() => expect(input).toBeInTheDocument());
+		input.focus();
+
+		await waitFor(() => {
+			const items = getCommandItems(canvasElement);
+			expect(items.length).toBeGreaterThan(1);
+			expect(items[0]).toHaveAttribute('data-selected');
+		});
+
+		await userEvent.keyboard('{ArrowDown}');
+		await waitFor(() => {
+			const items = getCommandItems(canvasElement);
+			expect(items[1]).toHaveAttribute('data-selected');
+			expect(items[0]).not.toHaveAttribute('data-selected');
+		});
+
+		await userEvent.keyboard('{ArrowUp}');
+		await waitFor(() => {
+			const items = getCommandItems(canvasElement);
+			expect(items[0]).toHaveAttribute('data-selected');
+		});
+	};
+
+	const playFiltering = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+		const input = getCommandInput(canvasElement)!;
+		await waitFor(() => expect(input).toBeInTheDocument());
+		input.focus();
+
+		await waitFor(() => {
+			const items = getCommandItems(canvasElement);
+			expect(items.length).toBeGreaterThan(2);
+		});
+
+		await userEvent.type(input, 'calendar');
+
+		await waitFor(() => {
+			const items = getCommandItems(canvasElement);
+			const visibleCount = items.filter(
+				(item) => getComputedStyle(item).display !== 'none',
+			).length;
+			expect(visibleCount).toBeLessThanOrEqual(1);
+		});
+	};
+
+	const playEmptyState = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+		const input = getCommandInput(canvasElement)!;
+		input.focus();
+
+		await userEvent.type(input, 'xyznonexistent');
+
+		await waitFor(() => {
+			const empty = getCommandEmpty(canvasElement);
+			expect(empty).toBeVisible();
+			expect(empty).toHaveTextContent(/no results/i);
+		});
+	};
+
+	const playGroupHeadings = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+		await waitFor(() => {
+			const headings = getGroupHeadings(canvasElement);
+			expect(headings.length).toBeGreaterThanOrEqual(2);
+		});
+
+		const headings = getGroupHeadings(canvasElement);
+		const headingTexts = headings.map((h) => h.textContent?.trim());
+		expect(headingTexts).toContain('Navigation');
+		expect(headingTexts).toContain('Actions');
+	};
+</script>
+
+<script lang="ts">
+	import * as Command from './index.js';
+	import SettingsIcon from '@lucide/svelte/icons/settings';
+	import UserIcon from '@lucide/svelte/icons/user';
+	import HomeIcon from '@lucide/svelte/icons/home';
+	import MoonIcon from '@lucide/svelte/icons/moon';
+	import PaletteIcon from '@lucide/svelte/icons/palette';
+</script>
+
+<Story name="Default" play={playKeyboardNavigation}>
+	{#snippet template()}
+		<div class="w-100">
+			<Command.Root class="rounded-xl border border-border shadow-md">
+				<Command.Input placeholder="Search commands..." />
+				<Command.List>
+					<Command.Group heading="Navigation">
+						<Command.Item value="Go to Dashboard">
+							<HomeIcon />
+							<span>Go to Dashboard</span>
+						</Command.Item>
+						<Command.Item value="Go to Settings">
+							<SettingsIcon />
+							<span>Go to Settings</span>
+						</Command.Item>
+						<Command.Item value="Go to Profile">
+							<UserIcon />
+							<span>Go to Profile</span>
+						</Command.Item>
+					</Command.Group>
+					<Command.Separator />
+					<Command.Group heading="Actions">
+						<Command.Item value="Toggle Theme">
+							<MoonIcon />
+							<span>Toggle Theme</span>
+						</Command.Item>
+						<Command.Item value="Change Color">
+							<PaletteIcon />
+							<span>Change Color</span>
+						</Command.Item>
+					</Command.Group>
+					<Command.Empty>No results found.</Command.Empty>
+				</Command.List>
+			</Command.Root>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="With Groups" play={playGroupHeadings}>
+	{#snippet template()}
+		<div class="w-100">
+			<Command.Root class="rounded-xl border border-border shadow-md">
+				<Command.Input placeholder="Search..." />
+				<Command.List>
+					<Command.Group heading="Navigation">
+						<Command.Item value="Dashboard"><HomeIcon /> Dashboard</Command.Item>
+						<Command.Item value="Settings"><SettingsIcon /> Settings</Command.Item>
+					</Command.Group>
+					<Command.Separator />
+					<Command.Group heading="Actions">
+						<Command.Item value="Toggle Theme"><MoonIcon /> Toggle Theme</Command.Item>
+					</Command.Group>
+					<Command.Empty>No results found.</Command.Empty>
+				</Command.List>
+			</Command.Root>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Empty State" play={playEmptyState}>
+	{#snippet template()}
+		<div class="w-100">
+			<Command.Root class="rounded-xl border border-border shadow-md">
+				<Command.Input placeholder="Type to search..." />
+				<Command.List>
+					<Command.Group heading="Items">
+						<Command.Item value="Alpha">Alpha</Command.Item>
+						<Command.Item value="Bravo">Bravo</Command.Item>
+					</Command.Group>
+					<Command.Empty>No results found.</Command.Empty>
+				</Command.List>
+			</Command.Root>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="Filtering" play={playFiltering}>
+	{#snippet template()}
+		<div class="w-100">
+			<Command.Root class="rounded-xl border border-border shadow-md">
+				<Command.Input placeholder="Filter items..." />
+				<Command.List>
+					<Command.Group heading="Fruits">
+						<Command.Item value="Apple">Apple</Command.Item>
+						<Command.Item value="Banana">Banana</Command.Item>
+						<Command.Item value="Cherry">Cherry</Command.Item>
+					</Command.Group>
+					<Command.Empty>No results found.</Command.Empty>
+				</Command.List>
+			</Command.Root>
+		</div>
+	{/snippet}
+</Story>
+
+<Story name="With Shortcuts">
+	{#snippet template()}
+		<div class="w-100">
+			<Command.Root class="rounded-xl border border-border shadow-md">
+				<Command.Input placeholder="Search..." />
+				<Command.List>
+					<Command.Group heading="Actions">
+						<Command.Item value="Copy">
+							<span>Copy</span>
+							<Command.Shortcut>⌘C</Command.Shortcut>
+						</Command.Item>
+						<Command.Item value="Paste">
+							<span>Paste</span>
+							<Command.Shortcut>⌘V</Command.Shortcut>
+						</Command.Item>
+						<Command.Item value="Cut">
+							<span>Cut</span>
+							<Command.Shortcut>⌘X</Command.Shortcut>
+						</Command.Item>
+					</Command.Group>
+					<Command.Empty>No results found.</Command.Empty>
+				</Command.List>
+			</Command.Root>
+		</div>
+	{/snippet}
+</Story>

--- a/src/lib/components/shadcn/command/command-dialog.svelte
+++ b/src/lib/components/shadcn/command/command-dialog.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+	import type { Command as CommandPrimitive, Dialog as DialogPrimitive } from 'bits-ui';
+	import type { Snippet } from 'svelte';
+	import Command from './command.svelte';
+	import * as Dialog from '$lib/components/shadcn/dialog/index.js';
+	import { cn, type WithoutChildrenOrChild } from '$lib/utils.js';
+
+	let {
+		open = $bindable(false),
+		ref = $bindable(null),
+		value = $bindable(''),
+		title = 'Command Palette',
+		description = 'Search for a command to run...',
+		portalProps,
+		children,
+		class: className,
+		...restProps
+	}: WithoutChildrenOrChild<DialogPrimitive.RootProps> &
+		WithoutChildrenOrChild<CommandPrimitive.RootProps> & {
+			portalProps?: DialogPrimitive.PortalProps;
+			children: Snippet;
+			title?: string;
+			description?: string;
+			class?: string;
+		} = $props();
+</script>
+
+<Dialog.Root bind:open>
+	<Dialog.Content
+		class={cn('rounded-xl! top-1/3 translate-y-0 overflow-hidden p-0', className)}
+		{portalProps}
+	>
+		<Dialog.Header class="sr-only">
+			<Dialog.Title>{title}</Dialog.Title>
+			<Dialog.Description>{description}</Dialog.Description>
+		</Dialog.Header>
+		<Command {...restProps} bind:value bind:ref {children} />
+	</Dialog.Content>
+</Dialog.Root>

--- a/src/lib/components/shadcn/command/command-empty.svelte
+++ b/src/lib/components/shadcn/command/command-empty.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { Command as CommandPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: CommandPrimitive.EmptyProps = $props();
+</script>
+
+<CommandPrimitive.Empty
+	bind:ref
+	data-slot="command-empty"
+	class={cn('py-6 text-center text-sm', className)}
+	{...restProps}
+/>

--- a/src/lib/components/shadcn/command/command-group.svelte
+++ b/src/lib/components/shadcn/command/command-group.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+	import { Command as CommandPrimitive, useId } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		heading,
+		value,
+		...restProps
+	}: CommandPrimitive.GroupProps & {
+		heading?: string;
+	} = $props();
+</script>
+
+<CommandPrimitive.Group
+	bind:ref
+	data-slot="command-group"
+	class={cn(
+		'text-foreground **:[[data-command-group-heading]]:text-muted-foreground overflow-hidden p-1 **:[[data-command-group-heading]]:px-2 **:[[data-command-group-heading]]:py-1.5 **:[[data-command-group-heading]]:text-xs **:[[data-command-group-heading]]:font-medium',
+		className,
+	)}
+	value={value ?? heading ?? `----${useId()}`}
+	{...restProps}
+>
+	{#if heading}
+		<CommandPrimitive.GroupHeading
+			class="text-muted-foreground px-2 py-1.5 text-xs font-medium"
+		>
+			{heading}
+		</CommandPrimitive.GroupHeading>
+	{/if}
+	<CommandPrimitive.GroupItems {children} />
+</CommandPrimitive.Group>

--- a/src/lib/components/shadcn/command/command-input.svelte
+++ b/src/lib/components/shadcn/command/command-input.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+	import { Command as CommandPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+	import * as InputGroup from '$lib/components/shadcn/input-group/index.js';
+	import SearchIcon from '@lucide/svelte/icons/search';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		value = $bindable(''),
+		...restProps
+	}: CommandPrimitive.InputProps = $props();
+</script>
+
+<div data-slot="command-input-wrapper" class="p-1 pb-0">
+	<InputGroup.Root
+		class="bg-input/30 border-input/30 h-8! rounded-lg! shadow-none! *:data-[slot=input-group-addon]:pl-2!"
+	>
+		<CommandPrimitive.Input
+			{value}
+			data-slot="command-input"
+			class={cn(
+				'w-full text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50',
+				className,
+			)}
+			{...restProps}
+		>
+			{#snippet child({ props })}
+				<InputGroup.Input {...props} bind:value bind:ref />
+			{/snippet}
+		</CommandPrimitive.Input>
+		<InputGroup.Addon>
+			<SearchIcon class="size-4 shrink-0 opacity-50" />
+		</InputGroup.Addon>
+	</InputGroup.Root>
+</div>

--- a/src/lib/components/shadcn/command/command-item.svelte
+++ b/src/lib/components/shadcn/command/command-item.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import { Command as CommandPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+	import CheckIcon from '@lucide/svelte/icons/check';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: CommandPrimitive.ItemProps = $props();
+</script>
+
+<CommandPrimitive.Item
+	bind:ref
+	data-slot="command-item"
+	class={cn(
+		"group/command-item data-selected:bg-muted data-selected:text-foreground data-selected:*:[svg]:text-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none in-data-[slot=dialog-content]:rounded-lg! data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+		className,
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+	<CheckIcon
+		class="cn-command-item-indicator ml-auto opacity-0 group-has-[[data-slot=command-shortcut]]/command-item:hidden group-data-[checked=true]/command-item:opacity-100"
+	/>
+</CommandPrimitive.Item>

--- a/src/lib/components/shadcn/command/command-link-item.svelte
+++ b/src/lib/components/shadcn/command/command-link-item.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { Command as CommandPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: CommandPrimitive.LinkItemProps = $props();
+</script>
+
+<CommandPrimitive.LinkItem
+	bind:ref
+	data-slot="command-item"
+	class={cn(
+		"group/command-item data-selected:bg-muted data-selected:text-foreground data-selected:*:[svg]:text-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+		className,
+	)}
+	{...restProps}
+/>

--- a/src/lib/components/shadcn/command/command-list.svelte
+++ b/src/lib/components/shadcn/command/command-list.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { Command as CommandPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: CommandPrimitive.ListProps = $props();
+</script>
+
+<CommandPrimitive.List
+	bind:ref
+	data-slot="command-list"
+	class={cn(
+		'no-scrollbar max-h-72 scroll-py-1 outline-none overflow-x-hidden overflow-y-auto',
+		className,
+	)}
+	{...restProps}
+/>

--- a/src/lib/components/shadcn/command/command-loading.svelte
+++ b/src/lib/components/shadcn/command/command-loading.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Command as CommandPrimitive } from 'bits-ui';
+
+	let { ref = $bindable(null), ...restProps }: CommandPrimitive.LoadingProps = $props();
+</script>
+
+<CommandPrimitive.Loading bind:ref {...restProps} />

--- a/src/lib/components/shadcn/command/command-separator.svelte
+++ b/src/lib/components/shadcn/command/command-separator.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { Command as CommandPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: CommandPrimitive.SeparatorProps = $props();
+</script>
+
+<CommandPrimitive.Separator
+	bind:ref
+	data-slot="command-separator"
+	class={cn('bg-border -mx-1 h-px w-auto', className)}
+	{...restProps}
+/>

--- a/src/lib/components/shadcn/command/command-shortcut.svelte
+++ b/src/lib/components/shadcn/command/command-shortcut.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from '$lib/utils.js';
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLSpanElement>> = $props();
+</script>
+
+<span
+	bind:this={ref}
+	data-slot="command-shortcut"
+	class={cn(
+		'text-muted-foreground group-data-selected/command-item:text-foreground ml-auto text-xs tracking-widest',
+		className,
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</span>

--- a/src/lib/components/shadcn/command/command.svelte
+++ b/src/lib/components/shadcn/command/command.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+	import { Command as CommandPrimitive } from 'bits-ui';
+
+	export type CommandRootApi = CommandPrimitive.Root;
+
+	let {
+		api = $bindable(null),
+		ref = $bindable(null),
+		value = $bindable(''),
+		class: className,
+		...restProps
+	}: CommandPrimitive.RootProps & {
+		api?: CommandRootApi | null;
+	} = $props();
+</script>
+
+<CommandPrimitive.Root
+	bind:this={api}
+	bind:value
+	bind:ref
+	data-slot="command"
+	class={cn(
+		'bg-popover text-popover-foreground rounded-xl! p-1 flex size-full flex-col overflow-hidden',
+		className,
+	)}
+	{...restProps}
+/>

--- a/src/lib/components/shadcn/command/index.ts
+++ b/src/lib/components/shadcn/command/index.ts
@@ -1,0 +1,37 @@
+import Root from './command.svelte';
+import Loading from './command-loading.svelte';
+import Dialog from './command-dialog.svelte';
+import Empty from './command-empty.svelte';
+import Group from './command-group.svelte';
+import Item from './command-item.svelte';
+import Input from './command-input.svelte';
+import List from './command-list.svelte';
+import Separator from './command-separator.svelte';
+import Shortcut from './command-shortcut.svelte';
+import LinkItem from './command-link-item.svelte';
+
+export {
+	Root,
+	Dialog,
+	Empty,
+	Group,
+	Item,
+	LinkItem,
+	Input,
+	List,
+	Separator,
+	Shortcut,
+	Loading,
+	//
+	Root as Command,
+	Dialog as CommandDialog,
+	Empty as CommandEmpty,
+	Group as CommandGroup,
+	Item as CommandItem,
+	LinkItem as CommandLinkItem,
+	Input as CommandInput,
+	List as CommandList,
+	Separator as CommandSeparator,
+	Shortcut as CommandShortcut,
+	Loading as CommandLoading,
+};

--- a/src/lib/components/shadcn/input-group/index.ts
+++ b/src/lib/components/shadcn/input-group/index.ts
@@ -1,0 +1,22 @@
+import Root from './input-group.svelte';
+import Addon from './input-group-addon.svelte';
+import Button from './input-group-button.svelte';
+import Input from './input-group-input.svelte';
+import Text from './input-group-text.svelte';
+import Textarea from './input-group-textarea.svelte';
+
+export {
+	Root,
+	Addon,
+	Button,
+	Input,
+	Text,
+	Textarea,
+	//
+	Root as InputGroup,
+	Addon as InputGroupAddon,
+	Button as InputGroupButton,
+	Input as InputGroupInput,
+	Text as InputGroupText,
+	Textarea as InputGroupTextarea,
+};

--- a/src/lib/components/shadcn/input-group/input-group-addon.svelte
+++ b/src/lib/components/shadcn/input-group/input-group-addon.svelte
@@ -1,0 +1,53 @@
+<script lang="ts" module>
+	import { tv, type VariantProps } from 'tailwind-variants';
+	export const inputGroupAddonVariants = tv({
+		base: "text-muted-foreground h-auto gap-2 py-1.5 text-sm font-medium group-data-[disabled=true]/input-group:opacity-50 [&>kbd]:rounded-[calc(var(--radius)-5px)] [&>svg:not([class*='size-'])]:size-4 flex cursor-text items-center justify-center select-none",
+		variants: {
+			align: {
+				'inline-start': 'pl-2 has-[>button]:-ml-1 has-[>kbd]:ml-[-0.15rem] order-first',
+				'inline-end': 'pr-2 has-[>button]:-mr-1 has-[>kbd]:mr-[-0.15rem] order-last',
+				'block-start':
+					'px-2.5 pt-2 group-has-[>input]/input-group:pt-2 [.border-b]:pb-2 order-first w-full justify-start',
+				'block-end':
+					'px-2.5 pb-2 group-has-[>input]/input-group:pb-2 [.border-t]:pt-2 order-last w-full justify-start',
+			},
+		},
+		defaultVariants: {
+			align: 'inline-start',
+		},
+	});
+
+	export type InputGroupAddonAlign = VariantProps<typeof inputGroupAddonVariants>['align'];
+</script>
+
+<script lang="ts">
+	import { cn, type WithElementRef } from '$lib/utils.js';
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		align = 'inline-start',
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> & {
+		align?: InputGroupAddonAlign;
+	} = $props();
+</script>
+
+<div
+	bind:this={ref}
+	role="group"
+	data-slot="input-group-addon"
+	data-align={align}
+	class={cn(inputGroupAddonVariants({ align }), className)}
+	onclick={(e) => {
+		if ((e.target as HTMLElement).closest('button')) {
+			return;
+		}
+		e.currentTarget.parentElement?.querySelector('input')?.focus();
+	}}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/shadcn/input-group/input-group-button.svelte
+++ b/src/lib/components/shadcn/input-group/input-group-button.svelte
@@ -1,0 +1,49 @@
+<script lang="ts" module>
+	import { tv, type VariantProps } from 'tailwind-variants';
+
+	const inputGroupButtonVariants = tv({
+		base: 'gap-2 text-sm flex items-center shadow-none',
+		variants: {
+			size: {
+				xs: "h-6 gap-1 rounded-[calc(var(--radius)-5px)] px-1.5 [&>svg:not([class*='size-'])]:size-3.5",
+				sm: 'cn-input-group-button-size-sm',
+				'icon-xs': 'size-6 rounded-[calc(var(--radius)-5px)] p-0 has-[>svg]:p-0',
+				'icon-sm': 'size-8 p-0 has-[>svg]:p-0',
+			},
+		},
+		defaultVariants: {
+			size: 'xs',
+		},
+	});
+
+	export type InputGroupButtonSize = VariantProps<typeof inputGroupButtonVariants>['size'];
+</script>
+
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+	import type { ComponentProps } from 'svelte';
+	import { Button } from '$lib/components/shadcn/button/index.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		type = 'button',
+		intent = 'primary',
+		size = 'xs',
+		...restProps
+	}: Omit<ComponentProps<typeof Button>, 'href' | 'size'> & {
+		size?: InputGroupButtonSize;
+	} = $props();
+</script>
+
+<Button
+	bind:ref
+	{type}
+	data-size={size}
+	{intent}
+	class={cn(inputGroupButtonVariants({ size }), className)}
+	{...restProps}
+>
+	{@render children?.()}
+</Button>

--- a/src/lib/components/shadcn/input-group/input-group-input.svelte
+++ b/src/lib/components/shadcn/input-group/input-group-input.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+	import type { ComponentProps } from 'svelte';
+	import { Input } from '$lib/components/shadcn/input/index.js';
+
+	let {
+		ref = $bindable(null),
+		value = $bindable(),
+		class: className,
+		...props
+	}: ComponentProps<typeof Input> = $props();
+</script>
+
+<Input
+	bind:ref
+	data-slot="input-group-control"
+	class={cn(
+		'rounded-none border-0 bg-transparent shadow-none ring-0 focus-visible:ring-0 aria-invalid:ring-0 dark:bg-transparent flex-1',
+		className,
+	)}
+	bind:value
+	{...props}
+/>

--- a/src/lib/components/shadcn/input-group/input-group-text.svelte
+++ b/src/lib/components/shadcn/input-group/input-group-text.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from '$lib/utils.js';
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLSpanElement>> = $props();
+</script>
+
+<span
+	bind:this={ref}
+	class={cn(
+		"text-muted-foreground gap-2 text-sm [&_svg:not([class*='size-'])]:size-4 flex items-center [&_svg]:pointer-events-none",
+		className,
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</span>

--- a/src/lib/components/shadcn/input-group/input-group-textarea.svelte
+++ b/src/lib/components/shadcn/input-group/input-group-textarea.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+	import { Textarea } from '$lib/components/shadcn/textarea/index.js';
+	import type { ComponentProps } from 'svelte';
+
+	let {
+		ref = $bindable(null),
+		value = $bindable(),
+		class: className,
+		...props
+	}: ComponentProps<typeof Textarea> = $props();
+</script>
+
+<Textarea
+	bind:ref
+	data-slot="input-group-control"
+	class={cn(
+		'rounded-none border-0 bg-transparent py-2 shadow-none ring-0 focus-visible:ring-0 aria-invalid:ring-0 dark:bg-transparent flex-1 resize-none',
+		className,
+	)}
+	bind:value
+	{...props}
+/>

--- a/src/lib/components/shadcn/input-group/input-group.svelte
+++ b/src/lib/components/shadcn/input-group/input-group.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from '$lib/utils.js';
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...props
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="input-group"
+	role="group"
+	class={cn(
+		'group/input-group border-input dark:bg-input/30 has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50 has-[[data-slot][aria-invalid=true]]:ring-destructive/20 has-[[data-slot][aria-invalid=true]]:border-destructive dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40 h-9 rounded-md border shadow-xs transition-[color,box-shadow] in-data-[slot=combobox-content]:focus-within:border-inherit in-data-[slot=combobox-content]:focus-within:ring-0 has-[[data-slot=input-group-control]:focus-visible]:ring-3 has-[[data-slot][aria-invalid=true]]:ring-3 has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>[data-align=block-end]]:[&>input]:pt-3 has-[>[data-align=block-start]]:[&>input]:pb-3 has-[>[data-align=inline-end]]:[&>input]:pr-1.5 has-[>[data-align=inline-start]]:[&>input]:pl-1.5 relative flex w-full min-w-0 items-center outline-none has-[>textarea]:h-auto',
+		className,
+	)}
+	{...props}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/modules/command-palette/command_palette.context.svelte.ts
+++ b/src/lib/modules/command-palette/command_palette.context.svelte.ts
@@ -1,5 +1,4 @@
 import { createContext } from 'svelte';
-import { SvelteMap } from 'svelte/reactivity';
 import { goto } from '$app/navigation';
 import { resolve } from '$app/paths';
 import { StateRaw } from '$lib/reactivity/state.svelte.js';
@@ -7,7 +6,7 @@ import { useBoard } from '$lib/modules/board/index.js';
 import { useActions } from '$lib/modules/actions/index.js';
 import { useIssues } from '$lib/modules/issues/index.js';
 import { useKeyboardShortcuts } from '$lib/modules/keyboard-shortcuts/index.js';
-import { filterItems, groupByCategory, flattenGrouped } from './search.js';
+import { groupByCategory } from './search.js';
 import { COMMAND_PALETTE_CATEGORIES } from './types.js';
 import type { CommandPaletteCategory, CommandPaletteItem } from './types.js';
 import type { ThemeMode } from '$lib/modules/board/index.js';
@@ -36,8 +35,6 @@ function createCommandPaletteContext() {
 	const shortcutsCtx = useKeyboardShortcuts();
 
 	const open = new StateRaw(false);
-	const query = new StateRaw('');
-	const selectedIndex = new StateRaw(0);
 
 	// ── Built-in navigation items ──────────────────────────────────────────
 
@@ -117,63 +114,20 @@ function createCommandPaletteContext() {
 	);
 
 	const allItems = $derived([...utilityItems, ...actionItems, ...navigationItems, ...issueItems]);
-	const filteredItems = $derived(filterItems(allItems, query.current));
-	const groupedResults = $derived(groupByCategory(filteredItems));
-	const flatResults = $derived(flattenGrouped(groupedResults));
-	const resultCount = $derived(flatResults.length);
-
-	const flatIndexByItemId = $derived.by(() => {
-		const map = new SvelteMap<string, number>();
-		for (let index = 0; index < flatResults.length; index++) {
-			map.set(flatResults[index].id, index);
-		}
-		return map;
-	});
+	const groupedResults = $derived(groupByCategory(allItems));
 
 	// ── Methods ────────────────────────────────────────────────────────────
-
-	function resetState() {
-		query.current = '';
-		selectedIndex.current = 0;
-	}
 
 	function toggle() {
 		if (open.current) {
 			close();
 		} else {
 			open.current = true;
-			resetState();
 		}
 	}
 
 	function close() {
 		open.current = false;
-		resetState();
-	}
-
-	function selectNext() {
-		if (resultCount === 0) {
-			return;
-		}
-		selectedIndex.current = (selectedIndex.current + 1) % resultCount;
-	}
-
-	function selectPrevious() {
-		if (resultCount === 0) {
-			return;
-		}
-		selectedIndex.current = (selectedIndex.current - 1 + resultCount) % resultCount;
-	}
-
-	function executeSelected() {
-		if (resultCount === 0) {
-			return;
-		}
-		const item = flatResults[selectedIndex.current];
-		if (item !== undefined) {
-			item.onSelect();
-			close();
-		}
 	}
 
 	function executeItem(item: CommandPaletteItem) {
@@ -187,41 +141,13 @@ function createCommandPaletteContext() {
 		},
 		set open(value: boolean) {
 			open.current = value;
-			if (!value) {
-				resetState();
-			}
-		},
-		get query() {
-			return query.current;
-		},
-		set query(value: string) {
-			query.current = value;
-			selectedIndex.current = 0;
-		},
-		get selectedIndex() {
-			return selectedIndex.current;
-		},
-		set selectedIndex(value: number) {
-			selectedIndex.current = value;
 		},
 		get groupedResults(): Map<CommandPaletteCategory, CommandPaletteItem[]> {
 			return groupedResults;
 		},
-		get flatResults(): CommandPaletteItem[] {
-			return flatResults;
-		},
-		get resultCount() {
-			return resultCount;
-		},
-		get flatIndexByItemId(): Map<string, number> {
-			return flatIndexByItemId;
-		},
 
 		toggle,
 		close,
-		selectNext,
-		selectPrevious,
-		executeSelected,
 		executeItem,
 	};
 }

--- a/src/lib/modules/command-palette/index.ts
+++ b/src/lib/modules/command-palette/index.ts
@@ -1,4 +1,4 @@
-export { filterItems, groupByCategory, flattenGrouped } from './search.js';
+export { groupByCategory } from './search.js';
 export {
 	COMMAND_PALETTE_CATEGORIES,
 	CATEGORY_DISPLAY_ORDER,

--- a/src/lib/modules/command-palette/search.test.ts
+++ b/src/lib/modules/command-palette/search.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { filterItems, groupByCategory, flattenGrouped } from './search.js';
+import { groupByCategory } from './search.js';
 import type { CommandPaletteItem } from './types.js';
 
 function makeItem(overrides: Partial<CommandPaletteItem> & { id: string }): CommandPaletteItem {
@@ -10,43 +10,6 @@ function makeItem(overrides: Partial<CommandPaletteItem> & { id: string }): Comm
 		...overrides,
 	};
 }
-
-describe('filterItems', () => {
-	const items: CommandPaletteItem[] = [
-		makeItem({ id: 'a1', label: 'Switch to forest view', category: 'navigation' }),
-		makeItem({ id: 'a2', label: 'Create new issue', description: 'session running' }),
-		makeItem({ id: 'a3', label: 'Open settings' }),
-	];
-
-	it('returns all items when query is empty string', () => {
-		const result = filterItems(items, '');
-		expect(result).toHaveLength(3);
-		expect(result).toEqual(items);
-	});
-
-	it('matches substring in label (case-insensitive)', () => {
-		const result = filterItems(items, 'for');
-		expect(result).toHaveLength(1);
-		expect(result[0].id).toBe('a1');
-	});
-
-	it('matches substring in description', () => {
-		const result = filterItems(items, 'running');
-		expect(result).toHaveLength(1);
-		expect(result[0].id).toBe('a2');
-	});
-
-	it('returns empty array when nothing matches', () => {
-		const result = filterItems(items, 'zzzznotfound');
-		expect(result).toHaveLength(0);
-	});
-
-	it('returns all items when query is whitespace-only', () => {
-		const result = filterItems(items, '   ');
-		expect(result).toHaveLength(3);
-		expect(result).toEqual(items);
-	});
-});
 
 describe('groupByCategory', () => {
 	it('groups items by their category field', () => {
@@ -85,28 +48,5 @@ describe('groupByCategory', () => {
 
 		expect(grouped.has('navigation')).toBe(false);
 		expect(grouped.size).toBe(2);
-	});
-});
-
-describe('flattenGrouped', () => {
-	it('produces a flat array in category order', () => {
-		const items: CommandPaletteItem[] = [
-			makeItem({ id: 'i1', category: 'issues', label: 'Issue 1' }),
-			makeItem({ id: 'a1', category: 'actions', label: 'Action 1' }),
-			makeItem({ id: 'n1', category: 'navigation', label: 'Nav 1' }),
-		];
-
-		const grouped = groupByCategory(items);
-		const flat = flattenGrouped(grouped);
-
-		expect(flat.map((item) => item.id)).toEqual(['a1', 'n1', 'i1']);
-	});
-
-	it('returns empty array when given empty map', () => {
-		const emptyMap = new Map();
-		const result = flattenGrouped(emptyMap);
-
-		expect(result).toEqual([]);
-		expect(result).toHaveLength(0);
 	});
 });

--- a/src/lib/modules/command-palette/search.ts
+++ b/src/lib/modules/command-palette/search.ts
@@ -1,23 +1,6 @@
 import { CATEGORY_DISPLAY_ORDER } from './types.js';
 import type { CommandPaletteCategory, CommandPaletteItem } from './types.js';
 
-export function filterItems(
-	items: readonly CommandPaletteItem[],
-	query: string,
-): CommandPaletteItem[] {
-	const trimmedQuery = query.trim().toLowerCase();
-
-	if (trimmedQuery === '') {
-		return [...items];
-	}
-
-	return items.filter((item) => {
-		const labelMatch = item.label.toLowerCase().includes(trimmedQuery);
-		const descriptionMatch = item.description?.toLowerCase().includes(trimmedQuery) ?? false;
-		return labelMatch || descriptionMatch;
-	});
-}
-
 export function groupByCategory(
 	items: readonly CommandPaletteItem[],
 ): Map<CommandPaletteCategory, CommandPaletteItem[]> {
@@ -42,16 +25,4 @@ export function groupByCategory(
 	}
 
 	return orderedResult;
-}
-
-export function flattenGrouped(
-	grouped: Map<CommandPaletteCategory, CommandPaletteItem[]>,
-): CommandPaletteItem[] {
-	const result: CommandPaletteItem[] = [];
-
-	for (const items of grouped.values()) {
-		result.push(...items);
-	}
-
-	return result;
 }

--- a/tests/e2e/keyboard-shortcuts.spec.ts
+++ b/tests/e2e/keyboard-shortcuts.spec.ts
@@ -64,9 +64,13 @@ test.describe('Global keyboard shortcuts', () => {
 		await page.keyboard.press('Control+k');
 		await expect(page.getByRole('dialog')).toBeVisible();
 
-		await page.keyboard.type('settings');
-		await page.keyboard.press('ArrowDown');
-		await page.keyboard.press('Enter');
+		const commandInput = page.locator('[data-command-input]');
+		await expect(commandInput).toBeVisible();
+		await commandInput.fill('settings');
+
+		const settingsItem = page.getByRole('option', { name: /settings/i });
+		await expect(settingsItem).toBeVisible();
+		await settingsItem.click();
 
 		await expect(page).toHaveURL(/settings/);
 	});


### PR DESCRIPTION
## Description
- Adopted the Command component from shadcn-svelte (built on bits-ui primitives) with 11 sub-components and InputGroup dependency
- Migrated CommandPalette from Dialog+Input+Popover.Item with manual keyboard nav to Command.Root+Command.Input+Command.List+Command.Group+Command.Item
- Migrated StepGithubSearch from SearchField+button list with manual selection to Command.Root with shouldFilter=false for server-side search
- Simplified command_palette.context.svelte.ts by removing selectedIndex, selectNext/Previous, executeSelected, flatResults, flatIndexByItemId, and filterItems (all now handled by Command primitive)
- Added Command.stories.svelte with 5 stories and 4 play tests covering keyboard nav, filtering, empty state, and groups
- Updated CommandPalette and CreationWizard story tests for new Command DOM structure
- Fixed stale CSS attribute selectors (cmdk-* → data-command-*) to match bits-ui 2.16.5
- Removed dead code including filterItems, flattenGrouped functions, unused i18n keys, and removed unsuitable components (Collapsible, Toggle, ToggleGroup)

## Resolves
Closes #308

## Testing
- [x] Command component stories and play tests
- [x] CommandPalette and CreationWizard story tests updated
- [x] Verified AssignedIssuesPanel, RepoCombobox, SoundPoolPanel are NOT suitable for Command migration