### PR TITLE
feat(tooling): add Tauri MCP bridge for visual testing

### DIFF
--- a/.claude/skills/gk-tauri-test/REFERENCE.md
+++ b/.claude/skills/gk-tauri-test/REFERENCE.md
@@ -1,0 +1,129 @@
+# Tauri MCP Bridge — Known Issues & Workarounds
+
+Reference material for the `gk-tauri-test` skill. Findings from testing `@hypothesi/tauri-mcp-server` with `tauri-plugin-mcp-bridge`.
+
+## Known Issues
+
+### 1. `ipc_execute_command` Is Not Implemented
+
+**Symptom**: Every call returns `"Unsupported Tauri command: <name>"`.
+
+**Root cause**: The Rust handler (`execute_command.rs` in the bridge plugin) is a stub. It always returns an error with "Dynamic command execution not yet implemented." The API docs claim it "executes any Tauri IPC command directly" — this is misleading.
+
+**Workaround**: Use `mcp__tauri__webview_execute_js` with `window.__TAURI__.core.invoke()`:
+
+```javascript
+(async () => {
+	const { invoke } = window.__TAURI__.core;
+	const result = await invoke('get_dashboards', { includeArchived: false });
+	return result;
+})();
+```
+
+This has full access to every registered Tauri command via the standard IPC path.
+
+### 2. Accessibility Snapshots Fail ("aria-api library not loaded")
+
+**Symptom**: `webview_dom_snapshot` with `type: "accessibility"` throws `"aria-api library not loaded"`.
+
+**Root cause**: The MCP server's `registerScript()` adds the aria-api bundle to the bridge's in-memory `ScriptRegistry` but never sends a follow-up `execute_js` to inject it into the webview. The bridge only injects registered scripts on page navigation events (`popstate`, initial load). Since the aria-api is registered _after_ page load (on first accessibility snapshot request), it sits in the registry without being injected.
+
+**Verification**: Call `request_script_injection` from the webview — it returns the aria-api as one of the registered-but-not-injected scripts:
+
+```javascript
+(async () => {
+	return await window.__TAURI__.core.invoke('plugin:mcp-bridge|request_script_injection');
+})();
+// Returns: { injected: 3, scriptIds: ["__mcp_aria_api__", "__mcp_resolve_ref__", "__mcp_html2canvas__"] }
+```
+
+**Workaround**: Run the above `request_script_injection` call once per session before using accessibility snapshots. After injection, accessibility snapshots work perfectly, returning WAI-ARIA roles, names, states, and ref IDs.
+
+**Alternative**: Use `type: "structure"` instead — it works without aria-api and is sufficient for most automation (gives tag names, classes, IDs, ref IDs).
+
+### 3. Window Label Defaults to "main"
+
+**Symptom**: Tools fail with `"Window 'main' not found"` when `windowId` is omitted.
+
+**Root cause**: All webview tools default `windowId` to `"main"`. Grovekeeper's window is labeled `"overview"` (configured in `tauri.conf.json`).
+
+**Workaround**: Always pass `windowId` explicitly. Discover the correct label from `ipc_get_backend_state`, which returns:
+
+```json
+{
+	"windows": [{ "label": "overview", "title": "Grovekeeper", "visible": true, "focused": true }]
+}
+```
+
+### 4. `read_logs` System Source Fails on Windows
+
+**Symptom**: `source: "system"` returns `"'log' is not recognized as an internal or external command"`.
+
+**Root cause**: The implementation uses macOS's `log show` command, which doesn't exist on Windows.
+
+**Workaround**: Use `source: "console"` for webview JavaScript logs. System-level Rust/Tauri logs are not accessible via MCP on Windows.
+
+## Tool Reliability Matrix
+
+| Tool                                   | Status                 | Notes                                                     |
+| -------------------------------------- | ---------------------- | --------------------------------------------------------- |
+| `driver_session`                       | Works                  | Reliable WebSocket connection on port 9223                |
+| `webview_screenshot`                   | Works                  | Native WebView2 API on Windows; requires correct windowId |
+| `webview_dom_snapshot` (structure)     | Works                  | Returns DOM tree with ref IDs; no dependencies            |
+| `webview_dom_snapshot` (accessibility) | Works after workaround | Requires manual `request_script_injection` first          |
+| `webview_execute_js`                   | Works                  | Full `window.__TAURI__` access; use for IPC commands      |
+| `webview_interact`                     | Works                  | Click, scroll, focus via text/css/ref selectors           |
+| `ipc_get_backend_state`                | Works                  | Returns app metadata, Tauri version, window list          |
+| `ipc_execute_command`                  | Broken                 | Stub implementation; use `webview_execute_js` instead     |
+| `ipc_emit_event`                       | Untested               | Should work for event system testing                      |
+| `ipc_monitor` / `ipc_get_captured`     | Untested               | Should work for IPC traffic debugging                     |
+| `read_logs` (console)                  | Works                  | Webview JS logs with optional regex filter                |
+| `read_logs` (system)                   | Broken on Windows      | Uses macOS-only `log show` command                        |
+
+## Testing Patterns
+
+### Verify a Rust Command Returns Expected Data
+
+```javascript
+// via webview_execute_js
+(async () => {
+	const dashboards = await window.__TAURI__.core.invoke('get_dashboards', {
+		includeArchived: false,
+	});
+	return { count: dashboards.length, names: dashboards.map((d) => d.name) };
+})();
+```
+
+### Interact With a Button and Verify State Change
+
+1. Take a `structure` snapshot to find the button's ref ID
+2. Click it: `webview_interact` with `action: "click"`, `selector: "ref=eN"`
+3. Take a screenshot to verify the visual result
+4. Take another snapshot to verify DOM changes
+
+### Test a Form Flow
+
+1. Snapshot to find form elements
+2. Use `webview_execute_js` to fill inputs (more reliable than interact for text):
+    ```javascript
+    (() => {
+    	const input = document.querySelector('input[name="field"]');
+    	const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+    		window.HTMLInputElement.prototype,
+    		'value',
+    	).set;
+    	nativeInputValueSetter.call(input, 'new value');
+    	input.dispatchEvent(new Event('input', { bubbles: true }));
+    })();
+    ```
+3. Click submit via `webview_interact`
+4. Screenshot to verify result
+
+### Check Accessibility of a Component
+
+1. Run the aria-api injection workaround (Step 3 in SKILL.md)
+2. Take an accessibility snapshot scoped to the component:
+    ```
+    webview_dom_snapshot type: "accessibility", selector: ".component-class", windowId: "overview"
+    ```
+3. Verify roles, names, and states match expectations

--- a/.claude/skills/gk-tauri-test/SKILL.md
+++ b/.claude/skills/gk-tauri-test/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: gk-tauri-test
+description: 'Test and interact with the running Grovekeeper Tauri app via the Tauri MCP bridge. Loads tool schemas, connects to the app, applies workarounds for known MCP server bugs, and provides testing patterns. Use when: "test tauri", "tauri mcp test", "verify tauri bridge", "test the app", "gk tauri test", "interact with the app", "take screenshot"'
+argument-hint: '[test description or area to test]'
+allowed-tools: ToolSearch, Bash, Read, Grep, Glob, mcp__tauri__driver_session, mcp__tauri__webview_screenshot, mcp__tauri__webview_dom_snapshot, mcp__tauri__webview_execute_js, mcp__tauri__webview_interact, mcp__tauri__ipc_get_backend_state, mcp__tauri__read_logs
+metadata:
+    author: MartinoPolo
+    version: '0.1'
+    category: utility
+---
+
+# Tauri MCP Bridge Testing
+
+Test and interact with the running Grovekeeper app through the Tauri MCP server (`@hypothesi/tauri-mcp-server` + `tauri-plugin-mcp-bridge`).
+
+The app must be running via `pnpm tauri dev` in a separate terminal before invoking this skill.
+
+## Step 1 — Load Deferred Tools
+
+Use `ToolSearch` to load the Tauri MCP tools:
+
+```
+ToolSearch query: "select:mcp__tauri__driver_session,mcp__tauri__webview_screenshot,mcp__tauri__webview_dom_snapshot,mcp__tauri__webview_execute_js,mcp__tauri__webview_interact,mcp__tauri__ipc_get_backend_state,mcp__tauri__read_logs"
+```
+
+## Step 2 — Connect and Discover
+
+1. Start a driver session: `mcp__tauri__driver_session` with `action: "start"`, `port: 9223`
+2. Get backend state: `mcp__tauri__ipc_get_backend_state` — this returns the window list with labels
+3. Store the window label from the response (Grovekeeper currently uses `"overview"`)
+4. Pass this `windowId` on **every** subsequent webview tool call
+
+## Step 3 — Fix Accessibility Snapshots
+
+Run this via `mcp__tauri__webview_execute_js` (with the discovered windowId):
+
+```javascript
+(async () => {
+	return await window.__TAURI__.core.invoke('plugin:mcp-bridge|request_script_injection');
+})();
+```
+
+This injects the aria-api library that the MCP server registers but fails to inject. See [REFERENCE.md](REFERENCE.md) for details.
+
+## Step 4 — Execute User's Test Request
+
+Use the patterns below. For detailed workarounds and known issues, see [REFERENCE.md](REFERENCE.md).
+
+### Taking Screenshots
+
+`mcp__tauri__webview_screenshot` with `windowId`, `format: "png"`
+
+### Reading the UI
+
+- **Structure snapshot**: `mcp__tauri__webview_dom_snapshot` with `type: "structure"` — gives DOM tree with ref IDs
+- **Accessibility snapshot**: `mcp__tauri__webview_dom_snapshot` with `type: "accessibility"` — gives semantic roles, names, states (requires Step 3)
+- Each element gets a `[ref=eN]` ID that can be used with other tools until the next snapshot
+
+### Calling Rust Backend Commands
+
+Use `mcp__tauri__webview_execute_js` with an async IIFE:
+
+```javascript
+(async () => {
+	const result = await window.__TAURI__.core.invoke('command_name', { argName: value });
+	return result;
+})();
+```
+
+To discover available commands, search `src-tauri/src/commands/` for `#[tauri::command]` functions.
+
+### Interacting with UI Elements
+
+`mcp__tauri__webview_interact` with `windowId` and:
+
+- `strategy: "text"`, `selector: "Button Text"` — find by visible text
+- `strategy: "css"`, `selector: ".my-class"` — find by CSS selector
+- `selector: "ref=e14"` — use ref ID from a prior dom snapshot
+
+Supported actions: `click`, `double-click`, `long-press`, `scroll`, `swipe`, `focus`
+
+### Reading Console Logs
+
+`mcp__tauri__read_logs` with `source: "console"`, `windowId`, optional `filter` regex.
+
+## Step 5 — Report Results
+
+After completing the test, summarize:
+
+- What was tested and the outcome (pass/fail)
+- Screenshots taken (describe what's visible)
+- Any errors encountered with context
+- Suggestions for follow-up if issues were found

--- a/.mcp.json
+++ b/.mcp.json
@@ -11,6 +11,10 @@
 		"chrome-devtools": {
 			"command": "npx",
 			"args": ["chrome-devtools-mcp@latest"]
+		},
+		"tauri": {
+			"command": "npx",
+			"args": ["-y", "@hypothesi/tauri-mcp-server"]
 		}
 	}
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,3 +74,9 @@ Always fix unrelated errors you encounter (merge artifacts, stale imports, broke
 ## Testing
 
 - TDD: write tests first, then implement.
+
+## Visual Testing (Tauri MCP)
+
+For frontend visual verification, spawn a `mp-tauri-tester` sub-agent with numbered test requirements and expected outcomes. The agent connects to the running app via Tauri MCP bridge, applies all known workarounds, and returns a structured pass/fail report with screenshot evidence.
+
+Prerequisite: `pnpm tauri dev` must be running.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -318,11 +318,20 @@ dependencies = [
 
 [[package]]
 name = "block2"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
+dependencies = [
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
- "objc2",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -839,6 +848,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "dbus"
 version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -941,9 +956,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.11.1",
- "block2",
+ "block2 0.6.2",
  "libc",
- "objc2",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -1658,6 +1673,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
+ "tauri-plugin-mcp-bridge",
  "tauri-plugin-notification",
  "tauri-plugin-opener",
  "tauri-plugin-single-instance",
@@ -2534,8 +2550,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29a16783dd1a47849b8c8133c9cd3eb2112cfbc6901670af3dba47c8bbfb07d3"
 dependencies = [
  "cc",
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
  "time",
 ]
 
@@ -2678,10 +2694,10 @@ dependencies = [
  "dpi",
  "gtk",
  "keyboard-types",
- "objc2",
- "objc2-app-kit",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "once_cell",
  "png 0.17.16",
  "serde",
@@ -2853,6 +2869,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
+
+[[package]]
+name = "objc2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
+dependencies = [
+ "objc-sys",
+ "objc2-encode",
+]
+
+[[package]]
 name = "objc2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2864,15 +2896,67 @@ dependencies = [
 
 [[package]]
 name = "objc2-app-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2 0.5.1",
+ "libc",
+ "objc2 0.5.2",
+ "objc2-core-data",
+ "objc2-core-image",
+ "objc2-foundation 0.2.2",
+ "objc2-quartz-core 0.2.2",
+]
+
+[[package]]
+name = "objc2-app-kit"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.11.1",
- "block2",
- "objc2",
+ "block2 0.6.2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-core-location",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-contacts"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -2883,7 +2967,7 @@ checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.1",
  "dispatch2",
- "objc2",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -2894,9 +2978,33 @@ checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
  "bitflags 2.11.1",
  "dispatch2",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "objc2-metal",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-contacts",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -2916,14 +3024,26 @@ dependencies = [
 
 [[package]]
 name = "objc2-foundation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2 0.5.1",
+ "libc",
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "objc2-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.1",
- "block2",
+ "block2 0.6.2",
  "libc",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
 ]
 
@@ -2934,8 +3054,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
  "bitflags 2.11.1",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-link-presentation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "objc2-metal",
 ]
 
 [[package]]
@@ -2945,9 +3102,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
  "bitflags 2.11.1",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-symbols"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a684efe3dec1b305badae1a28f6555f6ddd3bb2c2267896782858d5a78404dc"
+dependencies = [
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-foundation 0.2.2",
+ "objc2-link-presentation",
+ "objc2-quartz-core 0.2.2",
+ "objc2-symbols",
+ "objc2-uniform-type-identifiers",
+ "objc2-user-notifications",
 ]
 
 [[package]]
@@ -2957,9 +3145,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
  "bitflags 2.11.1",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-uniform-type-identifiers"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-core-location",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-web-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68bc69301064cebefc6c4c90ce9cba69225239e4b8ff99d445a2b5563797da65"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -2969,11 +3194,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f"
 dependencies = [
  "bitflags 2.11.1",
- "block2",
- "objc2",
- "objc2-app-kit",
+ "block2 0.6.2",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -3909,17 +4134,17 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
 dependencies = [
- "block2",
+ "block2 0.6.2",
  "dispatch2",
  "glib-sys",
  "gobject-sys",
  "gtk-sys",
  "js-sys",
  "log",
- "objc2",
- "objc2-app-kit",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "raw-window-handle",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -4400,6 +4625,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4486,11 +4722,11 @@ dependencies = [
  "bytemuck",
  "js-sys",
  "ndk 0.9.0",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-graphics",
- "objc2-foundation",
- "objc2-quartz-core",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
  "raw-window-handle",
  "redox_syscall",
  "tracing",
@@ -4700,7 +4936,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9103edf55f2da3c82aea4c7fab7c4241032bfeea0e71fa557d98e00e7ce7cc20"
 dependencies = [
  "bitflags 2.11.1",
- "block2",
+ "block2 0.6.2",
  "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
@@ -4716,9 +4952,9 @@ dependencies = [
  "ndk 0.9.0",
  "ndk-context",
  "ndk-sys 0.6.0+11769913",
- "objc2",
- "objc2-app-kit",
- "objc2-foundation",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
  "once_cell",
  "parking_lot",
  "raw-window-handle",
@@ -4770,11 +5006,11 @@ dependencies = [
  "log",
  "mime",
  "muda",
- "objc2",
- "objc2-app-kit",
- "objc2-foundation",
- "objc2-ui-kit",
- "objc2-web-kit",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
+ "objc2-ui-kit 0.3.2",
+ "objc2-web-kit 0.3.2",
  "percent-encoding",
  "plist",
  "raw-window-handle",
@@ -4907,7 +5143,7 @@ dependencies = [
  "dunce",
  "glob",
  "log",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "percent-encoding",
  "schemars 0.8.22",
  "serde",
@@ -4919,6 +5155,35 @@ dependencies = [
  "thiserror 2.0.18",
  "toml 1.1.2+spec-1.1.0",
  "url",
+]
+
+[[package]]
+name = "tauri-plugin-mcp-bridge"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e711daea388cdb3c4219cba25ed93ea1013be8237bc795341e82369909bbbf4f"
+dependencies = [
+ "base64 0.22.1",
+ "block2 0.5.1",
+ "futures-util",
+ "image",
+ "jni",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
+ "objc2-ui-kit 0.2.2",
+ "objc2-web-kit 0.2.2",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-tungstenite",
+ "uuid",
+ "webview2-com",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -4948,8 +5213,8 @@ checksum = "fc624469b06f59f5a29f874bbc61a2ed737c0f9c23ef09855a292c389c42e83f"
 dependencies = [
  "dunce",
  "glob",
- "objc2-app-kit",
- "objc2-foundation",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
  "open",
  "schemars 0.8.22",
  "serde",
@@ -4988,9 +5253,9 @@ dependencies = [
  "gtk",
  "http",
  "jni",
- "objc2",
- "objc2-ui-kit",
- "objc2-web-kit",
+ "objc2 0.6.4",
+ "objc2-ui-kit 0.3.2",
+ "objc2-web-kit 0.3.2",
  "raw-window-handle",
  "serde",
  "serde_json",
@@ -5012,8 +5277,8 @@ dependencies = [
  "http",
  "jni",
  "log",
- "objc2",
- "objc2-app-kit",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "once_cell",
  "percent-encoding",
  "raw-window-handle",
@@ -5237,6 +5502,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -5273,6 +5539,18 @@ checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
 ]
 
 [[package]]
@@ -5494,11 +5772,11 @@ dependencies = [
  "dirs",
  "libappindicator",
  "muda",
- "objc2",
- "objc2-app-kit",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
  "objc2-core-graphics",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "once_cell",
  "png 0.17.16",
  "serde",
@@ -5534,6 +5812,23 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "termcolor",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "sha1",
+ "thiserror 2.0.18",
+ "utf-8",
 ]
 
 [[package]]
@@ -6033,10 +6328,10 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9bec5a31f3f9362f2258fd0e9c9dd61a9ca432e7306cc78c444258f0dce9a9c"
 dependencies = [
- "objc2",
- "objc2-app-kit",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "raw-window-handle",
  "windows-sys 0.59.0",
  "windows-version",
@@ -6664,7 +6959,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5a8135d8676225e5744de000d4dff5a082501bf7db6a1c1495034f8c314edbc"
 dependencies = [
  "base64 0.22.1",
- "block2",
+ "block2 0.6.2",
  "cookie",
  "crossbeam-channel",
  "dirs",
@@ -6678,12 +6973,12 @@ dependencies = [
  "jni",
  "libc",
  "ndk 0.9.0",
- "objc2",
- "objc2-app-kit",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
- "objc2-foundation",
- "objc2-ui-kit",
- "objc2-web-kit",
+ "objc2-foundation 0.3.2",
+ "objc2-ui-kit 0.3.2",
+ "objc2-web-kit 0.3.2",
  "once_cell",
  "percent-encoding",
  "raw-window-handle",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -48,6 +48,7 @@ image = { version = "0.25", default-features = false, features = ["png", "jpeg",
 keyring = { version = "3", features = ["sync-secret-service", "windows-native"] }
 which = "6"
 toml = "0.8"
+tauri-plugin-mcp-bridge = "0.11"
 
 [target."cfg(any(target_os = \"macos\", windows, target_os = \"linux\"))".dependencies]
 tauri-plugin-single-instance = "2"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -7,6 +7,7 @@
 		"core:default",
 		"opener:default",
 		"notification:default",
-		"dialog:default"
+		"dialog:default",
+		"mcp-bridge:default"
 	]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -43,6 +43,7 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_notification::init())
+        .plugin(tauri_plugin_mcp_bridge::init())
         .setup(|app| {
             // Register single-instance plugin in setup so we have access to app handle
             #[cfg(desktop)]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -10,6 +10,7 @@
 		"frontendDist": "../build"
 	},
 	"app": {
+		"withGlobalTauri": true,
 		"windows": [
 			{
 				"label": "overview",
@@ -21,7 +22,7 @@
 			}
 		],
 		"security": {
-			"csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://avatars.githubusercontent.com; font-src 'self'; connect-src ipc: http://ipc.localhost https://github.com https://api.github.com"
+			"csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://avatars.githubusercontent.com; font-src 'self'; connect-src ipc: http://ipc.localhost https://github.com https://api.github.com ws://localhost:9223"
 		}
 	},
 	"bundle": {

--- a/src/lib/components/blocks/workspace/AddWorkspaceCard.svelte
+++ b/src/lib/components/blocks/workspace/AddWorkspaceCard.svelte
@@ -11,7 +11,7 @@
 
 <button class="block h-full w-full text-left" {onclick}>
 	<div
-		class="flex h-full min-h-49 cursor-pointer items-center justify-center rounded-lg border-[1.5px] border-dashed border-border bg-surface transition-all duration-200 hover:translate-y-0.5 hover:border-moss-400 hover:bg-[color-mix(in_oklch,var(--moss-400)_6%,var(--surface))] hover:text-moss-300"
+		class="flex h-full min-h-49 cursor-pointer items-center justify-center rounded-lg border-[1.5px] border-dashed border-border bg-surface transition-all duration-200 hover:-translate-y-0.5 hover:border-moss-400 hover:bg-[color-mix(in_oklch,var(--moss-400)_6%,var(--surface))] hover:text-moss-300"
 	>
 		<div class="flex flex-col items-center gap-2.5 text-foreground-muted">
 			<div class="flex size-9 items-center justify-center rounded-full bg-surface-2">

--- a/src/lib/components/blocks/workspace/WorkspaceCard.svelte
+++ b/src/lib/components/blocks/workspace/WorkspaceCard.svelte
@@ -177,7 +177,7 @@
 		{gradientTint}
 		class={cn(
 			'group relative isolate h-full cursor-pointer transition-all duration-200',
-			'hover:translate-y-0.5 gk-ws-hover-glow',
+			'hover:-translate-y-0.5 gk-ws-hover-glow',
 			isDormant && 'opacity-[0.72] saturate-[0.7]',
 		)}
 	>

--- a/src/lib/components/derived/color-picker/ColorPickerContent.svelte
+++ b/src/lib/components/derived/color-picker/ColorPickerContent.svelte
@@ -20,7 +20,7 @@
 	}: ColorPickerContentProps = $props();
 
 	let focusedIndex = $state(0);
-	let swatchElements: HTMLButtonElement[] = [];
+	let swatchElements: HTMLButtonElement[] = $state([]);
 
 	let effectiveColor = $derived(selectedColor || colors[0] || '#000000');
 


### PR DESCRIPTION
## Description

- Adds tauri-plugin-mcp-bridge Rust plugin for MCP server integration
- Implements gk-tauri-test skill with comprehensive documentation and workarounds for known MCP server bugs (ipc_execute_command, aria-api injection, window label defaults, Windows logging)
- Configures MCP server support in .mcp.json and Tauri manifest
- Fixes hover direction behavior on workspace cards
- Wraps swatchElements with $state for proper reactivity in ColorPickerContent

## Testing

- [x] MCP bridge integration verified
- [x] gk-tauri-test skill documentation complete with known issues and workarounds
- [x] Component reactivity fixes tested