### PR TITLE
fix(character-creator): persist name/displayName/language on save and fix icon attribute

### DIFF
--- a/src-tauri/src/commands/character_pack_commands.rs
+++ b/src-tauri/src/commands/character_pack_commands.rs
@@ -131,6 +131,13 @@ pub fn update_character_pack(
             return Err("Cannot edit bundled character packs".to_owned());
         }
 
+        if let Some(name) = &request.name {
+            conn.execute(
+                "UPDATE character_packs SET name = ?1 WHERE id = ?2",
+                rusqlite::params![name, request.id],
+            )
+            .map_err(|e| e.to_string())?;
+        }
         if let Some(display_name) = &request.display_name {
             conn.execute(
                 "UPDATE character_packs SET display_name = ?1 WHERE id = ?2",

--- a/src-tauri/src/models/character_pack.rs
+++ b/src-tauri/src/models/character_pack.rs
@@ -45,6 +45,7 @@ pub struct CreateCharacterPackRequest {
 #[derive(Debug, Deserialize)]
 pub struct UpdateCharacterPackRequest {
     pub id: String,
+    pub name: Option<String>,
     pub display_name: Option<String>,
     pub language: Option<Option<String>>,
 }

--- a/src/lib/modules/character-packs/character_packs.context.svelte.ts
+++ b/src/lib/modules/character-packs/character_packs.context.svelte.ts
@@ -259,6 +259,7 @@ function createCharacterPacksContext() {
 
 		async updatePack(request: {
 			id: string;
+			name?: string;
 			display_name?: string;
 			language?: string | null;
 		}): Promise<CharacterPack> {

--- a/src/lib/tauri_mock.ts
+++ b/src/lib/tauri_mock.ts
@@ -233,7 +233,7 @@ const MOCK_COMMAND_HANDLERS: Record<string, MockHandler> = {
 	}),
 	update_character_pack: ({ request }: Record<string, unknown>) => ({
 		id: (request as Record<string, unknown>).id,
-		name: 'updated',
+		name: (request as Record<string, unknown>).name ?? 'updated',
 		display_name: (request as Record<string, unknown>).display_name ?? 'Updated',
 		language: (request as Record<string, unknown>).language ?? null,
 		avatar_path: null,

--- a/src/routes/settings/character-creator/+page.svelte
+++ b/src/routes/settings/character-creator/+page.svelte
@@ -217,13 +217,12 @@
 
 		saving = true;
 		try {
-			if (isEditMode) {
-				await characterPacks.updatePack({
-					id: packId,
-					display_name: resolveDisplayName(),
-					language,
-				});
-			}
+			await characterPacks.updatePack({
+				id: packId,
+				name: characterName.trim(),
+				display_name: resolveDisplayName(),
+				language,
+			});
 
 			await characterPacks.saveSounds(packId, buildAssignmentsFromMap());
 			await goto(backRoute);
@@ -281,7 +280,7 @@
 	<!-- Header -->
 	<header class="flex items-center gap-3 border-b border-border px-4 py-3">
 		<Button intent="ghost" size="sm" class="size-8 p-0" onclick={() => void goto(backRoute)}>
-			<ArrowLeftIcon data-icon="inline-end" />
+			<ArrowLeftIcon data-icon="inline-start" />
 		</Button>
 
 		<h1 class="text-lg font-semibold">


### PR DESCRIPTION
## Summary
- **Bug fix:** In create mode, `handleSave` now always calls `updatePack` — previously it was gated behind `isEditMode`, so character name, display name, and language were silently discarded on new packs
- **Backend:** Added `name: Option<String>` to `UpdateCharacterPackRequest` Rust struct and SQL update handler
- **Icon fix:** Changed `ArrowLeftIcon` from `data-icon="inline-end"` to `data-icon="inline-start"` (back arrow is a prefix icon)

## Resolves
Follow-up fix for #322

## Test plan
- [x] `pnpm check:all` passes (0 errors)
- [x] `pnpm test` passes (1585/1585)
- [ ] Create a new character pack → name, display name, and language persist after save
- [ ] Edit existing pack → name field is read-only, display name and language update correctly
- [ ] Back arrow icon renders in correct position (left of button)