### PR TITLE
#355 feat(workspace): port pattern regex validation UI

### DIFF
--- a/src/lib/components/blocks/workspace/WorkspaceCommandRow.svelte
+++ b/src/lib/components/blocks/workspace/WorkspaceCommandRow.svelte
@@ -3,11 +3,14 @@
 	import { Input } from '$lib/components/shadcn/input/index.js';
 	import { Select } from '$lib/components/shadcn/select/index.js';
 	import { Button } from '$lib/components/shadcn/button/index.js';
-	import { PORT_PATTERN_PRESETS } from './port_pattern_presets.js';
+	import { PORT_PATTERN_PRESETS, extractPort, validateRegex } from './port_pattern_presets.js';
 	import { useProcesses } from '$lib/modules/processes';
 	import TrashIcon from '@lucide/svelte/icons/trash-2';
 	import GripVerticalIcon from '@lucide/svelte/icons/grip-vertical';
 	import PlayIcon from '@lucide/svelte/icons/play';
+	import CircleCheckIcon from '@lucide/svelte/icons/circle-check';
+	import CircleXIcon from '@lucide/svelte/icons/circle-x';
+	import TriangleAlertIcon from '@lucide/svelte/icons/triangle-alert';
 
 	interface Props {
 		command: WorkspaceCommand;
@@ -21,6 +24,28 @@
 	const processesCtx = useProcesses();
 	const isServer = $derived(command.category === 'server');
 	let testRunning = $state(false);
+	let portPatternTestInput = $state('');
+
+	const regexValidationError = $derived(
+		command.port_pattern !== null && command.port_pattern !== ''
+			? validateRegex(command.port_pattern)
+			: null,
+	);
+
+	const portPatternTestResult = $derived.by(() => {
+		if (
+			command.port_pattern === null ||
+			command.port_pattern === '' ||
+			portPatternTestInput === ''
+		) {
+			return null;
+		}
+		if (regexValidationError !== null) {
+			return null;
+		}
+		const port = extractPort(portPatternTestInput, command.port_pattern);
+		return port !== null ? { matched: true as const, port } : { matched: false as const };
+	});
 
 	const selectedPresetId = $derived.by(() => {
 		const currentPattern = command.port_pattern;
@@ -109,6 +134,35 @@
 					/>
 				</div>
 			</div>
+
+			{#if command.port_pattern}
+				<div class="flex flex-col gap-1">
+					<Input
+						value={portPatternTestInput}
+						oninput={(e) => {
+							portPatternTestInput = e.currentTarget.value;
+						}}
+						placeholder="Paste sample stdout to test pattern..."
+						class="h-7 font-mono text-xs"
+					/>
+					{#if regexValidationError}
+						<div class="flex items-center gap-1 text-destructive text-xs">
+							<TriangleAlertIcon size={12} />
+							<span>{regexValidationError}</span>
+						</div>
+					{:else if portPatternTestResult?.matched === true}
+						<div class="flex items-center gap-1 text-status-success text-xs">
+							<CircleCheckIcon size={12} />
+							<span>Port: {portPatternTestResult.port}</span>
+						</div>
+					{:else if portPatternTestResult?.matched === false}
+						<div class="flex items-center gap-1 text-muted-foreground text-xs">
+							<CircleXIcon size={12} />
+							<span>No match</span>
+						</div>
+					{/if}
+				</div>
+			{/if}
 		{:else}
 			<div class="flex w-32 flex-col gap-1">
 				<span class="text-xs text-muted-foreground">Expected Exit Code</span>

--- a/src/lib/components/blocks/workspace/port_pattern_presets.test.ts
+++ b/src/lib/components/blocks/workspace/port_pattern_presets.test.ts
@@ -1,14 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { PORT_PATTERN_PRESETS } from './port_pattern_presets.js';
-
-function extractPort(line: string, pattern: string): number | null {
-	const regex = new RegExp(pattern);
-	const match = regex.exec(line);
-	if (match === null || match[1] === undefined) {
-		return null;
-	}
-	return parseInt(match[1], 10);
-}
+import { PORT_PATTERN_PRESETS, extractPort, validateRegex } from './port_pattern_presets.js';
 
 describe('PORT_PATTERN_PRESETS', () => {
 	it('has at least 4 regex presets plus Custom', () => {
@@ -30,6 +21,42 @@ describe('PORT_PATTERN_PRESETS', () => {
 	it('has exactly one recommended preset', () => {
 		const recommended = PORT_PATTERN_PRESETS.filter((p) => p.recommended === true);
 		expect(recommended).toHaveLength(1);
+	});
+});
+
+describe('extractPort', () => {
+	it('returns port number on match', () => {
+		expect(extractPort('localhost:3000', String.raw`localhost:(\d+)`)).toBe(3000);
+	});
+
+	it('returns null on no match', () => {
+		expect(extractPort('Compiling...', String.raw`localhost:(\d+)`)).toBeNull();
+	});
+
+	it('handles empty string input', () => {
+		expect(extractPort('', String.raw`localhost:(\d+)`)).toBeNull();
+	});
+});
+
+describe('validateRegex', () => {
+	it('returns null for valid pattern', () => {
+		expect(validateRegex(String.raw`localhost:(\d+)`)).toBeNull();
+	});
+
+	it('returns error string for invalid regex', () => {
+		expect(validateRegex('(((invalid')).not.toBeNull();
+	});
+
+	it('returns null for all preset patterns', () => {
+		for (const preset of PORT_PATTERN_PRESETS) {
+			if (preset.regex !== null) {
+				expect(validateRegex(preset.regex)).toBeNull();
+			}
+		}
+	});
+
+	it('returns null for empty string', () => {
+		expect(validateRegex('')).toBeNull();
 	});
 });
 

--- a/src/lib/components/blocks/workspace/port_pattern_presets.ts
+++ b/src/lib/components/blocks/workspace/port_pattern_presets.ts
@@ -32,3 +32,21 @@ export const PORT_PATTERN_PRESETS = [
 ] as const;
 
 export type PortPatternPreset = (typeof PORT_PATTERN_PRESETS)[number];
+
+export function extractPort(line: string, pattern: string): number | null {
+	const regex = new RegExp(pattern);
+	const match = regex.exec(line);
+	if (match === null || match[1] === undefined) {
+		return null;
+	}
+	return parseInt(match[1], 10);
+}
+
+export function validateRegex(pattern: string): string | null {
+	try {
+		new RegExp(pattern);
+		return null;
+	} catch (error) {
+		return error instanceof SyntaxError ? error.message : 'Invalid regex';
+	}
+}


### PR DESCRIPTION
## Description
- Added inline regex validation/testing UI to WorkspaceCommandRow
- Test input field appears when a port pattern is configured (preset or custom)
- Success indicator displays captured port number when pattern matches sample stdout
- "No match" indicator for non-matching stdout
- Error indication for invalid regex syntax
- Reactive validation updates on every keystroke via `$derived`
- Exported `extractPort()` and `validateRegex()` utility functions from port_pattern_presets.ts
- Comprehensive test coverage: 31 unit tests for all presets, match/no-match scenarios, and regex validation

## Resolves
Closes #355

## Testing
- [x] Unit tests added (31 tests covering all presets, validation, and edge cases)