### PR TITLE
#357 feat(processes): Refresh CI badges on process restart

### DIFF
--- a/src/lib/modules/processes/processes.context.svelte.ts
+++ b/src/lib/modules/processes/processes.context.svelte.ts
@@ -22,14 +22,14 @@ type ProcessesContext = ReturnType<typeof createProcessesContext>['publicApi'];
 const [useProcesses, setProcessesInternal] = createContext<ProcessesContext>();
 export { useProcesses };
 
-export function setProcessesContext() {
+export function setProcessesContext(onProcessRestarted?: (issueId: string) => void) {
 	const {
 		publicApi,
 		handlePortDetected,
 		handleProcessExited,
 		handleProcessOutput,
 		handleProcessRestarted,
-	} = createProcessesContext();
+	} = createProcessesContext(onProcessRestarted);
 	setProcessesInternal(publicApi);
 
 	let cancelled = false;
@@ -84,7 +84,7 @@ export function setProcessesContext() {
 // ─── Factory ──────────────────────────────────────────────────────────────
 
 /** @internal - exported only for testing */
-export function createProcessesContext() {
+export function createProcessesContext(onProcessRestarted?: (issueId: string) => void) {
 	let processes = $state<RunningProcess[]>([]);
 	const logLines = new SvelteMap<string, ProcessLogLine[]>();
 	let activeLogViewerProcessId = $state<string | null>(null);
@@ -127,6 +127,7 @@ export function createProcessesContext() {
 			process.restart_count = restartCount;
 			process.max_restarts = maxRestarts;
 			process.status = 'running';
+			onProcessRestarted?.(process.issue_id);
 		}
 	}
 

--- a/src/lib/modules/processes/processes_context.svelte.test.ts
+++ b/src/lib/modules/processes/processes_context.svelte.test.ts
@@ -42,9 +42,9 @@ describe('processes context (factory)', () => {
 		mockListen.mockReset().mockResolvedValue(() => {});
 	});
 
-	async function createCtx() {
+	async function createCtx(onProcessRestarted?: (issueId: string) => void) {
 		const { createProcessesContext } = await import('./processes.context.svelte.js');
-		return createProcessesContext();
+		return createProcessesContext(onProcessRestarted);
 	}
 
 	it('loadProcesses calls get_running_processes and populates state', async () => {
@@ -195,6 +195,42 @@ describe('processes context (factory)', () => {
 		// Should not throw
 		handleProcessRestarted(['unknown-proc', 1, 3]);
 		expect(publicApi.processes).toHaveLength(0);
+	});
+
+	it('handleProcessRestarted calls onProcessRestarted callback with issue_id', async () => {
+		const callback = vi.fn();
+		const { publicApi, handleProcessRestarted } = await createCtx(callback);
+
+		mockInvoke.mockResolvedValue(MOCK_PROCESS);
+		await publicApi.runCommand('cmd-1', 'issue-1');
+
+		handleProcessRestarted(['proc-1', 1, 3]);
+
+		expect(callback).toHaveBeenCalledOnce();
+		expect(callback).toHaveBeenCalledWith('issue-1');
+	});
+
+	it('handleProcessRestarted does NOT call callback for unknown process', async () => {
+		const callback = vi.fn();
+		const { handleProcessRestarted } = await createCtx(callback);
+
+		handleProcessRestarted(['unknown-proc', 1, 3]);
+
+		expect(callback).not.toHaveBeenCalled();
+	});
+
+	it('createProcessesContext works without callback (backwards compat)', async () => {
+		const { publicApi, handleProcessRestarted } = await createCtx();
+
+		mockInvoke.mockResolvedValue(MOCK_PROCESS);
+		await publicApi.runCommand('cmd-1', 'issue-1');
+
+		// Should not throw even without callback
+		handleProcessRestarted(['proc-1', 1, 3]);
+
+		const process = publicApi.processes.find((p) => p.process_id === 'proc-1');
+		expect(process?.restart_count).toBe(1);
+		expect(process?.status).toBe('running');
 	});
 
 	it('getFullProcessLogs invokes with correct args', async () => {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,7 +2,8 @@
 	import '@fontsource/geist';
 	import '@fontsource/geist-mono';
 	import '../app.css';
-	import { onMount } from 'svelte';
+	import { onMount, onDestroy } from 'svelte';
+	import { SvelteSet } from 'svelte/reactivity';
 	import { preloadCode, goto } from '$app/navigation';
 	import { page } from '$app/state';
 	import { resolve } from '$app/paths';
@@ -52,7 +53,33 @@
 	setIssuesContext();
 	const versionControlCtx = setVersionControlContext();
 	setActionsContext();
-	setProcessesContext();
+
+	const RESTART_CI_REFRESH_DELAY_MS = 5_000;
+	const pendingRefreshIssueIds = new SvelteSet<string>();
+	let restartRefreshTimeout: ReturnType<typeof setTimeout> | null = null;
+
+	function batchedCiRefreshOnRestart(issueId: string) {
+		pendingRefreshIssueIds.add(issueId);
+		if (restartRefreshTimeout !== null) {
+			clearTimeout(restartRefreshTimeout);
+		}
+		restartRefreshTimeout = setTimeout(() => {
+			for (const id of pendingRefreshIssueIds) {
+				versionControlCtx.refreshGitStatus(id);
+			}
+			pendingRefreshIssueIds.clear();
+			restartRefreshTimeout = null;
+		}, RESTART_CI_REFRESH_DELAY_MS);
+	}
+
+	setProcessesContext(batchedCiRefreshOnRestart);
+
+	onDestroy(() => {
+		if (restartRefreshTimeout !== null) {
+			clearTimeout(restartRefreshTimeout);
+		}
+		pendingRefreshIssueIds.clear();
+	});
 	const shortcutsCtx = setKeyboardShortcutsContext();
 	const commandPaletteCtx = setCommandPaletteContext();
 	const toastsCtx = setToastsContext();


### PR DESCRIPTION
## Description
- Added optional `onProcessRestarted` callback to `createProcessesContext()` and `setProcessesContext()` — invoked with the issue ID after state update in `handleProcessRestarted`
- Wired batched CI refresh in root layout: collects restart issue IDs into a SvelteSet, flushes via `versionControlCtx.refreshGitStatus()` after 5-second debounce to coalesce rapid restart cycles
- Added cleanup on destroy to clear pending timeout
- Added 3 unit tests: callback invocation with correct issue_id, no callback for unknown process, backwards compat without callback

## Resolves
Closes #357

## Testing
- [x] Unit tests added for new callback behavior
- [x] Backwards compatibility verified (context works without callback)
- [x] Debounce logic prevents excessive CI refresh calls during rapid restarts