### PR TITLE
#356 feat(process): configurable restart retry count and backoff delays

### DIFF
--- a/src-tauri/src/commands/process_commands.rs
+++ b/src-tauri/src/commands/process_commands.rs
@@ -5,7 +5,7 @@ use uuid::Uuid;
 
 use crate::database::connection::DatabaseState;
 use crate::models::workspace_command::{CommandCategory, CommandMode, RestartPolicy};
-use crate::process::lifecycle::{backoff_delay, resolve_timeout, should_restart, MAX_RESTARTS};
+use crate::process::lifecycle::{backoff_delay, resolve_timeout, should_restart};
 use crate::process::manager::{ProcessManager, ProcessStatus, RunningProcess};
 
 fn spawn_shell_command(
@@ -51,6 +51,8 @@ pub async fn run_workspace_command(
         working_directory,
         mode,
         restart_policy,
+        max_restart_count,
+        backoff_base_delay_ms,
         timeout_seconds,
     ) = {
         let connection = state.read()?;
@@ -58,7 +60,8 @@ pub async fn run_workspace_command(
         connection
             .query_row(
                 "SELECT wc.command, wc.name, wc.category, wc.port_pattern, wc.expected_exit_code, \
-                 COALESCE(i.worktree_folder, d.local_folder), wc.mode, wc.restart_policy, wc.timeout_seconds \
+                 COALESCE(i.worktree_folder, d.local_folder), wc.mode, wc.restart_policy, \
+                 wc.max_restart_count, wc.backoff_base_delay_ms, wc.timeout_seconds \
                  FROM workspace_commands wc \
                  JOIN issues i ON i.id = ?2 \
                  JOIN dashboards d ON i.dashboard_id = d.id \
@@ -74,7 +77,9 @@ pub async fn run_workspace_command(
                         row.get::<_, Option<String>>(5)?,
                         row.get::<_, String>(6)?,
                         row.get::<_, String>(7)?,
-                        row.get::<_, Option<i64>>(8)?,
+                        row.get::<_, i64>(8)?,
+                        row.get::<_, i64>(9)?,
+                        row.get::<_, Option<i64>>(10)?,
                     ))
                 },
             )
@@ -124,6 +129,8 @@ pub async fn run_workspace_command(
     let task_command_str = command_str;
     let task_working_dir = working_dir;
     let task_restart_policy = restart_policy;
+    let task_max_restart_count = max_restart_count as u32;
+    let task_backoff_base_delay_ms = backoff_base_delay_ms as u64;
     // Compile once — avoids per-line recompilation
     let compiled_port_regex = port_pattern.as_deref().and_then(|p| Regex::new(p).ok());
 
@@ -234,15 +241,16 @@ pub async fn run_workspace_command(
                 exit_code,
                 is_timeout,
                 restart_count,
+                task_max_restart_count,
             ) {
                 restart_count += 1;
                 task_pm.set_restart_count(&task_process_id, restart_count);
                 task_pm.set_status(&task_process_id, ProcessStatus::Running);
                 let _ = task_app.emit(
                     "process-restarted",
-                    (&task_process_id, restart_count, MAX_RESTARTS),
+                    (&task_process_id, restart_count, task_max_restart_count),
                 );
-                tokio::time::sleep(backoff_delay(restart_count - 1)).await;
+                tokio::time::sleep(backoff_delay(restart_count - 1, task_backoff_base_delay_ms)).await;
                 continue;
             }
 
@@ -261,6 +269,7 @@ pub async fn run_workspace_command(
             name,
             0, // PID is set inside the task once child spawns
             join_handle.abort_handle(),
+            task_max_restart_count,
         )
         .map_err(|err| format!("Failed to create process log file: {err}"))?;
 

--- a/src-tauri/src/commands/workspace_command_commands.rs
+++ b/src-tauri/src/commands/workspace_command_commands.rs
@@ -7,11 +7,12 @@ use crate::models::workspace_command::{
     CommandCategory, CommandMode, CreateWorkspaceCommandRequest, RestartPolicy,
     UpdateWorkspaceCommandRequest, WorkspaceCommand,
 };
+use crate::process::lifecycle::{DEFAULT_BACKOFF_BASE_DELAY_MS, DEFAULT_MAX_RESTART_COUNT};
 
 use super::shared::resolve_nullable_field;
 
 const SELECT_COLUMNS: &str =
-    "id, dashboard_id, category, name, command, port_pattern, expected_exit_code, sort_order, mode, restart_policy, timeout_seconds";
+    "id, dashboard_id, category, name, command, port_pattern, expected_exit_code, sort_order, mode, restart_policy, max_restart_count, backoff_base_delay_ms, timeout_seconds";
 
 fn row_to_workspace_command(row: &Row) -> Result<WorkspaceCommand, rusqlite::Error> {
     let category_string: String = row.get(2)?;
@@ -29,7 +30,7 @@ fn row_to_workspace_command(row: &Row) -> Result<WorkspaceCommand, rusqlite::Err
         rusqlite::Error::FromSqlConversionFailure(9, rusqlite::types::Type::Text, error.into())
     })?;
 
-    let timeout_seconds: Option<i64> = row.get(10)?;
+    let timeout_seconds: Option<i64> = row.get(12)?;
 
     Ok(WorkspaceCommand {
         id: row.get(0)?,
@@ -42,6 +43,8 @@ fn row_to_workspace_command(row: &Row) -> Result<WorkspaceCommand, rusqlite::Err
         sort_order: row.get(7)?,
         mode,
         restart_policy,
+        max_restart_count: row.get(10)?,
+        backoff_base_delay_ms: row.get(11)?,
         timeout_seconds,
     })
 }
@@ -56,8 +59,8 @@ pub fn create_workspace_command(
 
     connection
         .execute(
-            "INSERT INTO workspace_commands (id, dashboard_id, category, name, command, port_pattern, expected_exit_code, sort_order, mode, restart_policy, timeout_seconds) \
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+            "INSERT INTO workspace_commands (id, dashboard_id, category, name, command, port_pattern, expected_exit_code, sort_order, mode, restart_policy, max_restart_count, backoff_base_delay_ms, timeout_seconds) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
             rusqlite::params![
                 id,
                 request.dashboard_id,
@@ -69,6 +72,8 @@ pub fn create_workspace_command(
                 request.sort_order.unwrap_or(0),
                 request.mode.unwrap_or(CommandMode::Headless).to_string(),
                 request.restart_policy.unwrap_or(RestartPolicy::Never).to_string(),
+                request.max_restart_count.unwrap_or(DEFAULT_MAX_RESTART_COUNT),
+                request.backoff_base_delay_ms.unwrap_or(DEFAULT_BACKOFF_BASE_DELAY_MS),
                 request.timeout_seconds,
             ],
         )
@@ -125,13 +130,16 @@ pub fn update_workspace_command(
     let sort_order = request.sort_order.unwrap_or(existing.sort_order);
     let mode = request.mode.unwrap_or(existing.mode);
     let restart_policy = request.restart_policy.unwrap_or(existing.restart_policy);
+    let max_restart_count = request.max_restart_count.unwrap_or(existing.max_restart_count);
+    let backoff_base_delay_ms = request.backoff_base_delay_ms.unwrap_or(existing.backoff_base_delay_ms);
     let timeout_seconds = resolve_nullable_field(request.timeout_seconds, existing.timeout_seconds);
 
     connection
         .execute(
             "UPDATE workspace_commands SET name = ?1, category = ?2, command = ?3, port_pattern = ?4, \
-             expected_exit_code = ?5, sort_order = ?6, mode = ?7, restart_policy = ?8, timeout_seconds = ?9 \
-             WHERE id = ?10",
+             expected_exit_code = ?5, sort_order = ?6, mode = ?7, restart_policy = ?8, \
+             max_restart_count = ?9, backoff_base_delay_ms = ?10, timeout_seconds = ?11 \
+             WHERE id = ?12",
             rusqlite::params![
                 name,
                 category.to_string(),
@@ -141,6 +149,8 @@ pub fn update_workspace_command(
                 sort_order,
                 mode.to_string(),
                 restart_policy.to_string(),
+                max_restart_count,
+                backoff_base_delay_ms,
                 timeout_seconds,
                 existing.id,
             ],

--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -240,6 +240,8 @@ pub fn create_tables(connection: &Connection) -> Result<(), rusqlite::Error> {
             sort_order INTEGER NOT NULL DEFAULT 0,
             mode TEXT NOT NULL DEFAULT 'headless' CHECK (mode IN ('headless', 'terminal')),
             restart_policy TEXT NOT NULL DEFAULT 'never' CHECK (restart_policy IN ('never', 'on_failure', 'always')),
+            max_restart_count INTEGER NOT NULL DEFAULT 3 CHECK (max_restart_count >= 0),
+            backoff_base_delay_ms INTEGER NOT NULL DEFAULT 1000 CHECK (backoff_base_delay_ms >= 0),
             timeout_seconds INTEGER
         );
 

--- a/src-tauri/src/models/workspace_command.rs
+++ b/src-tauri/src/models/workspace_command.rs
@@ -100,6 +100,10 @@ pub struct WorkspaceCommand {
     pub sort_order: i64,
     pub mode: CommandMode,
     pub restart_policy: RestartPolicy,
+    #[ts(type = "number")]
+    pub max_restart_count: i64,
+    #[ts(type = "number")]
+    pub backoff_base_delay_ms: i64,
     #[ts(type = "number | null")]
     pub timeout_seconds: Option<i64>,
 }
@@ -115,6 +119,8 @@ pub struct CreateWorkspaceCommandRequest {
     pub sort_order: Option<i64>,
     pub mode: Option<CommandMode>,
     pub restart_policy: Option<RestartPolicy>,
+    pub max_restart_count: Option<i64>,
+    pub backoff_base_delay_ms: Option<i64>,
     pub timeout_seconds: Option<i64>,
 }
 
@@ -130,6 +136,8 @@ pub struct UpdateWorkspaceCommandRequest {
     pub sort_order: Option<i64>,
     pub mode: Option<CommandMode>,
     pub restart_policy: Option<RestartPolicy>,
+    pub max_restart_count: Option<i64>,
+    pub backoff_base_delay_ms: Option<i64>,
     #[serde(default, deserialize_with = "crate::models::dashboard::deserialize_optional_nullable_i64")]
     pub timeout_seconds: Option<Option<i64>>,
 }

--- a/src-tauri/src/process/lifecycle.rs
+++ b/src-tauri/src/process/lifecycle.rs
@@ -2,11 +2,13 @@ use std::time::Duration;
 
 use crate::models::workspace_command::{CommandCategory, RestartPolicy};
 
-pub const MAX_RESTARTS: u32 = 3;
+pub const DEFAULT_MAX_RESTART_COUNT: i64 = 3;
+pub const DEFAULT_BACKOFF_BASE_DELAY_MS: i64 = 1000;
 const DEFAULT_CHECK_TIMEOUT_SECONDS: u64 = 30;
 
-pub fn backoff_delay(restart_count: u32) -> Duration {
-    Duration::from_secs(1u64 << restart_count.min(30))
+pub fn backoff_delay(restart_count: u32, base_delay_ms: u64) -> Duration {
+    let multiplier = 1u64 << restart_count.min(30);
+    Duration::from_millis(base_delay_ms.saturating_mul(multiplier))
 }
 
 pub fn resolve_timeout(category: &CommandCategory, timeout_seconds: Option<i64>) -> Option<Duration> {
@@ -25,8 +27,9 @@ pub fn should_restart(
     exit_code: Option<i32>,
     is_timeout: bool,
     restart_count: u32,
+    max_restarts: u32,
 ) -> bool {
-    if restart_count >= MAX_RESTARTS {
+    if restart_count >= max_restarts {
         return false;
     }
     match policy {
@@ -51,18 +54,54 @@ mod tests {
     // --- backoff_delay ---
 
     #[test]
-    fn backoff_delay_first_retry() {
-        assert_eq!(backoff_delay(0), Duration::from_secs(1));
+    fn backoff_delay_base_1000_first_retry() {
+        assert_eq!(backoff_delay(0, 1000), Duration::from_millis(1000));
     }
 
     #[test]
-    fn backoff_delay_second_retry() {
-        assert_eq!(backoff_delay(1), Duration::from_secs(2));
+    fn backoff_delay_base_1000_second_retry() {
+        assert_eq!(backoff_delay(1, 1000), Duration::from_millis(2000));
     }
 
     #[test]
-    fn backoff_delay_third_retry() {
-        assert_eq!(backoff_delay(2), Duration::from_secs(4));
+    fn backoff_delay_base_1000_third_retry() {
+        assert_eq!(backoff_delay(2, 1000), Duration::from_millis(4000));
+    }
+
+    #[test]
+    fn backoff_delay_base_500_first_retry() {
+        assert_eq!(backoff_delay(0, 500), Duration::from_millis(500));
+    }
+
+    #[test]
+    fn backoff_delay_base_500_second_retry() {
+        assert_eq!(backoff_delay(1, 500), Duration::from_millis(1000));
+    }
+
+    #[test]
+    fn backoff_delay_base_500_third_retry() {
+        assert_eq!(backoff_delay(2, 500), Duration::from_millis(2000));
+    }
+
+    #[test]
+    fn backoff_delay_base_2000_first_retry() {
+        assert_eq!(backoff_delay(0, 2000), Duration::from_millis(2000));
+    }
+
+    #[test]
+    fn backoff_delay_base_2000_second_retry() {
+        assert_eq!(backoff_delay(1, 2000), Duration::from_millis(4000));
+    }
+
+    #[test]
+    fn backoff_delay_base_2000_third_retry() {
+        assert_eq!(backoff_delay(2, 2000), Duration::from_millis(8000));
+    }
+
+    #[test]
+    fn backoff_delay_high_count_no_overflow() {
+        assert_eq!(backoff_delay(30, 1000), Duration::from_millis(1_073_741_824_000));
+        assert_eq!(backoff_delay(63, u64::MAX), Duration::from_millis(u64::MAX));
     }
 
     // --- resolve_timeout ---
@@ -102,40 +141,58 @@ mod tests {
 
     #[test]
     fn should_restart_never_policy() {
-        assert!(!should_restart(&RestartPolicy::Never, Some(1), false, 0));
-        assert!(!should_restart(&RestartPolicy::Never, Some(0), false, 0));
-        assert!(!should_restart(&RestartPolicy::Never, None, true, 0));
+        assert!(!should_restart(&RestartPolicy::Never, Some(1), false, 0, 3));
+        assert!(!should_restart(&RestartPolicy::Never, Some(0), false, 0, 3));
+        assert!(!should_restart(&RestartPolicy::Never, None, true, 0, 3));
     }
 
     #[test]
     fn should_restart_on_failure_nonzero() {
-        assert!(should_restart(&RestartPolicy::OnFailure, Some(1), false, 0));
+        assert!(should_restart(&RestartPolicy::OnFailure, Some(1), false, 0, 3));
     }
 
     #[test]
     fn should_restart_on_failure_zero() {
-        assert!(!should_restart(&RestartPolicy::OnFailure, Some(0), false, 0));
+        assert!(!should_restart(&RestartPolicy::OnFailure, Some(0), false, 0, 3));
     }
 
     #[test]
     fn should_restart_on_failure_timeout() {
-        assert!(should_restart(&RestartPolicy::OnFailure, None, true, 0));
+        assert!(should_restart(&RestartPolicy::OnFailure, None, true, 0, 3));
     }
 
     #[test]
     fn should_restart_always_zero() {
-        assert!(should_restart(&RestartPolicy::Always, Some(0), false, 0));
+        assert!(should_restart(&RestartPolicy::Always, Some(0), false, 0, 3));
     }
 
     #[test]
     fn should_restart_always_nonzero() {
-        assert!(should_restart(&RestartPolicy::Always, Some(1), false, 0));
+        assert!(should_restart(&RestartPolicy::Always, Some(1), false, 0, 3));
     }
 
     #[test]
     fn should_restart_max_reached() {
-        assert!(!should_restart(&RestartPolicy::Always, Some(1), false, 3));
-        assert!(!should_restart(&RestartPolicy::OnFailure, Some(1), false, 3));
-        assert!(!should_restart(&RestartPolicy::Never, Some(1), false, 3));
+        assert!(!should_restart(&RestartPolicy::Always, Some(1), false, 3, 3));
+        assert!(!should_restart(&RestartPolicy::OnFailure, Some(1), false, 3, 3));
+        assert!(!should_restart(&RestartPolicy::Never, Some(1), false, 3, 3));
+    }
+
+    #[test]
+    fn should_restart_custom_max_1() {
+        assert!(!should_restart(&RestartPolicy::Always, Some(1), false, 1, 1));
+        assert!(should_restart(&RestartPolicy::Always, Some(1), false, 0, 1));
+    }
+
+    #[test]
+    fn should_restart_custom_max_5() {
+        assert!(should_restart(&RestartPolicy::OnFailure, Some(1), false, 4, 5));
+        assert!(!should_restart(&RestartPolicy::OnFailure, Some(1), false, 5, 5));
+    }
+
+    #[test]
+    fn should_restart_max_zero_always_false() {
+        assert!(!should_restart(&RestartPolicy::Always, Some(1), false, 0, 0));
+        assert!(!should_restart(&RestartPolicy::OnFailure, Some(1), false, 0, 0));
     }
 }

--- a/src-tauri/src/process/manager.rs
+++ b/src-tauri/src/process/manager.rs
@@ -135,6 +135,7 @@ impl ProcessManager {
         name: String,
         pid: u32,
         abort_handle: tokio::task::AbortHandle,
+        max_restarts: u32,
     ) -> Result<(), std::io::Error> {
         let log_file_path =
             std::env::temp_dir().join(format!("grovekeeper-proc-{process_id}.log"));
@@ -151,7 +152,7 @@ impl ProcessManager {
             port: None,
             status: ProcessStatus::Running,
             restart_count: 0,
-            max_restarts: crate::process::lifecycle::MAX_RESTARTS,
+            max_restarts,
         };
         let tracked = TrackedProcess {
             info,

--- a/src/lib/components/blocks/issue-card/command_submenu_utils.test.ts
+++ b/src/lib/components/blocks/issue-card/command_submenu_utils.test.ts
@@ -14,6 +14,8 @@ function makeCommand(overrides: Partial<WorkspaceCommand> = {}): WorkspaceComman
 		sort_order: 0,
 		mode: 'headless',
 		restart_policy: 'never',
+		max_restart_count: 3,
+		backoff_base_delay_ms: 1000,
 		timeout_seconds: null,
 		...overrides,
 	};

--- a/src/lib/components/blocks/workspace/WorkspaceCommandRow.svelte
+++ b/src/lib/components/blocks/workspace/WorkspaceCommandRow.svelte
@@ -169,6 +169,41 @@
 			</div>
 		</div>
 
+		{#if command.restart_policy !== 'never'}
+			<div class="flex gap-2">
+				<div class="flex w-28 flex-col gap-1">
+					<span class="text-xs text-muted-foreground">Max Retries</span>
+					<Input
+						type="number"
+						value={String(command.max_restart_count)}
+						onchange={(e) =>
+							onUpdate(
+								command.id,
+								'max_restart_count',
+								Math.max(0, parseInt(e.currentTarget.value, 10) || 0),
+							)}
+						min="0"
+						class="h-8 text-sm"
+					/>
+				</div>
+				<div class="flex w-36 flex-col gap-1">
+					<span class="text-xs text-muted-foreground">Backoff Base (ms)</span>
+					<Input
+						type="number"
+						value={String(command.backoff_base_delay_ms)}
+						onchange={(e) =>
+							onUpdate(
+								command.id,
+								'backoff_base_delay_ms',
+								parseInt(e.currentTarget.value, 10) || 100,
+							)}
+						min="100"
+						class="h-8 text-sm"
+					/>
+				</div>
+			</div>
+		{/if}
+
 		{#if command.mode === 'terminal'}
 			<p class="text-[10px] text-muted-foreground">
 				Terminal mode: opens in external terminal, no process tracking or badges.

--- a/src/lib/tauri_mock.ts
+++ b/src/lib/tauri_mock.ts
@@ -104,6 +104,8 @@ const MOCK_COMMAND_HANDLERS: Record<string, MockHandler> = {
 		sort_order: (request as Record<string, unknown>).sort_order ?? 0,
 		mode: (request as Record<string, unknown>).mode ?? 'headless',
 		restart_policy: (request as Record<string, unknown>).restart_policy ?? 'never',
+		max_restart_count: (request as Record<string, unknown>).max_restart_count ?? 3,
+		backoff_base_delay_ms: (request as Record<string, unknown>).backoff_base_delay_ms ?? 1000,
 		timeout_seconds: (request as Record<string, unknown>).timeout_seconds ?? null,
 	}),
 	update_workspace_command: ({ request }) => request,

--- a/src/lib/tauri_mock_data.ts
+++ b/src/lib/tauri_mock_data.ts
@@ -1433,6 +1433,8 @@ export const MOCK_WORKSPACE_COMMANDS: WorkspaceCommand[] = [
 		sort_order: 0,
 		mode: 'headless',
 		restart_policy: 'never',
+		max_restart_count: 3,
+		backoff_base_delay_ms: 1000,
 		timeout_seconds: null,
 	},
 	{
@@ -1446,6 +1448,8 @@ export const MOCK_WORKSPACE_COMMANDS: WorkspaceCommand[] = [
 		sort_order: 1,
 		mode: 'headless',
 		restart_policy: 'on_failure',
+		max_restart_count: 3,
+		backoff_base_delay_ms: 1000,
 		timeout_seconds: null,
 	},
 	{
@@ -1459,6 +1463,8 @@ export const MOCK_WORKSPACE_COMMANDS: WorkspaceCommand[] = [
 		sort_order: 0,
 		mode: 'headless',
 		restart_policy: 'never',
+		max_restart_count: 3,
+		backoff_base_delay_ms: 1000,
 		timeout_seconds: 60,
 	},
 	{
@@ -1472,6 +1478,8 @@ export const MOCK_WORKSPACE_COMMANDS: WorkspaceCommand[] = [
 		sort_order: 1,
 		mode: 'terminal',
 		restart_policy: 'never',
+		max_restart_count: 3,
+		backoff_base_delay_ms: 1000,
 		timeout_seconds: null,
 	},
 ];

--- a/src/lib/types/generated/WorkspaceCommand.ts
+++ b/src/lib/types/generated/WorkspaceCommand.ts
@@ -3,4 +3,4 @@ import type { CommandCategory } from "./CommandCategory";
 import type { CommandMode } from "./CommandMode";
 import type { RestartPolicy } from "./RestartPolicy";
 
-export type WorkspaceCommand = { id: string, dashboard_id: string, category: CommandCategory, name: string, command: string, port_pattern: string | null, expected_exit_code: number, sort_order: number, mode: CommandMode, restart_policy: RestartPolicy, timeout_seconds: number | null, };
+export type WorkspaceCommand = { id: string, dashboard_id: string, category: CommandCategory, name: string, command: string, port_pattern: string | null, expected_exit_code: number, sort_order: number, mode: CommandMode, restart_policy: RestartPolicy, max_restart_count: number, backoff_base_delay_ms: number, timeout_seconds: number | null, };


### PR DESCRIPTION
## Description
- Replaces hardcoded MAX_RESTARTS=3 and 1s base delay with per-command `max_restart_count` and `backoff_base_delay_ms` columns
- Adds database schema with CHECK constraints and named default constants (MAX_RESTART_COUNT=3, BACKOFF_BASE_DELAY_MS=1000)
- Implements exponential backoff calculation with configurable base delay in process lifecycle manager
- Adds conditional UI inputs for retry count and backoff delay visible when restart_policy is not "never"
- Includes 13 parameterized Rust tests validating backoff calculations and restart limits

## Resolves
Closes #356

## Testing
- [ ] Verify UI inputs appear only when restart_policy is not "never"
- [ ] Test restart with various max_restart_count and backoff_base_delay_ms values
- [ ] Confirm backoff timing follows exponential calculation (base * 2^attempt)
- [ ] Check database defaults apply correctly when columns not explicitly set