### PR TITLE
fix(ui): add cursor-pointer to all interactive components

### DIFF
--- a/src/lib/components/shadcn/accordion/accordion-trigger.svelte
+++ b/src/lib/components/shadcn/accordion/accordion-trigger.svelte
@@ -20,7 +20,7 @@
 		data-slot="accordion-trigger"
 		bind:ref
 		class={cn(
-			'focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md py-4 text-left text-sm font-medium hover:underline focus-visible:ring-3 **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 items-start justify-between border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50',
+			'focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md py-4 text-left text-sm font-medium cursor-pointer hover:underline focus-visible:ring-3 **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 items-start justify-between border border-transparent transition-all outline-none disabled:cursor-not-allowed disabled:opacity-50',
 			className,
 		)}
 		{...restProps}

--- a/src/lib/components/shadcn/button/button-variants.ts
+++ b/src/lib/components/shadcn/button/button-variants.ts
@@ -7,7 +7,7 @@ const FILLED_BUTTON_KBD_CLASSES =
 	'[&_[data-slot=kbd]]:border-[color-mix(in_oklch,currentColor_28%,transparent)] [&_[data-slot=kbd]]:bg-[color-mix(in_oklch,currentColor_16%,transparent)] [&_[data-slot=kbd]]:text-current';
 
 export const buttonVariants = tv({
-	base: 'inline-flex shrink-0 items-center justify-center gap-1.5 whitespace-nowrap rounded-md border border-transparent font-medium leading-none outline-none select-none transition-[background,border-color,color,transform,filter,box-shadow] duration-120 ease-[ease] active:scale-[0.96] focus-visible:outline-2 focus-visible:outline-solid focus-visible:outline-offset-2 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-45 [&_[data-icon]]:pointer-events-none [&_[data-icon]]:shrink-0',
+	base: 'inline-flex shrink-0 items-center justify-center gap-1.5 whitespace-nowrap rounded-md border border-transparent font-medium leading-none outline-none select-none cursor-pointer transition-[background,border-color,color,transform,filter,box-shadow] duration-120 ease-[ease] active:scale-[0.96] focus-visible:outline-2 focus-visible:outline-solid focus-visible:outline-offset-2 focus-visible:outline-ring disabled:cursor-not-allowed disabled:opacity-45 [&_[data-icon]]:pointer-events-none [&_[data-icon]]:shrink-0',
 	variants: {
 		intent: {
 			primary: `bg-primary text-primary-foreground shadow-sm hover:bg-[color-mix(in_oklch,var(--primary)_88%,white_12%)] dark:hover:bg-[color-mix(in_oklch,var(--primary)_88%,black_12%)] ${FILLED_BUTTON_KBD_CLASSES}`,

--- a/src/lib/components/shadcn/calendar/calendar-day.svelte
+++ b/src/lib/components/shadcn/calendar/calendar-day.svelte
@@ -12,7 +12,7 @@
 <CalendarPrimitive.Day
 	bind:ref
 	class={cn(
-		'flex size-(--cell-size) flex-col items-center justify-center gap-1 rounded-(--cell-radius) p-0 leading-none font-normal whitespace-nowrap select-none',
+		'flex size-(--cell-size) flex-col items-center justify-center gap-1 rounded-(--cell-radius) p-0 leading-none font-normal whitespace-nowrap select-none cursor-pointer',
 		'[&:last-child[data-selected=true]_button]:rounded-r-(--cell-radius)',
 		'not-data-selected:hover:bg-accent/15',
 		// Today (not selected) — light accent tint ensures contrast on all accent colors

--- a/src/lib/components/shadcn/collapsible/collapsible-trigger.svelte
+++ b/src/lib/components/shadcn/collapsible/collapsible-trigger.svelte
@@ -12,6 +12,6 @@
 <CollapsiblePrimitive.Trigger
 	bind:ref
 	data-slot="collapsible-trigger"
-	class={cn(className)}
+	class={cn('cursor-pointer', className)}
 	{...restProps}
 />

--- a/src/lib/components/shadcn/command/command-item.svelte
+++ b/src/lib/components/shadcn/command/command-item.svelte
@@ -15,7 +15,7 @@
 	bind:ref
 	data-slot="command-item"
 	class={cn(
-		"group/command-item data-selected:bg-muted data-selected:text-foreground data-selected:*:[svg]:text-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none in-data-[slot=dialog-content]:rounded-lg! data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+		"group/command-item data-selected:bg-muted data-selected:text-foreground data-selected:*:[svg]:text-foreground relative flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none in-data-[slot=dialog-content]:rounded-lg! data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
 		className,
 	)}
 	{...restProps}

--- a/src/lib/components/shadcn/command/command-link-item.svelte
+++ b/src/lib/components/shadcn/command/command-link-item.svelte
@@ -13,7 +13,7 @@
 	bind:ref
 	data-slot="command-item"
 	class={cn(
-		"group/command-item data-selected:bg-muted data-selected:text-foreground data-selected:*:[svg]:text-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+		"group/command-item data-selected:bg-muted data-selected:text-foreground data-selected:*:[svg]:text-foreground relative flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
 		className,
 	)}
 	{...restProps}

--- a/src/lib/components/shadcn/context-menu/context-menu-checkbox-item.svelte
+++ b/src/lib/components/shadcn/context-menu/context-menu-checkbox-item.svelte
@@ -25,7 +25,7 @@
 	data-slot="context-menu-checkbox-item"
 	data-inset={inset}
 	class={cn(
-		"focus:bg-accent/25 gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm data-inset:pl-8 [&_svg:not([class*='size-'])]:size-4 relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		"focus:bg-accent/25 gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm data-inset:pl-8 [&_svg:not([class*='size-'])]:size-4 relative flex cursor-pointer items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
 		className,
 	)}
 	{...restProps}

--- a/src/lib/components/shadcn/context-menu/context-menu-item.svelte
+++ b/src/lib/components/shadcn/context-menu/context-menu-item.svelte
@@ -20,7 +20,7 @@
 	data-inset={inset}
 	data-variant={variant}
 	class={cn(
-		"focus:bg-accent/25 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive data-[variant=destructive]:focus:text-destructive-foreground data-[variant=destructive]:*:[svg]:text-destructive data-[variant=destructive]:focus:*:[svg]:text-destructive-foreground data-[variant=destructive]:focus:**:[data-slot=context-menu-shortcut]:text-destructive-foreground gap-2 rounded-sm px-2 py-1.5 text-sm data-inset:pl-8 [&_svg:not([class*='size-'])]:size-4 group/context-menu-item relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		"focus:bg-accent/25 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive data-[variant=destructive]:focus:text-destructive-foreground data-[variant=destructive]:*:[svg]:text-destructive data-[variant=destructive]:focus:*:[svg]:text-destructive-foreground data-[variant=destructive]:focus:**:[data-slot=context-menu-shortcut]:text-destructive-foreground gap-2 rounded-sm px-2 py-1.5 text-sm data-inset:pl-8 [&_svg:not([class*='size-'])]:size-4 group/context-menu-item relative flex cursor-pointer items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
 		className,
 	)}
 	{...restProps}

--- a/src/lib/components/shadcn/context-menu/context-menu-radio-item.svelte
+++ b/src/lib/components/shadcn/context-menu/context-menu-radio-item.svelte
@@ -21,7 +21,7 @@
 	data-slot="context-menu-radio-item"
 	data-inset={inset}
 	class={cn(
-		"focus:bg-accent/25 gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm data-inset:pl-8 [&_svg:not([class*='size-'])]:size-4 relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		"focus:bg-accent/25 gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm data-inset:pl-8 [&_svg:not([class*='size-'])]:size-4 relative flex cursor-pointer items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
 		className,
 	)}
 	{...restProps}

--- a/src/lib/components/shadcn/context-menu/context-menu-sub-trigger.svelte
+++ b/src/lib/components/shadcn/context-menu/context-menu-sub-trigger.svelte
@@ -21,7 +21,7 @@
 	data-slot="context-menu-sub-trigger"
 	data-inset={inset}
 	class={cn(
-		"focus:bg-accent/25 data-open:bg-accent/25 gap-2 rounded-sm px-2 py-1.5 text-sm data-inset:pl-8 [&_svg:not([class*='size-'])]:size-4 flex cursor-default items-center outline-hidden select-none data-inset:ps-8 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		"focus:bg-accent/25 data-open:bg-accent/25 gap-2 rounded-sm px-2 py-1.5 text-sm data-inset:pl-8 [&_svg:not([class*='size-'])]:size-4 flex cursor-pointer items-center outline-hidden select-none data-inset:ps-8 [&_svg]:pointer-events-none [&_svg]:shrink-0",
 		className,
 	)}
 	{...restProps}

--- a/src/lib/components/shadcn/dropdown-menu/dropdown-menu-checkbox-item.svelte
+++ b/src/lib/components/shadcn/dropdown-menu/dropdown-menu-checkbox-item.svelte
@@ -23,7 +23,7 @@
 	bind:indeterminate
 	data-slot="dropdown-menu-checkbox-item"
 	class={cn(
-		"focus:bg-accent/25 gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm data-inset:pl-8 [&_svg:not([class*='size-'])]:size-4 relative flex cursor-default items-center outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		"focus:bg-accent/25 gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm data-inset:pl-8 [&_svg:not([class*='size-'])]:size-4 relative flex cursor-pointer items-center outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
 		className,
 	)}
 	{...restProps}

--- a/src/lib/components/shadcn/dropdown-menu/dropdown-menu-item.svelte
+++ b/src/lib/components/shadcn/dropdown-menu/dropdown-menu-item.svelte
@@ -20,7 +20,7 @@
 	data-inset={inset}
 	data-variant={variant}
 	class={cn(
-		"focus:bg-accent/25 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive data-[variant=destructive]:focus:text-destructive-foreground data-[variant=destructive]:*:[svg]:text-destructive data-[variant=destructive]:focus:*:[svg]:text-destructive-foreground data-[variant=destructive]:focus:**:[data-slot=dropdown-menu-shortcut]:text-destructive-foreground gap-2 rounded-sm px-2 py-1.5 text-sm data-inset:pl-8 [&_svg:not([class*='size-'])]:size-4 group/dropdown-menu-item relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		"focus:bg-accent/25 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive data-[variant=destructive]:focus:text-destructive-foreground data-[variant=destructive]:*:[svg]:text-destructive data-[variant=destructive]:focus:*:[svg]:text-destructive-foreground data-[variant=destructive]:focus:**:[data-slot=dropdown-menu-shortcut]:text-destructive-foreground gap-2 rounded-sm px-2 py-1.5 text-sm data-inset:pl-8 [&_svg:not([class*='size-'])]:size-4 group/dropdown-menu-item relative flex cursor-pointer items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0",
 		className,
 	)}
 	{...restProps}

--- a/src/lib/components/shadcn/dropdown-menu/dropdown-menu-radio-item.svelte
+++ b/src/lib/components/shadcn/dropdown-menu/dropdown-menu-radio-item.svelte
@@ -15,7 +15,7 @@
 	bind:ref
 	data-slot="dropdown-menu-radio-item"
 	class={cn(
-		"focus:bg-accent/25 gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm data-inset:pl-8 [&_svg:not([class*='size-'])]:size-4 relative flex cursor-default items-center outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		"focus:bg-accent/25 gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm data-inset:pl-8 [&_svg:not([class*='size-'])]:size-4 relative flex cursor-pointer items-center outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
 		className,
 	)}
 	{...restProps}

--- a/src/lib/components/shadcn/dropdown-menu/dropdown-menu-sub-trigger.svelte
+++ b/src/lib/components/shadcn/dropdown-menu/dropdown-menu-sub-trigger.svelte
@@ -19,7 +19,7 @@
 	data-slot="dropdown-menu-sub-trigger"
 	data-inset={inset}
 	class={cn(
-		"focus:bg-accent/25 data-open:bg-accent/25 gap-2 rounded-sm px-2 py-1.5 text-sm data-inset:pl-8 [&_svg:not([class*='size-'])]:size-4 flex cursor-default items-center outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		"focus:bg-accent/25 data-open:bg-accent/25 gap-2 rounded-sm px-2 py-1.5 text-sm data-inset:pl-8 [&_svg:not([class*='size-'])]:size-4 flex cursor-pointer items-center outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0",
 		className,
 	)}
 	{...restProps}

--- a/src/lib/components/shadcn/range-calendar/range-calendar-day.svelte
+++ b/src/lib/components/shadcn/range-calendar/range-calendar-day.svelte
@@ -12,7 +12,7 @@
 <RangeCalendarPrimitive.Day
 	bind:ref
 	class={cn(
-		'flex size-(--cell-size) flex-col items-center justify-center gap-1 rounded-(--cell-radius) p-0 leading-none font-normal whitespace-nowrap select-none',
+		'flex size-(--cell-size) flex-col items-center justify-center gap-1 rounded-(--cell-radius) p-0 leading-none font-normal whitespace-nowrap select-none cursor-pointer',
 		'[&:not([data-selected]):not([data-highlighted])]:hover:bg-accent/15',
 		// Today (not selected) — light accent tint ensures contrast on all accent colors
 		'[&[data-today]:not([data-selected])]:bg-accent/25 [&[data-today]:not([data-selected])]:hover:bg-accent/50',

--- a/src/lib/components/shadcn/select/select-custom-item.svelte
+++ b/src/lib/components/shadcn/select/select-custom-item.svelte
@@ -19,7 +19,7 @@
 	{label}
 	data-slot="select-item"
 	class={cn(
-		'flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-(length:--text-md) text-foreground outline-none transition-colors',
+		'flex cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 text-(length:--text-md) text-foreground outline-none transition-colors',
 		'data-highlighted:bg-surface-2',
 		'data-[selected=]:bg-primary-soft',
 		'data-disabled:pointer-events-none data-disabled:opacity-50',

--- a/src/lib/components/shadcn/select/select-custom-trigger.svelte
+++ b/src/lib/components/shadcn/select/select-custom-trigger.svelte
@@ -19,7 +19,7 @@
 	bind:ref
 	data-slot="select-trigger"
 	class={cn(
-		'flex h-(--size-control-md) w-full cursor-default items-center justify-between rounded-md border border-border bg-surface px-2.5 font-sans text-(length:--text-md) text-foreground outline-none transition-[border-color,box-shadow] duration-120',
+		'flex h-(--size-control-md) w-full cursor-pointer items-center justify-between rounded-md border border-border bg-surface px-2.5 font-sans text-(length:--text-md) text-foreground outline-none transition-[border-color,box-shadow] duration-120',
 		'hover:border-border-strong',
 		'aria-expanded:border-ring aria-expanded:shadow-[0_0_0_3px_color-mix(in_oklch,var(--ring)_22%,transparent)]',
 		'disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-surface-2 disabled:text-foreground-subtle disabled:opacity-70',


### PR DESCRIPTION
## Description

Audited all base UI components for proper cursor styles. Added cursor-pointer to 17 interactive components that were missing it:

- Button: added cursor-pointer, replaced disabled:pointer-events-none with disabled:cursor-not-allowed
- Accordion trigger: added cursor-pointer, replaced disabled:pointer-events-none with disabled:cursor-not-allowed
- Collapsible trigger: added cursor-pointer
- Calendar day / Range calendar day: added cursor-pointer
- Select trigger and item: cursor-default → cursor-pointer
- Dropdown menu items (item, sub-trigger, checkbox-item, radio-item): cursor-default → cursor-pointer
- Context menu items (item, sub-trigger, checkbox-item, radio-item): cursor-default → cursor-pointer
- Command items (item, link-item): cursor-default → cursor-pointer

Components already correct (no changes): Switch, Checkbox, RadioGroupItem, Tabs, Input, Textarea, Label, StatCell, StatusRow, Badge, Kbd, Popover item

## Testing

- [ ] Visual verification of cursor feedback on interactive components
- [ ] No regression in existing component behavior
