### PR TITLE
#365 feat(issue-card): Ghost state for non-adopted issues

### DIFF
--- a/src/lib/components/blocks/issue-card/IssueCard.svelte
+++ b/src/lib/components/blocks/issue-card/IssueCard.svelte
@@ -32,6 +32,7 @@
 		issue: Issue;
 		cache?: GitStatusCache | null;
 		ghAvailable?: boolean;
+		isGhost?: boolean;
 		notificationDotColor?: string | null;
 		prdParent?: PrdParent | null;
 		prioritiesEnabled?: boolean;
@@ -47,6 +48,7 @@
 		issue,
 		cache = null,
 		ghAvailable = false,
+		isGhost = false,
 		notificationDotColor = null,
 		prdParent = null,
 		prioritiesEnabled = true,
@@ -64,6 +66,7 @@
 		issue,
 		cache,
 		ghAvailable,
+		isGhost,
 		notificationDotColor,
 		prdParent,
 		prioritiesEnabled,
@@ -142,7 +145,7 @@
 	</div>
 
 	<!-- Contextual action buttons -->
-	{#if !ctx.isArchived && onExecuteAction}
+	{#if !ctx.isArchived && !ctx.isGhost && onExecuteAction}
 		<div class="absolute bottom-2 right-2.5 flex items-center gap-1">
 			<ContextualActionButtons
 				derivedActions={contextualActions}

--- a/src/lib/components/blocks/issue-card/IssueCardHeaderActions.svelte
+++ b/src/lib/components/blocks/issue-card/IssueCardHeaderActions.svelte
@@ -15,7 +15,7 @@
 </script>
 
 <div class="flex shrink-0 items-center gap-1.5">
-	{#if ctx.chipState}
+	{#if !ctx.isGhost && ctx.chipState}
 		<IssueStateChip
 			label={ctx.chipState.label}
 			colorVariable={ctx.chipState.colorVariable}
@@ -35,5 +35,7 @@
 		/>
 	{/if}
 
-	<QuickActionButtons />
+	{#if !ctx.isGhost}
+		<QuickActionButtons />
+	{/if}
 </div>

--- a/src/lib/components/blocks/issue-card/IssueCardPreview.svelte
+++ b/src/lib/components/blocks/issue-card/IssueCardPreview.svelte
@@ -15,7 +15,7 @@
 			></span>
 		</SimpleTooltip>
 	{/if}
-	{#if ctx.visualization}
+	{#if !ctx.isGhost && ctx.visualization}
 		<div
 			class="absolute inset-0"
 			style="transform: scale(1.4); transform-origin: bottom center;"

--- a/src/lib/components/blocks/issue-card/batch_selection_utils.test.ts
+++ b/src/lib/components/blocks/issue-card/batch_selection_utils.test.ts
@@ -55,6 +55,7 @@ describe('computeRangeSelection', () => {
 describe('ISSUE_CARD_STATES', () => {
 	it('has all expected state keys', () => {
 		const expectedKeys = [
+			'ghost',
 			'active',
 			'hovered',
 			'selectionHover',

--- a/src/lib/components/blocks/issue-card/derive_card_state_class.test.ts
+++ b/src/lib/components/blocks/issue-card/derive_card_state_class.test.ts
@@ -3,6 +3,7 @@ import { deriveCardState, ISSUE_CARD_STATES, type CardStateInput } from './issue
 
 function makeInput(overrides: Partial<CardStateInput> = {}): CardStateInput {
 	return {
+		isGhost: false,
 		isArchived: false,
 		isBatchSelected: false,
 		isActive: false,
@@ -64,5 +65,35 @@ describe('deriveCardState', () => {
 		expect(deriveCardState(makeInput({ worktreeState: 'pending' }))).toBe(
 			ISSUE_CARD_STATES.worktreeSetup,
 		);
+	});
+
+	describe('ghost state', () => {
+		it('isGhost -> ghost', () => {
+			expect(deriveCardState(makeInput({ isGhost: true }))).toBe(ISSUE_CARD_STATES.ghost);
+		});
+
+		it('ghost overrides archived', () => {
+			expect(deriveCardState(makeInput({ isGhost: true, isArchived: true }))).toBe(
+				ISSUE_CARD_STATES.ghost,
+			);
+		});
+
+		it('ghost overrides selected', () => {
+			expect(deriveCardState(makeInput({ isGhost: true, isBatchSelected: true }))).toBe(
+				ISSUE_CARD_STATES.ghost,
+			);
+		});
+
+		it('ghost overrides active', () => {
+			expect(deriveCardState(makeInput({ isGhost: true, isActive: true }))).toBe(
+				ISSUE_CARD_STATES.ghost,
+			);
+		});
+
+		it('ghost overrides hovered', () => {
+			expect(deriveCardState(makeInput({ isGhost: true, isHovered: true }))).toBe(
+				ISSUE_CARD_STATES.ghost,
+			);
+		});
 	});
 });

--- a/src/lib/components/blocks/issue-card/issue_card.context.svelte.ts
+++ b/src/lib/components/blocks/issue-card/issue_card.context.svelte.ts
@@ -40,6 +40,7 @@ export interface IssueCardContextProps {
 	sessionState: SessionStateProp;
 	visualization: TreeVisualization | undefined;
 	appearanceSettings: IssueCardAppearanceSettings;
+	isGhost?: boolean;
 	isActive: boolean;
 	isHovered: boolean;
 	isBatchSelected: boolean;
@@ -96,6 +97,7 @@ export function createIssueCardContext(getProps: () => IssueCardContextProps) {
 	const cardState = $derived.by(() => {
 		const props = getProps();
 		return deriveCardState({
+			isGhost: props.isGhost ?? false,
 			isArchived: props.issue.status === 'archived',
 			isBatchSelected: props.isBatchSelected,
 			isActive: props.isActive,
@@ -113,6 +115,7 @@ export function createIssueCardContext(getProps: () => IssueCardContextProps) {
 			issueColor: props.issue.color ?? DEFAULT_ISSUE_COLOR,
 			state: cardState,
 			isHovered: props.isHovered,
+			labels: props.issue.labels,
 		});
 	});
 
@@ -138,6 +141,9 @@ export function createIssueCardContext(getProps: () => IssueCardContextProps) {
 		},
 		get visualization(): TreeVisualization | undefined {
 			return getProps().visualization;
+		},
+		get isGhost(): boolean {
+			return cardState === 'ghost';
 		},
 		get isActive(): boolean {
 			return getProps().isActive;

--- a/src/lib/components/blocks/issue-card/issue_card_variant_css.test.ts
+++ b/src/lib/components/blocks/issue-card/issue_card_variant_css.test.ts
@@ -24,14 +24,20 @@ function makeSettings(
 function computeForVariant(
 	variant: IssueCardAppearanceSettings['variant'],
 	overrides: Partial<IssueCardAppearanceSettings> = {},
-	options: { issueColor?: string; state?: IssueCardState } = {},
+	options: {
+		issueColor?: string;
+		state?: IssueCardState;
+		isHovered?: boolean;
+		labels?: ReadonlyArray<{ name: string; color: string }>;
+	} = {},
 ) {
 	return computeVariantSlotStyles({
 		variant,
 		settings: makeSettings({ variant, ...overrides }),
 		issueColor: options.issueColor ?? '#ff5500',
 		state: options.state ?? 'interactive',
-		isHovered: false,
+		isHovered: options.isHovered ?? false,
+		labels: options.labels ?? [],
 	});
 }
 
@@ -148,6 +154,7 @@ describe('computeVariantSlotStyles', () => {
 				issueColor: '#ff5500',
 				state: 'hovered',
 				isHovered: true,
+				labels: [],
 			});
 			expect(result.card.transform).toBe('translateY(-3px)');
 			expect(result.card['box-shadow']).toContain('var(--shadow-lg)');
@@ -170,6 +177,230 @@ describe('computeVariantSlotStyles', () => {
 		it('converts style map to CSS string', () => {
 			const result = styleMapToString({ background: 'red', color: 'blue' });
 			expect(result).toBe('background: red; color: blue');
+		});
+	});
+
+	describe('ghost state CSS', () => {
+		describe('base (0 labels, not hovered)', () => {
+			it('has dashed border-style', () => {
+				const result = computeForVariant('veil', {}, { state: 'ghost' });
+				expect(result.card['border-style']).toBe('dashed');
+			});
+
+			it('has neutral gray border-color', () => {
+				const result = computeForVariant('veil', {}, { state: 'ghost' });
+				expect(result.card['border-color']).toBe('var(--border)');
+			});
+
+			it('has neutral #1e1e1e background', () => {
+				const result = computeForVariant('veil', {}, { state: 'ghost' });
+				expect(result.card.background).toBe('#1e1e1e');
+			});
+
+			it('has no box-shadow', () => {
+				const result = computeForVariant('veil', {}, { state: 'ghost' });
+				expect(result.card['box-shadow']).toBe('none');
+			});
+
+			it('has opacity 0.82', () => {
+				const result = computeForVariant('veil', {}, { state: 'ghost' });
+				expect(result.card.opacity).toBe('0.82');
+			});
+
+			it('sets --ic-color to issueColor', () => {
+				const result = computeForVariant(
+					'veil',
+					{},
+					{ state: 'ghost', issueColor: '#aabbcc' },
+				);
+				expect(result.card['--ic-color']).toBe('#aabbcc');
+			});
+
+			it('sets --ic-header-text to var(--foreground)', () => {
+				const result = computeForVariant('veil', {}, { state: 'ghost' });
+				expect(result.card['--ic-header-text']).toBe('var(--foreground)');
+			});
+
+			it('has transparent header background', () => {
+				const result = computeForVariant('veil', {}, { state: 'ghost' });
+				expect(result.header.background).toBe('transparent');
+			});
+		});
+
+		describe('hover (0 labels, hovered)', () => {
+			it('has brighter border-color on hover', () => {
+				const result = computeForVariant('veil', {}, { state: 'ghost', isHovered: true });
+				expect(result.card['border-color']).toBe('var(--border-strong)');
+			});
+
+			it('has subtle gradient background on hover', () => {
+				const result = computeForVariant('veil', {}, { state: 'ghost', isHovered: true });
+				expect(result.card.background).toContain('linear-gradient');
+			});
+
+			it('has translateY(-2px) transform on hover', () => {
+				const result = computeForVariant('veil', {}, { state: 'ghost', isHovered: true });
+				expect(result.card.transform).toBe('translateY(-2px)');
+			});
+
+			it('has opacity 0.92 on hover', () => {
+				const result = computeForVariant('veil', {}, { state: 'ghost', isHovered: true });
+				expect(result.card.opacity).toBe('0.92');
+			});
+
+			it('keeps dashed border-style on hover', () => {
+				const result = computeForVariant('veil', {}, { state: 'ghost', isHovered: true });
+				expect(result.card['border-style']).toBe('dashed');
+			});
+		});
+
+		describe('hover with labels', () => {
+			const oneLabel = [{ name: 'bug', color: '#ff0000' }];
+
+			it('labeled ghost hover gains gradient overlay on top of tint', () => {
+				const result = computeForVariant(
+					'veil',
+					{ labelTint: 20 },
+					{ state: 'ghost', isHovered: true, labels: oneLabel },
+				);
+				expect(result.card.background).toContain('linear-gradient');
+				expect(result.card.background).toContain('#ff0000');
+			});
+
+			it('labeled ghost hover still lifts and brightens border', () => {
+				const result = computeForVariant(
+					'veil',
+					{},
+					{ state: 'ghost', isHovered: true, labels: oneLabel },
+				);
+				expect(result.card.transform).toBe('translateY(-2px)');
+				expect(result.card['border-color']).toBe('var(--border-strong)');
+			});
+		});
+
+		describe('1 label tinting', () => {
+			const oneLabel = [{ name: 'bug', color: '#ff0000' }];
+
+			it('card background uses color-mix with label color', () => {
+				const result = computeForVariant(
+					'veil',
+					{ labelTint: 20 },
+					{ state: 'ghost', labels: oneLabel },
+				);
+				expect(result.card.background).toContain('color-mix');
+				expect(result.card.background).toContain('#ff0000');
+				expect(result.card.background).toContain('20%');
+			});
+
+			it('header background uses higher tint opacity', () => {
+				const result = computeForVariant(
+					'veil',
+					{ labelTint: 20 },
+					{ state: 'ghost', labels: oneLabel },
+				);
+				expect(result.header.background).toContain('color-mix');
+				expect(result.header.background).toContain('#ff0000');
+				expect(result.header.background).toContain('40%');
+			});
+		});
+
+		describe('2 labels tinting', () => {
+			const twoLabels = [
+				{ name: 'enhancement', color: '#00ff00' },
+				{ name: 'bug', color: '#ff0000' },
+			];
+
+			it('sorts labels alphabetically and uses gradient', () => {
+				const result = computeForVariant(
+					'veil',
+					{ labelTint: 20 },
+					{ state: 'ghost', labels: twoLabels },
+				);
+				expect(result.card.background).toContain('linear-gradient');
+				// bug (#ff0000) comes first alphabetically, enhancement (#00ff00) second
+				const bgValue = result.card.background;
+				const firstColorIdx = bgValue.indexOf('#ff0000');
+				const secondColorIdx = bgValue.indexOf('#00ff00');
+				expect(firstColorIdx).toBeLessThan(secondColorIdx);
+			});
+
+			it('both labels appear in the gradient', () => {
+				const result = computeForVariant(
+					'veil',
+					{ labelTint: 20 },
+					{ state: 'ghost', labels: twoLabels },
+				);
+				expect(result.card.background).toContain('#ff0000');
+				expect(result.card.background).toContain('#00ff00');
+			});
+		});
+
+		describe('3+ labels tinting', () => {
+			const threeLabels = [
+				{ name: 'enhancement', color: '#00ff00' },
+				{ name: 'bug', color: '#ff0000' },
+				{ name: 'docs', color: '#0000ff' },
+			];
+
+			it('uses only first 2 alphabetically (same as 2-label)', () => {
+				const result = computeForVariant(
+					'veil',
+					{ labelTint: 20 },
+					{ state: 'ghost', labels: threeLabels },
+				);
+				// alphabetically: bug, docs, enhancement → first 2 are bug (#ff0000) and docs (#0000ff)
+				expect(result.card.background).toContain('#ff0000');
+				expect(result.card.background).toContain('#0000ff');
+				expect(result.card.background).not.toContain('#00ff00');
+			});
+		});
+
+		describe('labelTint respects settings', () => {
+			const oneLabel = [{ name: 'bug', color: '#ff0000' }];
+
+			it('uses 10% tint when labelTint is 10', () => {
+				const result = computeForVariant(
+					'veil',
+					{ labelTint: 10 },
+					{ state: 'ghost', labels: oneLabel },
+				);
+				expect(result.card.background).toContain('10%');
+			});
+
+			it('uses 30% tint when labelTint is 30', () => {
+				const result = computeForVariant(
+					'veil',
+					{ labelTint: 30 },
+					{ state: 'ghost', labels: oneLabel },
+				);
+				expect(result.card.background).toContain('30%');
+			});
+		});
+
+		describe('ghost produces same styles regardless of variant', () => {
+			it('veil ghost matches refined-horizon ghost', () => {
+				const veilResult = computeForVariant('veil', {}, { state: 'ghost' });
+				const horizonResult = computeForVariant('refined-horizon', {}, { state: 'ghost' });
+				expect(veilResult.card.background).toBe(horizonResult.card.background);
+				expect(veilResult.card['border-style']).toBe(horizonResult.card['border-style']);
+				expect(veilResult.card.opacity).toBe(horizonResult.card.opacity);
+			});
+
+			it('veil ghost matches radiant ghost', () => {
+				const veilResult = computeForVariant('veil', {}, { state: 'ghost' });
+				const radiantResult = computeForVariant('radiant', {}, { state: 'ghost' });
+				expect(veilResult.card.background).toBe(radiantResult.card.background);
+				expect(veilResult.card['border-style']).toBe(radiantResult.card['border-style']);
+				expect(veilResult.card.opacity).toBe(radiantResult.card.opacity);
+			});
+
+			it('refined-horizon ghost matches radiant ghost', () => {
+				const horizonResult = computeForVariant('refined-horizon', {}, { state: 'ghost' });
+				const radiantResult = computeForVariant('radiant', {}, { state: 'ghost' });
+				expect(horizonResult.card.background).toBe(radiantResult.card.background);
+				expect(horizonResult.card['border-style']).toBe(radiantResult.card['border-style']);
+				expect(horizonResult.card.opacity).toBe(radiantResult.card.opacity);
+			});
 		});
 	});
 });

--- a/src/lib/components/blocks/issue-card/issue_card_variant_css.ts
+++ b/src/lib/components/blocks/issue-card/issue_card_variant_css.ts
@@ -16,6 +16,7 @@ interface VariantStylesInput {
 	readonly issueColor: string;
 	readonly state: IssueCardState;
 	readonly isHovered: boolean;
+	readonly labels: ReadonlyArray<{ readonly name: string; readonly color: string }>;
 }
 
 // ── Helpers ───────────────────────────────────────────────────
@@ -131,6 +132,9 @@ function applyStateOverrides(
 	let header: Readonly<Record<string, string>> = base.header;
 
 	switch (state) {
+		case 'ghost':
+			break;
+
 		case 'interactive':
 			if (isHovered) {
 				header = applyHoverGlow(card, base.header, issueColor);
@@ -191,10 +195,85 @@ function applyStateOverrides(
 	return { card, header, preview: base.preview };
 }
 
+// ── Ghost label tinting ──────────────────────────────────────
+
+const GHOST_NEUTRAL_BASE = '#1e1e1e';
+
+function computeGhostLabelTint(
+	labels: ReadonlyArray<{ readonly name: string; readonly color: string }>,
+	labelTint: number,
+): { card: Record<string, string>; header: Record<string, string>; hasLabels: boolean } {
+	if (labels.length === 0) {
+		return {
+			card: { background: GHOST_NEUTRAL_BASE },
+			header: { background: 'transparent' },
+			hasLabels: false,
+		};
+	}
+
+	const sorted = [...labels].sort((a, b) => a.name.localeCompare(b.name));
+
+	if (sorted.length === 1) {
+		const color = sorted[0].color;
+		return {
+			card: {
+				background: `color-mix(in oklch, ${color} ${labelTint}%, ${GHOST_NEUTRAL_BASE})`,
+			},
+			header: {
+				background: `color-mix(in oklch, ${color} ${labelTint * 2}%, ${GHOST_NEUTRAL_BASE})`,
+			},
+			hasLabels: true,
+		};
+	}
+
+	// 2+ labels: split colorization with first 2 alphabetically
+	const leftColor = sorted[0].color;
+	const rightColor = sorted[1].color;
+	return {
+		card: {
+			background: `linear-gradient(to right, color-mix(in oklch, ${leftColor} ${labelTint}%, ${GHOST_NEUTRAL_BASE}) 0%, ${GHOST_NEUTRAL_BASE} 50%, color-mix(in oklch, ${rightColor} ${labelTint}%, ${GHOST_NEUTRAL_BASE}) 100%)`,
+		},
+		header: {
+			background: `linear-gradient(to right, color-mix(in oklch, ${leftColor} ${labelTint * 2}%, ${GHOST_NEUTRAL_BASE}) 0%, ${GHOST_NEUTRAL_BASE} 50%, color-mix(in oklch, ${rightColor} ${labelTint * 2}%, ${GHOST_NEUTRAL_BASE}) 100%)`,
+		},
+		hasLabels: true,
+	};
+}
+
 // ── Main export ───────────────────────────────────────────────
 
 export function computeVariantSlotStyles(input: VariantStylesInput): VariantSlotStyles {
-	const { variant, issueColor, settings, state, isHovered } = input;
+	const { variant, issueColor, settings, state, isHovered, labels } = input;
+
+	// Ghost cards bypass variant-specific styling
+	if (state === 'ghost') {
+		const tint = computeGhostLabelTint(labels, settings.labelTint);
+		const card: Record<string, string> = {
+			'--ic-color': issueColor,
+			'--ic-header-text': 'var(--foreground)',
+			'--ic-number-color': 'inherit',
+			'--ic-overlay-glow': '0',
+			...tint.card,
+			'border-style': 'dashed',
+			'border-color': 'var(--border)',
+			'box-shadow': 'none',
+			opacity: '0.82',
+		};
+		const header: Record<string, string> = { ...tint.header };
+
+		if (isHovered) {
+			card['border-color'] = 'var(--border-strong)';
+			if (tint.hasLabels) {
+				card.background = `linear-gradient(135deg, color-mix(in oklch, var(--foreground) 5%, transparent) 0%, transparent 100%), ${tint.card.background}`;
+			} else {
+				card.background = `linear-gradient(135deg, color-mix(in oklch, var(--foreground) 5%, ${GHOST_NEUTRAL_BASE}) 0%, ${GHOST_NEUTRAL_BASE} 100%)`;
+			}
+			card.transform = 'translateY(-2px)';
+			card.opacity = '0.92';
+		}
+
+		return { card, header, preview: {} };
+	}
 
 	const sharedCardProps: Record<string, string> = {
 		'--ic-color': issueColor,

--- a/src/lib/components/blocks/issue-card/issue_card_variants.ts
+++ b/src/lib/components/blocks/issue-card/issue_card_variants.ts
@@ -3,6 +3,7 @@ import { tv } from 'tailwind-variants';
 // ── Card state (visual priority cascade) ─────────────────────────────
 
 export const ISSUE_CARD_STATES = {
+	ghost: 'ghost',
 	archived: 'archived',
 	selected: 'selected',
 	active: 'active',
@@ -29,6 +30,7 @@ export const issueCardVariants = tv({
 // ── Derive card state from inputs ────────────────────────────────────
 
 export interface CardStateInput {
+	readonly isGhost: boolean;
 	readonly isArchived: boolean;
 	readonly isBatchSelected: boolean;
 	readonly isActive: boolean;
@@ -38,6 +40,9 @@ export interface CardStateInput {
 }
 
 export function deriveCardState(input: CardStateInput): IssueCardState {
+	if (input.isGhost) {
+		return 'ghost';
+	}
 	if (input.isArchived) {
 		return 'archived';
 	}


### PR DESCRIPTION
## Description
- Adds 'ghost' state to IssueCardState for non-adopted assigned issues
- Ghost cards feature dashed borders, neutral gray surface, and muted opacity
- Implements label-based tinting with alphabetical sort (0/1/2/3+ labels for split colorization)
- Hover effects: border brightens, gradient overlay, card lifts slightly
- Hides quick-action buttons, tree preview, state chip, and contextual actions
- All 3 variants (Veil, Horizon, Radiant) produce identical ghost styling
- 26 new tests covering state derivation, CSS properties, label tinting, hover behavior, and variant parity

## Resolves
Closes #365