### PR TITLE
#363 feat(ui): add 'done' state to issue cards

### DIFF
--- a/src/lib/components/blocks/issue-card/ContextualActionButtons.svelte
+++ b/src/lib/components/blocks/issue-card/ContextualActionButtons.svelte
@@ -42,10 +42,17 @@
 	const ctx = useIssueCard();
 
 	const primaryIntent = $derived<ButtonIntent>(
-		ctx.appearanceSettings.buttonColor === 'issue-color' ? 'issue-color' : 'contextual-primary',
+		ctx.cardState === 'done'
+			? 'secondary'
+			: ctx.appearanceSettings.buttonColor === 'issue-color'
+				? 'issue-color'
+				: 'contextual-primary',
 	);
 
 	const issueColorStyle = $derived.by(() => {
+		if (ctx.cardState === 'done') {
+			return '';
+		}
 		if (ctx.appearanceSettings.buttonColor !== 'issue-color') {
 			return '';
 		}

--- a/src/lib/components/blocks/issue-card/batch_selection_utils.test.ts
+++ b/src/lib/components/blocks/issue-card/batch_selection_utils.test.ts
@@ -56,6 +56,7 @@ describe('ISSUE_CARD_STATES', () => {
 	it('has all expected state keys', () => {
 		const expectedKeys = [
 			'active',
+			'done',
 			'hovered',
 			'selectionHover',
 			'selected',

--- a/src/lib/components/blocks/issue-card/derive_card_state_class.test.ts
+++ b/src/lib/components/blocks/issue-card/derive_card_state_class.test.ts
@@ -4,6 +4,7 @@ import { deriveCardState, ISSUE_CARD_STATES, type CardStateInput } from './issue
 function makeInput(overrides: Partial<CardStateInput> = {}): CardStateInput {
 	return {
 		isArchived: false,
+		isDone: false,
 		isBatchSelected: false,
 		isActive: false,
 		isHovered: false,
@@ -63,6 +64,34 @@ describe('deriveCardState', () => {
 	it('worktree pending -> worktreeSetup', () => {
 		expect(deriveCardState(makeInput({ worktreeState: 'pending' }))).toBe(
 			ISSUE_CARD_STATES.worktreeSetup,
+		);
+	});
+
+	it('isDone true with no other flags -> done', () => {
+		expect(deriveCardState(makeInput({ isDone: true }))).toBe(ISSUE_CARD_STATES.done);
+	});
+
+	it('isDone true + isBatchSelected -> selected (batch overrides done)', () => {
+		expect(deriveCardState(makeInput({ isDone: true, isBatchSelected: true }))).toBe(
+			ISSUE_CARD_STATES.selected,
+		);
+	});
+
+	it('isDone true + isActive -> active (active overrides done)', () => {
+		expect(deriveCardState(makeInput({ isDone: true, isActive: true }))).toBe(
+			ISSUE_CARD_STATES.active,
+		);
+	});
+
+	it('isDone true + isHovered -> hovered (hover overrides done)', () => {
+		expect(deriveCardState(makeInput({ isDone: true, isHovered: true }))).toBe(
+			ISSUE_CARD_STATES.hovered,
+		);
+	});
+
+	it('isDone true + isArchived -> archived (archived highest priority)', () => {
+		expect(deriveCardState(makeInput({ isDone: true, isArchived: true }))).toBe(
+			ISSUE_CARD_STATES.archived,
 		);
 	});
 });

--- a/src/lib/components/blocks/issue-card/issue_card.context.svelte.ts
+++ b/src/lib/components/blocks/issue-card/issue_card.context.svelte.ts
@@ -93,10 +93,16 @@ function mapCacheToPrState(cache: GitStatusCache | null): ForestPullRequestState
 
 /** @internal - exported only for testing */
 export function createIssueCardContext(getProps: () => IssueCardContextProps) {
+	const isDone = $derived.by(() => {
+		const props = getProps();
+		return props.cache?.github_issue_state === 'closed' && props.cache?.pr_state === 'merged';
+	});
+
 	const cardState = $derived.by(() => {
 		const props = getProps();
 		return deriveCardState({
 			isArchived: props.issue.status === 'archived',
+			isDone,
 			isBatchSelected: props.isBatchSelected,
 			isActive: props.isActive,
 			isHovered: props.isHovered,
@@ -113,6 +119,7 @@ export function createIssueCardContext(getProps: () => IssueCardContextProps) {
 			issueColor: props.issue.color ?? DEFAULT_ISSUE_COLOR,
 			state: cardState,
 			isHovered: props.isHovered,
+			isDone,
 		});
 	});
 
@@ -166,6 +173,9 @@ export function createIssueCardContext(getProps: () => IssueCardContextProps) {
 		},
 		get isArchived(): boolean {
 			return getProps().issue.status === 'archived';
+		},
+		get isDone(): boolean {
+			return isDone;
 		},
 		get hasWorktree(): boolean {
 			const worktreeState = getProps().issue.worktree_state;

--- a/src/lib/components/blocks/issue-card/issue_card_states.test.ts
+++ b/src/lib/components/blocks/issue-card/issue_card_states.test.ts
@@ -3,6 +3,7 @@ import { createIssueCardContext, type IssueCardContextProps } from './issue_card
 import { ISSUE_CARD_SETTING_DEFAULTS } from './issue_card_settings.js';
 import { ISSUE_CARD_STATES } from './issue_card_variants.js';
 import type { Issue } from '$lib/modules/issues/index.js';
+import type { GitStatusCache } from '$lib/types/generated';
 
 function makeIssue(overrides: Partial<Issue> = {}): Issue {
 	return {
@@ -49,6 +50,24 @@ function makeProps(overrides: Partial<IssueCardContextProps> = {}): IssueCardCon
 		isHovered: false,
 		isBatchSelected: false,
 		isModifierHeld: false,
+		...overrides,
+	};
+}
+
+function makeDoneCache(overrides: Partial<GitStatusCache> = {}): GitStatusCache {
+	return {
+		issue_id: 'issue-1',
+		branch_status: null,
+		pr_state: 'merged',
+		pr_number: null,
+		pr_url: null,
+		github_issue_state: 'closed',
+		behind_base_count: null,
+		merge_conflict: null,
+		has_local_changes: null,
+		ahead_remote_count: null,
+		fetched_at: null,
+		pr_ci_status: null,
 		...overrides,
 	};
 }
@@ -130,6 +149,39 @@ describe('cardState derivation via IssueCardContext', () => {
 				}),
 			);
 			expect(ctx.cardState).toBe(ISSUE_CARD_STATES.archived);
+		});
+	});
+
+	describe('done state from cache', () => {
+		it('closed issue + merged PR with no interaction states -> done', () => {
+			const ctx = createIssueCardContext(() => makeProps({ cache: makeDoneCache() }));
+			expect(ctx.cardState).toBe(ISSUE_CARD_STATES.done);
+		});
+
+		it('closed issue + merged PR + isBatchSelected -> selected', () => {
+			const ctx = createIssueCardContext(() =>
+				makeProps({ cache: makeDoneCache(), isBatchSelected: true }),
+			);
+			expect(ctx.cardState).toBe(ISSUE_CARD_STATES.selected);
+		});
+
+		it('closed issue + open PR -> NOT done', () => {
+			const ctx = createIssueCardContext(() =>
+				makeProps({ cache: makeDoneCache({ pr_state: 'open' }) }),
+			);
+			expect(ctx.cardState).not.toBe(ISSUE_CARD_STATES.done);
+		});
+
+		it('open issue + merged PR -> NOT done', () => {
+			const ctx = createIssueCardContext(() =>
+				makeProps({ cache: makeDoneCache({ github_issue_state: 'open' }) }),
+			);
+			expect(ctx.cardState).not.toBe(ISSUE_CARD_STATES.done);
+		});
+
+		it('isDone is false when cache is null', () => {
+			const ctx = createIssueCardContext(() => makeProps({ cache: null }));
+			expect(ctx.isDone).toBe(false);
 		});
 	});
 });

--- a/src/lib/components/blocks/issue-card/issue_card_variant_css.test.ts
+++ b/src/lib/components/blocks/issue-card/issue_card_variant_css.test.ts
@@ -24,7 +24,7 @@ function makeSettings(
 function computeForVariant(
 	variant: IssueCardAppearanceSettings['variant'],
 	overrides: Partial<IssueCardAppearanceSettings> = {},
-	options: { issueColor?: string; state?: IssueCardState } = {},
+	options: { issueColor?: string; state?: IssueCardState; isDone?: boolean } = {},
 ) {
 	return computeVariantSlotStyles({
 		variant,
@@ -32,6 +32,7 @@ function computeForVariant(
 		issueColor: options.issueColor ?? '#ff5500',
 		state: options.state ?? 'interactive',
 		isHovered: false,
+		isDone: options.isDone ?? false,
 	});
 }
 
@@ -147,6 +148,7 @@ describe('computeVariantSlotStyles', () => {
 				settings: makeSettings(),
 				issueColor: '#ff5500',
 				state: 'hovered',
+				isDone: false,
 				isHovered: true,
 			});
 			expect(result.card.transform).toBe('translateY(-3px)');
@@ -163,6 +165,46 @@ describe('computeVariantSlotStyles', () => {
 			const result = computeForVariant('refined-horizon', {}, { state: 'selected' });
 			expect(result.card.outline).toContain('var(--primary)');
 			expect(result.card['box-shadow']).toContain('var(--primary)');
+		});
+
+		it('done state sets transparent bg, transparent border, no shadow', () => {
+			const result = computeForVariant('refined-horizon', {}, { state: 'done' });
+			expect(result.card.background).toBe('transparent');
+			expect(result.card['border-color']).toBe('transparent');
+			expect(result.card['box-shadow']).toBe('none');
+		});
+
+		it('done state does NOT set opacity (full opacity)', () => {
+			const result = computeForVariant('refined-horizon', {}, { state: 'done' });
+			expect(result.card.opacity).toBeUndefined();
+		});
+
+		it('hovered state with isDone uses neutral bg/border instead of issue-color glow', () => {
+			const result = computeVariantSlotStyles({
+				variant: 'refined-horizon',
+				settings: makeSettings(),
+				issueColor: '#ff5500',
+				state: 'hovered',
+				isHovered: true,
+				isDone: true,
+			});
+			expect(result.card.background).toBe('var(--surface)');
+			expect(result.card['border-color']).toBe('var(--border)');
+			expect(result.card['box-shadow']).toBe('var(--shadow-sm)');
+			expect(result.card.transform).toBe('translateY(-2px)');
+		});
+
+		it('hovered state without isDone uses issue-color glow as before', () => {
+			const result = computeVariantSlotStyles({
+				variant: 'refined-horizon',
+				settings: makeSettings(),
+				issueColor: '#ff5500',
+				state: 'hovered',
+				isHovered: true,
+				isDone: false,
+			});
+			expect(result.card['box-shadow']).toContain('#ff5500');
+			expect(result.card.transform).toBe('translateY(-3px)');
 		});
 	});
 

--- a/src/lib/components/blocks/issue-card/issue_card_variant_css.ts
+++ b/src/lib/components/blocks/issue-card/issue_card_variant_css.ts
@@ -16,6 +16,7 @@ interface VariantStylesInput {
 	readonly issueColor: string;
 	readonly state: IssueCardState;
 	readonly isHovered: boolean;
+	readonly isDone: boolean;
 }
 
 // ── Helpers ───────────────────────────────────────────────────
@@ -126,6 +127,7 @@ function applyStateOverrides(
 	state: IssueCardState,
 	isHovered: boolean,
 	issueColor: string,
+	isDone: boolean = false,
 ): VariantSlotStyles {
 	const card: Record<string, string> = { ...base.card };
 	let header: Readonly<Record<string, string>> = base.header;
@@ -137,8 +139,21 @@ function applyStateOverrides(
 			}
 			break;
 
+		case 'done':
+			card.background = 'transparent';
+			card['border-color'] = 'transparent';
+			card['box-shadow'] = 'none';
+			break;
+
 		case 'hovered':
-			header = applyHoverGlow(card, base.header, issueColor);
+			if (isDone) {
+				card.background = 'var(--surface)';
+				card['border-color'] = 'var(--border)';
+				card['box-shadow'] = 'var(--shadow-sm)';
+				card.transform = 'translateY(-2px)';
+			} else {
+				header = applyHoverGlow(card, base.header, issueColor);
+			}
 			break;
 
 		case 'selectionHover':
@@ -223,5 +238,5 @@ export function computeVariantSlotStyles(input: VariantStylesInput): VariantSlot
 		preview: base.preview,
 	};
 
-	return applyStateOverrides(base, state, isHovered, issueColor);
+	return applyStateOverrides(base, state, isHovered, issueColor, input.isDone);
 }

--- a/src/lib/components/blocks/issue-card/issue_card_variants.ts
+++ b/src/lib/components/blocks/issue-card/issue_card_variants.ts
@@ -4,6 +4,7 @@ import { tv } from 'tailwind-variants';
 
 export const ISSUE_CARD_STATES = {
 	archived: 'archived',
+	done: 'done',
 	selected: 'selected',
 	active: 'active',
 	selectionHover: 'selectionHover',
@@ -19,7 +20,7 @@ export type IssueCardState = (typeof ISSUE_CARD_STATES)[keyof typeof ISSUE_CARD_
 // fallow-ignore-next-line unused-export
 export const issueCardVariants = tv({
 	slots: {
-		card: 'group relative overflow-hidden rounded-lg border outline-none transition-[box-shadow,transform,opacity,filter] duration-3',
+		card: 'group relative overflow-hidden rounded-lg border outline-none transition-[box-shadow,transform,opacity,filter,background,border-color] duration-3',
 		header: 'flex min-h-8 items-center justify-between gap-2.5 px-3 py-1.5',
 		preview:
 			'relative flex size-25 shrink-0 items-end justify-center overflow-hidden rounded-1.75 border border-[color-mix(in_oklch,var(--ic-color)_20%,var(--border))]',
@@ -30,6 +31,7 @@ export const issueCardVariants = tv({
 
 export interface CardStateInput {
 	readonly isArchived: boolean;
+	readonly isDone: boolean;
 	readonly isBatchSelected: boolean;
 	readonly isActive: boolean;
 	readonly isHovered: boolean;
@@ -40,6 +42,9 @@ export interface CardStateInput {
 export function deriveCardState(input: CardStateInput): IssueCardState {
 	if (input.isArchived) {
 		return 'archived';
+	}
+	if (input.isDone && !input.isBatchSelected && !input.isActive && !input.isHovered) {
+		return 'done';
 	}
 	if (input.isBatchSelected) {
 		return 'selected';


### PR DESCRIPTION
## Description
- Add `IssueCardState.done` derived when both `github_issue_state=closed` AND `pr_state=merged`
- Transparent background and borderless design for done state
- Neutral hover treatment with fade in/out transitions (var(--surface) bg, var(--border) on hover)
- Secondary intent applied to action buttons when in done state
- Batch selection, active, and hover states take priority in cascade
- 15 new tests covering state derivation, CSS overrides, and context integration

## Resolves
Closes #363

## Testing
- [ ] All 15 new tests pass
- [ ] Visual verification of done card state with both closed issue and merged PR
- [ ] Batch selection works correctly on done cards
- [ ] Hover and interaction states display properly