### PR TITLE
#373 feat(workspace-dashboard): add ghost card accordion

### DIFF
--- a/src/lib/components/blocks/issue-card/GhostCardAccordion.svelte
+++ b/src/lib/components/blocks/issue-card/GhostCardAccordion.svelte
@@ -1,0 +1,130 @@
+<script lang="ts">
+	import type { AssignedIssue } from '$lib/types/generated';
+	import type { Issue } from '$lib/modules/issues';
+	import * as Collapsible from '$lib/components/shadcn/collapsible/index.js';
+	import ChevronDownIcon from '@lucide/svelte/icons/chevron-down';
+	import ArrowUpDownIcon from '@lucide/svelte/icons/arrow-up-down';
+	import FilterIcon from '@lucide/svelte/icons/filter';
+	import IssueCard from './IssueCard.svelte';
+	import { useIssueCardSettings } from './index.js';
+	import {
+		sortAssignedIssues,
+		type SortColumn,
+		type SortDirection,
+	} from '$lib/components/blocks/issue/assigned_issues_utils.js';
+	import {
+		assignedIssueToGhostIssue,
+		getUnlinkedOpenAssignedIssues,
+	} from './ghost_card_utils.js';
+	import { cn } from '$lib/utils.js';
+
+	const SORT_COLUMNS: SortColumn[] = ['number', 'title', 'prd', 'labels'];
+
+	interface Props {
+		assignedIssues: AssignedIssue[];
+		dashboardIssues: readonly Issue[];
+		onWizardOpen?: (issue: AssignedIssue) => void;
+		onQuickAddWithWorktree?: (issue: AssignedIssue) => void;
+	}
+
+	let { assignedIssues, dashboardIssues, onWizardOpen, onQuickAddWithWorktree }: Props = $props();
+
+	const issueCardSettingsCtx = useIssueCardSettings();
+
+	let open = $state(false);
+	let sortColumn: SortColumn = $state('number');
+	let sortDirection: SortDirection = $state('asc');
+
+	const filteredIssues = $derived(getUnlinkedOpenAssignedIssues(assignedIssues, dashboardIssues));
+
+	const sortedIssues = $derived(sortAssignedIssues(filteredIssues, sortColumn, sortDirection));
+
+	const ghostIssues = $derived(sortedIssues.map(assignedIssueToGhostIssue));
+
+	const count = $derived(filteredIssues.length);
+
+	const assignedIssueByNumber = $derived(
+		new Map(assignedIssues.map((issue) => [issue.number, issue])),
+	);
+
+	function handleSortClick() {
+		const currentIndex = SORT_COLUMNS.indexOf(sortColumn);
+		const nextIndex = (currentIndex + 1) % SORT_COLUMNS.length;
+		if (nextIndex === 0 && sortDirection === 'asc') {
+			sortDirection = 'desc';
+		} else if (nextIndex === 0) {
+			sortDirection = 'asc';
+		}
+		sortColumn = SORT_COLUMNS[nextIndex];
+	}
+
+	function handleCardClick(ghostIssue: Issue) {
+		const assigned = assignedIssueByNumber.get(ghostIssue.github_issue_number!);
+		if (assigned && onWizardOpen) {
+			onWizardOpen(assigned);
+		}
+	}
+</script>
+
+{#if count > 0}
+	<Collapsible.Root bind:open>
+		<div class="flex items-center gap-2">
+			<Collapsible.Trigger
+				class="flex items-center gap-1.5 text-xs font-medium text-muted-foreground hover:text-foreground"
+			>
+				<ChevronDownIcon
+					class={cn('size-3.5 transition-transform duration-3', !open && '-rotate-90')}
+				/>
+				Assigned &middot; {count}
+				{count === 1 ? 'issue' : 'issues'}
+			</Collapsible.Trigger>
+
+			<div class="flex items-center gap-1">
+				<button
+					type="button"
+					class="inline-flex size-5 items-center justify-center rounded text-muted-foreground/60 hover:text-muted-foreground"
+					aria-label="Sort issues"
+					onclick={handleSortClick}
+				>
+					<ArrowUpDownIcon class="size-3" />
+				</button>
+				<button
+					type="button"
+					class="inline-flex size-5 items-center justify-center rounded text-muted-foreground/60 hover:text-muted-foreground"
+					aria-label="Filter issues"
+				>
+					<FilterIcon class="size-3" />
+				</button>
+			</div>
+		</div>
+
+		<Collapsible.Content class="pt-3">
+			<div
+				class="grid gap-5"
+				style="grid-template-columns: repeat(auto-fill, minmax(450px, 1fr));"
+			>
+				{#each ghostIssues as issue (issue.id)}
+					<!-- svelte-ignore a11y_no_static_element_interactions -->
+					<!-- svelte-ignore a11y_click_events_have_key_events -->
+					<div onclick={() => handleCardClick(issue)} class="cursor-pointer">
+						<IssueCard
+							{issue}
+							isGhost={true}
+							appearanceSettings={issueCardSettingsCtx.settings}
+							onQuickActionAssignFolder={onQuickAddWithWorktree
+								? () => {
+										const assigned = assignedIssueByNumber.get(
+											issue.github_issue_number!,
+										);
+										if (assigned) {
+											onQuickAddWithWorktree(assigned);
+										}
+									}
+								: undefined}
+						/>
+					</div>
+				{/each}
+			</div>
+		</Collapsible.Content>
+	</Collapsible.Root>
+{/if}

--- a/src/lib/components/blocks/issue-card/ghost_card_utils.test.ts
+++ b/src/lib/components/blocks/issue-card/ghost_card_utils.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import type { AssignedIssue } from '$lib/types/generated';
+import type { Issue } from '$lib/modules/issues';
+import { assignedIssueToGhostIssue, getUnlinkedOpenAssignedIssues } from './ghost_card_utils.js';
+
+function makeAssignedIssue(overrides: Partial<AssignedIssue> = {}): AssignedIssue {
+	return {
+		number: 42,
+		title: 'Test issue',
+		state: 'OPEN',
+		url: 'https://github.com/org/repo/issues/42',
+		labels: [{ name: 'bug', color: 'ff0000' }],
+		parent_issue_number: 10,
+		...overrides,
+	};
+}
+
+function makeDashboardIssue(overrides: Partial<Issue> = {}): Issue {
+	return {
+		id: 'issue-1',
+		dashboard_id: 'dash-1',
+		name: 'Dashboard issue',
+		priority: null,
+		color: null,
+		status: 'active',
+		github_issue_url: null,
+		github_issue_number: null,
+		branch_name: null,
+		base_branch: null,
+		worktree_folder: null,
+		worktree_state: 'none',
+		parent_issue_id: null,
+		editor_folder: null,
+		dev_server_command: null,
+		dev_server_port: null,
+		dev_server_pid: null,
+		browser_url: null,
+		labels: [],
+		sort_order: 0,
+		created_at: '2024-01-01',
+		character_pack_id: null,
+		character_avatar: null,
+		is_sound_muted: false,
+		...overrides,
+	};
+}
+
+describe('assignedIssueToGhostIssue', () => {
+	it('maps all fields correctly from a complete AssignedIssue', () => {
+		const assigned = makeAssignedIssue();
+		const result = assignedIssueToGhostIssue(assigned);
+
+		expect(result).toEqual({
+			id: 'ghost-42',
+			dashboard_id: '',
+			name: 'Test issue',
+			priority: null,
+			color: null,
+			status: 'active',
+			github_issue_url: 'https://github.com/org/repo/issues/42',
+			github_issue_number: 42,
+			branch_name: null,
+			base_branch: null,
+			worktree_folder: null,
+			worktree_state: 'none',
+			parent_issue_id: null,
+			editor_folder: null,
+			dev_server_command: null,
+			dev_server_port: null,
+			dev_server_pid: null,
+			browser_url: null,
+			labels: [{ name: 'bug', color: 'ff0000' }],
+			sort_order: 0,
+			created_at: '',
+			character_pack_id: null,
+			character_avatar: null,
+			is_sound_muted: false,
+		});
+	});
+
+	it('uses ghost-${number} as the synthetic ID', () => {
+		const result = assignedIssueToGhostIssue(makeAssignedIssue({ number: 999 }));
+		expect(result.id).toBe('ghost-999');
+	});
+
+	it('passes labels through directly', () => {
+		const labels = [
+			{ name: 'enhancement', color: '00ff00' },
+			{ name: 'priority', color: '0000ff' },
+		];
+		const result = assignedIssueToGhostIssue(makeAssignedIssue({ labels }));
+		expect(result.labels).toEqual(labels);
+	});
+
+	it('handles parent_issue_number: null without affecting parent_issue_id', () => {
+		const result = assignedIssueToGhostIssue(makeAssignedIssue({ parent_issue_number: null }));
+		expect(result.parent_issue_id).toBeNull();
+	});
+});
+
+describe('getUnlinkedOpenAssignedIssues', () => {
+	it('returns only unlinked issues (excludes those linked to dashboard issues)', () => {
+		const assigned = [
+			makeAssignedIssue({ number: 1 }),
+			makeAssignedIssue({ number: 2 }),
+			makeAssignedIssue({ number: 3 }),
+		];
+		const dashboard = [makeDashboardIssue({ github_issue_number: 2 })];
+
+		const result = getUnlinkedOpenAssignedIssues(assigned, dashboard);
+		expect(result.map((i) => i.number)).toEqual([1, 3]);
+	});
+
+	it('excludes closed issues (state: CLOSED)', () => {
+		const assigned = [
+			makeAssignedIssue({ number: 1, state: 'OPEN' }),
+			makeAssignedIssue({ number: 2, state: 'CLOSED' }),
+			makeAssignedIssue({ number: 3, state: 'OPEN' }),
+		];
+		const dashboard: Issue[] = [];
+
+		const result = getUnlinkedOpenAssignedIssues(assigned, dashboard);
+		expect(result.map((i) => i.number)).toEqual([1, 3]);
+	});
+
+	it('returns empty array when all issues are linked', () => {
+		const assigned = [makeAssignedIssue({ number: 1 }), makeAssignedIssue({ number: 2 })];
+		const dashboard = [
+			makeDashboardIssue({ github_issue_number: 1 }),
+			makeDashboardIssue({ github_issue_number: 2 }),
+		];
+
+		const result = getUnlinkedOpenAssignedIssues(assigned, dashboard);
+		expect(result).toEqual([]);
+	});
+
+	it('returns empty array when all issues are closed', () => {
+		const assigned = [
+			makeAssignedIssue({ number: 1, state: 'CLOSED' }),
+			makeAssignedIssue({ number: 2, state: 'CLOSED' }),
+		];
+		const dashboard: Issue[] = [];
+
+		const result = getUnlinkedOpenAssignedIssues(assigned, dashboard);
+		expect(result).toEqual([]);
+	});
+});

--- a/src/lib/components/blocks/issue-card/ghost_card_utils.ts
+++ b/src/lib/components/blocks/issue-card/ghost_card_utils.ts
@@ -1,0 +1,40 @@
+import type { AssignedIssue } from '$lib/types/generated';
+import type { Issue } from '$lib/modules/issues';
+import { categorizeAssignedIssues } from '$lib/components/blocks/issue/assigned_issues_utils.js';
+
+export function assignedIssueToGhostIssue(assigned: AssignedIssue): Issue {
+	return {
+		id: `ghost-${assigned.number}`,
+		dashboard_id: '',
+		name: assigned.title,
+		priority: null,
+		color: null,
+		status: 'active',
+		github_issue_url: assigned.url,
+		github_issue_number: assigned.number,
+		branch_name: null,
+		base_branch: null,
+		worktree_folder: null,
+		worktree_state: 'none',
+		parent_issue_id: null,
+		editor_folder: null,
+		dev_server_command: null,
+		dev_server_port: null,
+		dev_server_pid: null,
+		browser_url: null,
+		labels: assigned.labels,
+		sort_order: 0,
+		created_at: '',
+		character_pack_id: null,
+		character_avatar: null,
+		is_sound_muted: false,
+	};
+}
+
+export function getUnlinkedOpenAssignedIssues(
+	assignedIssues: readonly AssignedIssue[],
+	dashboardIssues: readonly Issue[],
+): AssignedIssue[] {
+	const { unlinked } = categorizeAssignedIssues(assignedIssues, dashboardIssues);
+	return unlinked.filter((issue) => issue.state !== 'CLOSED');
+}

--- a/src/lib/components/blocks/layout/WorkspaceBottomPanel.svelte
+++ b/src/lib/components/blocks/layout/WorkspaceBottomPanel.svelte
@@ -22,7 +22,8 @@
 	import IssueDetail from '$lib/components/blocks/issue/IssueDetail.svelte';
 	import GhSetupBanner from '$lib/components/blocks/github/GhSetupBanner.svelte';
 	import AssignedIssuesPanel from '$lib/components/blocks/issue/AssignedIssuesPanel.svelte';
-	import { categorizeAssignedIssues } from '$lib/components/blocks/issue/assigned_issues_utils.js';
+	import { getUnlinkedOpenAssignedIssues } from '$lib/components/blocks/issue-card/ghost_card_utils.js';
+	import GhostCardAccordion from '$lib/components/blocks/issue-card/GhostCardAccordion.svelte';
 
 	// fallow-ignore-next-line code-duplication
 	interface Props extends IssueCardCallbacks {
@@ -126,11 +127,7 @@
 		return computeStageCounts(visualizations);
 	});
 
-	const unlinkedCount = $derived(
-		categorizeAssignedIssues(assignedIssues, issues).unlinked.filter(
-			(issue) => issue.state !== 'CLOSED',
-		).length,
-	);
+	const unlinkedCount = $derived(getUnlinkedOpenAssignedIssues(assignedIssues, issues).length);
 
 	function handleTabClick(tab: BottomPanelTab) {
 		if (selection.activeTab === tab) {
@@ -211,6 +208,13 @@
 					{onExecuteAction}
 					{onChangeColor}
 					onBatchPrune={onPrune ? () => onPrune!() : undefined}
+				/>
+
+				<GhostCardAccordion
+					{assignedIssues}
+					dashboardIssues={issues}
+					{onWizardOpen}
+					{onQuickAddWithWorktree}
 				/>
 			</div>
 		{:else if defaultTab === BOTTOM_PANEL_TABS.kanban}


### PR DESCRIPTION
## Description
- Adds collapsible accordion below adopted issue grid showing unlinked assigned GitHub issues as ghost cards
- Ghost cards display in same responsive grid layout with independent sort/filter controls
- Accordion collapsed by default, header shows "Assigned · {count} issues" with sort/filter buttons
- Sort button cycles through columns (number, title, prd, labels)
- Ghost cards are clickable to trigger adoption wizard
- Reuses existing `assigned_issues_utils` for sorting, filtering, and categorization
- Refactored `WorkspaceBottomPanel` to use shared `getUnlinkedOpenAssignedIssues` utility (DRY improvement)

## Resolves
Closes #373

## Testing
- Unit tests added for `ghost_card_utils` (mapper and filter logic)
- Test coverage: `assignedIssueToGhostIssue` field mapping and `getUnlinkedOpenAssignedIssues` filtering