### PR TITLE
#370 feat(issue-card): use opaque dark surface for radiant preview box

### DIFF
--- a/src/lib/components/blocks/issue-card/issue_card_variant_css.test.ts
+++ b/src/lib/components/blocks/issue-card/issue_card_variant_css.test.ts
@@ -99,9 +99,10 @@ describe('computeVariantSlotStyles', () => {
 			expect(result.card['--ic-header-text']).toBe('#ffffff');
 		});
 
-		it('preview has gradient background', () => {
-			const result = computeForVariant('veil');
+		it('preview has gradient background with issue color', () => {
+			const result = computeForVariant('veil', {}, { issueColor: '#ff5500' });
 			expect(result.preview.background).toContain('linear-gradient');
+			expect(result.preview.background).toContain('#ff5500');
 		});
 	});
 
@@ -151,10 +152,27 @@ describe('computeVariantSlotStyles', () => {
 			expect(result.card['--ic-header-text']).toBe('var(--foreground)');
 		});
 
-		it('preview uses gradient with theme-aware surface variables', () => {
-			const result = computeForVariant('radiant');
+		it('preview background is opaque dark surface without issue color', () => {
+			const result = computeForVariant('radiant', {}, { issueColor: '#ff5500' });
+			expect(result.preview.background).toBe(
+				'color-mix(in oklch, var(--surface) 85%, black)',
+			);
+			expect(result.preview.background).not.toContain('#ff5500');
+			expect(result.preview.background).not.toContain('linear-gradient');
+		});
+
+		it('card body radial gradient glow still uses issueColor', () => {
+			const result = computeForVariant('radiant', {}, { issueColor: '#00cc88' });
+			expect(result.card.background).toContain('#00cc88');
+			expect(result.card.background).toContain('radial-gradient');
+		});
+	});
+
+	describe('other variants preview backgrounds unchanged', () => {
+		it('refined-horizon preview still uses linear-gradient with issue color', () => {
+			const result = computeForVariant('refined-horizon', {}, { issueColor: '#ff5500' });
 			expect(result.preview.background).toContain('linear-gradient');
-			expect(result.preview.background).toContain('var(--surface-2)');
+			expect(result.preview.background).toContain('#ff5500');
 		});
 	});
 

--- a/src/lib/components/blocks/issue-card/issue_card_variant_css.ts
+++ b/src/lib/components/blocks/issue-card/issue_card_variant_css.ts
@@ -98,7 +98,7 @@ function computeRadiantStyles(
 			background: `linear-gradient(90deg, color-mix(in oklch, var(--surface) 35%, transparent) 0%, color-mix(in oklch, var(--surface) 65%, transparent) 40%, color-mix(in oklch, var(--surface) 80%, transparent) 100%)`,
 		},
 		preview: {
-			background: `linear-gradient(135deg, color-mix(in oklch, ${issueColor} 5%, var(--surface-2)) 0%, var(--surface-3) 100%)`,
+			background: 'color-mix(in oklch, var(--surface) 85%, black)',
 		},
 	};
 }


### PR DESCRIPTION
## Description
- Radiant variant preview box now uses opaque dark surface `color-mix(in oklch, var(--surface) 85%, black)` per REQ-CV-5 spec and design decision
- Removed semi-transparent issueColor gradient from preview background
- Card body radial gradient glow remains unchanged (still uses issueColor)
- Other variants (veil, refined-horizon) unaffected

## Resolves
Closes #370

## Testing
- [x] Updated tests for opaque dark assertion
- [x] Added non-regression tests for card body glow
- [x] Verified other variants' preview backgrounds unchanged