### PR TITLE
#369 feat(issue-card): dev-only A/B comparison toggle

### DIFF
--- a/src/lib/components/blocks/issue-card/DevComparisonToggle.svelte
+++ b/src/lib/components/blocks/issue-card/DevComparisonToggle.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import { Switch } from '$lib/components/shadcn/switch/index.js';
+	import { useIssueCardSettings } from './issue_card_settings.context.svelte.js';
+
+	const settingsCtx = useIssueCardSettings();
+</script>
+
+{#if import.meta.env.DEV}
+	<div
+		class="flex items-center gap-3 rounded-md border border-dashed border-muted-foreground/30 bg-surface-1/50 px-3 py-2"
+	>
+		<Switch
+			checked={settingsCtx.comparisonEnabled}
+			onCheckedChange={() => settingsCtx.toggleComparison()}
+		/>
+		<div class="flex flex-col">
+			<span class="text-xs font-medium text-muted-foreground">A/B: Badge Style</span>
+			<span class="text-[10px] text-muted-foreground/70">
+				Toggles badge style across all cards. Observe priority badges.
+			</span>
+		</div>
+	</div>
+{/if}

--- a/src/lib/components/blocks/issue-card/IssueCardGrid.svelte
+++ b/src/lib/components/blocks/issue-card/IssueCardGrid.svelte
@@ -270,7 +270,7 @@
 						prdParent={getPrdParent(issue)}
 						{prioritiesEnabled}
 						visualization={getVisualization?.(issue.id)}
-						appearanceSettings={issueCardSettingsCtx.settings}
+						appearanceSettings={issueCardSettingsCtx.comparisonSettings}
 						{onExecuteAction}
 					/>
 				</IssueCardContextMenu>
@@ -309,7 +309,7 @@
 								{ghAvailable}
 								prdParent={getPrdParent(issue)}
 								visualization={getVisualization?.(issue.id)}
-								appearanceSettings={issueCardSettingsCtx.settings}
+								appearanceSettings={issueCardSettingsCtx.comparisonSettings}
 							/>
 						</IssueCardContextMenu>
 					</div>

--- a/src/lib/components/blocks/issue-card/dev_comparison_toggle.test.ts
+++ b/src/lib/components/blocks/issue-card/dev_comparison_toggle.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { getComparisonBadgeStyle, applyComparisonOverride } from './dev_comparison_toggle.js';
+import type { IssueCardAppearanceSettings } from './issue_card_settings.js';
+
+const BASE_SETTINGS: IssueCardAppearanceSettings = {
+	buttonColor: 'issue-color',
+	priorityPosition: 'header-right',
+	badgeStyle: 'subtle',
+	labelTint: 20,
+	overlayGlow: 150,
+	variant: 'refined-horizon',
+	gradientReach: 60,
+	colorSaturation: 150,
+	headerSaturation: 85,
+	radialIntensity: 75,
+};
+
+describe('dev_comparison_toggle', () => {
+	describe('getComparisonBadgeStyle', () => {
+		it('returns outlined when current badge style is solid', () => {
+			expect(getComparisonBadgeStyle('solid')).toBe('outlined');
+		});
+
+		it('returns solid when current badge style is subtle', () => {
+			expect(getComparisonBadgeStyle('subtle')).toBe('solid');
+		});
+
+		it('returns solid when current badge style is outlined', () => {
+			expect(getComparisonBadgeStyle('outlined')).toBe('solid');
+		});
+	});
+
+	describe('applyComparisonOverride', () => {
+		it('returns original settings unchanged when comparison is disabled', () => {
+			const result = applyComparisonOverride(BASE_SETTINGS, false);
+			expect(result).toEqual(BASE_SETTINGS);
+		});
+
+		it('overrides badgeStyle when comparison is enabled', () => {
+			const result = applyComparisonOverride(BASE_SETTINGS, true);
+			expect(result.badgeStyle).toBe('solid');
+		});
+
+		it('preserves all non-badge settings when comparison is enabled', () => {
+			const result = applyComparisonOverride(BASE_SETTINGS, true);
+			expect(result.buttonColor).toBe(BASE_SETTINGS.buttonColor);
+			expect(result.priorityPosition).toBe(BASE_SETTINGS.priorityPosition);
+			expect(result.labelTint).toBe(BASE_SETTINGS.labelTint);
+			expect(result.overlayGlow).toBe(BASE_SETTINGS.overlayGlow);
+			expect(result.variant).toBe(BASE_SETTINGS.variant);
+			expect(result.gradientReach).toBe(BASE_SETTINGS.gradientReach);
+			expect(result.colorSaturation).toBe(BASE_SETTINGS.colorSaturation);
+			expect(result.headerSaturation).toBe(BASE_SETTINGS.headerSaturation);
+			expect(result.radialIntensity).toBe(BASE_SETTINGS.radialIntensity);
+		});
+
+		it('flips solid to outlined when comparison is enabled', () => {
+			const solidSettings: IssueCardAppearanceSettings = {
+				...BASE_SETTINGS,
+				badgeStyle: 'solid',
+			};
+			const result = applyComparisonOverride(solidSettings, true);
+			expect(result.badgeStyle).toBe('outlined');
+		});
+	});
+});

--- a/src/lib/components/blocks/issue-card/dev_comparison_toggle.ts
+++ b/src/lib/components/blocks/issue-card/dev_comparison_toggle.ts
@@ -1,0 +1,19 @@
+import type { BadgeStyleOption, IssueCardAppearanceSettings } from './issue_card_settings.js';
+
+/** Returns the alternate badge style: solid → outlined, anything else → solid. */
+export function getComparisonBadgeStyle(current: BadgeStyleOption): BadgeStyleOption {
+	return current === 'solid' ? 'outlined' : 'solid';
+}
+
+export function applyComparisonOverride(
+	settings: IssueCardAppearanceSettings,
+	comparisonEnabled: boolean,
+): IssueCardAppearanceSettings {
+	if (!comparisonEnabled) {
+		return settings;
+	}
+	return {
+		...settings,
+		badgeStyle: getComparisonBadgeStyle(settings.badgeStyle),
+	};
+}

--- a/src/lib/components/blocks/issue-card/issue_card_settings.context.svelte.ts
+++ b/src/lib/components/blocks/issue-card/issue_card_settings.context.svelte.ts
@@ -1,6 +1,7 @@
 import { createContext } from 'svelte';
 import { useSettings } from '$lib/modules/settings/index.js';
 import type { SettingKey } from '$lib/modules/settings/index.js';
+import { StateRaw } from '$lib/reactivity/state.svelte.js';
 import {
 	parseSettingValue,
 	type IssueCardAppearanceSettings,
@@ -10,6 +11,7 @@ import {
 	type PriorityPositionOption,
 	type BadgeStyleOption,
 } from './issue_card_settings.js';
+import { applyComparisonOverride } from './dev_comparison_toggle.js';
 
 type IssueCardSettingsContext = ReturnType<typeof createIssueCardSettingsContext>;
 
@@ -65,6 +67,12 @@ function createIssueCardSettingsContext() {
 		return new Set(keys.filter((key) => isOverridden(key)));
 	});
 
+	const comparisonEnabled = new StateRaw(false);
+
+	function toggleComparison() {
+		comparisonEnabled.current = !comparisonEnabled.current;
+	}
+
 	return {
 		get settings(): IssueCardAppearanceSettings {
 			return {
@@ -81,10 +89,19 @@ function createIssueCardSettingsContext() {
 			};
 		},
 
+		get comparisonSettings(): IssueCardAppearanceSettings {
+			return applyComparisonOverride(this.settings, comparisonEnabled.current);
+		},
+
+		get comparisonEnabled() {
+			return comparisonEnabled.current;
+		},
+
 		get overriddenKeys() {
 			return overriddenKeys;
 		},
 
+		toggleComparison,
 		updateSetting,
 		resetOverride,
 		isOverridden,

--- a/src/lib/components/blocks/layout/WorkspaceBottomPanel.svelte
+++ b/src/lib/components/blocks/layout/WorkspaceBottomPanel.svelte
@@ -19,6 +19,7 @@
 	import PrdOverview from '$lib/components/blocks/issue/PrdOverview.svelte';
 	import DependencyGraphView from '$lib/components/blocks/dependency-graph/DependencyGraphView.svelte';
 	import IssueCardGrid from '$lib/components/blocks/issue-card/IssueCardGrid.svelte';
+	import DevComparisonToggle from '$lib/components/blocks/issue-card/DevComparisonToggle.svelte';
 	import IssueDetail from '$lib/components/blocks/issue/IssueDetail.svelte';
 	import GhSetupBanner from '$lib/components/blocks/github/GhSetupBanner.svelte';
 	import AssignedIssuesPanel from '$lib/components/blocks/issue/AssignedIssuesPanel.svelte';
@@ -188,6 +189,8 @@
 				{#if authStatus && authStatus.status === 'not-connected'}
 					<GhSetupBanner {authStatus} {onconnect} />
 				{/if}
+
+				<DevComparisonToggle />
 
 				<IssueCardGrid
 					{parentIssues}


### PR DESCRIPTION
## Summary

- Adds dev-only toggle in Issues preview panel that flips badge style across all issue cards for live A/B visual comparison
- Pure logic extracted and tested (7 unit tests)
- Guarded by `import.meta.env.DEV` — tree-shaken in production builds

## Test plan

- [x] Toggle visible in Issues preview panel (dev mode only)
- [x] Toggling updates all cards live (badge style flips between solid/outlined)
- [x] Explanatory label visible near toggle
- [x] Not visible in production builds (`import.meta.env.DEV` guard)
- [x] Unit tests pass for comparison logic
- [x] Static checks pass (format + lint + fallow + typecheck + eslint)

Fixes #369
