### PR TITLE
#374 feat(issue-card): wire adopt split-button into ghost cards

### DIFF
--- a/src/lib/components/blocks/issue-card/GhostCardAccordion.svelte
+++ b/src/lib/components/blocks/issue-card/GhostCardAccordion.svelte
@@ -57,13 +57,6 @@
 		}
 		sortColumn = SORT_COLUMNS[nextIndex];
 	}
-
-	function handleCardClick(ghostIssue: Issue) {
-		const assigned = assignedIssueByNumber.get(ghostIssue.github_issue_number!);
-		if (assigned && onWizardOpen) {
-			onWizardOpen(assigned);
-		}
-	}
 </script>
 
 {#if count > 0}
@@ -104,25 +97,31 @@
 				style="grid-template-columns: repeat(auto-fill, minmax(450px, 1fr));"
 			>
 				{#each ghostIssues as issue (issue.id)}
-					<!-- svelte-ignore a11y_no_static_element_interactions -->
-					<!-- svelte-ignore a11y_click_events_have_key_events -->
-					<div onclick={() => handleCardClick(issue)} class="cursor-pointer">
-						<IssueCard
-							{issue}
-							isGhost={true}
-							appearanceSettings={issueCardSettingsCtx.settings}
-							onQuickActionAssignFolder={onQuickAddWithWorktree
-								? () => {
-										const assigned = assignedIssueByNumber.get(
-											issue.github_issue_number!,
-										);
-										if (assigned) {
-											onQuickAddWithWorktree(assigned);
-										}
+					<IssueCard
+						{issue}
+						isGhost={true}
+						appearanceSettings={issueCardSettingsCtx.settings}
+						onAdoptNoWorktree={onWizardOpen
+							? () => {
+									const assigned = assignedIssueByNumber.get(
+										issue.github_issue_number!,
+									);
+									if (assigned) {
+										onWizardOpen(assigned);
 									}
-								: undefined}
-						/>
-					</div>
+								}
+							: undefined}
+						onAdoptWithWorktree={onQuickAddWithWorktree
+							? () => {
+									const assigned = assignedIssueByNumber.get(
+										issue.github_issue_number!,
+									);
+									if (assigned) {
+										onQuickAddWithWorktree(assigned);
+									}
+								}
+							: undefined}
+					/>
 				{/each}
 			</div>
 		</Collapsible.Content>

--- a/src/lib/components/blocks/issue-card/IssueCard.svelte
+++ b/src/lib/components/blocks/issue-card/IssueCard.svelte
@@ -15,6 +15,12 @@
 		type IssueCardAppearanceSettings,
 	} from './index.js';
 	import { getHoveredPrdNumber } from './prd_hover_store.svelte.js';
+	import {
+		ADOPT_ACTION_VALUES,
+		ADOPT_SPLIT_BUTTON_OPTIONS,
+		ADOPT_SETTINGS_KEY,
+	} from './ghost_card_utils.js';
+	import SplitButton from '$lib/components/derived/split-button/SplitButton.svelte';
 	import IssueCardHeader from './IssueCardHeader.svelte';
 	import IssueCardPreview from './IssueCardPreview.svelte';
 	import WorktreeRow from './WorktreeRow.svelte';
@@ -42,6 +48,8 @@
 		onExecuteAction?: (actionId: string, issueId: string) => void;
 		onPriorityClick?: () => void;
 		onQuickActionAssignFolder?: (issueId: string) => void;
+		onAdoptNoWorktree?: (issueId: string) => void;
+		onAdoptWithWorktree?: (issueId: string) => void;
 	}
 
 	let {
@@ -58,6 +66,8 @@
 		onExecuteAction,
 		onPriorityClick,
 		onQuickActionAssignFolder,
+		onAdoptNoWorktree,
+		onAdoptWithWorktree,
 	}: Props = $props();
 
 	const selection = useSelection();
@@ -101,6 +111,14 @@
 	function handleContextualAction(actionId: ActionId) {
 		if (onExecuteAction) {
 			onExecuteAction(actionId, issue.id);
+		}
+	}
+
+	function handleAdoptSelect(value: string) {
+		if (value === ADOPT_ACTION_VALUES.WITH_WORKTREE && onAdoptWithWorktree) {
+			onAdoptWithWorktree(issue.id);
+		} else if (value === ADOPT_ACTION_VALUES.NO_WORKTREE && onAdoptNoWorktree) {
+			onAdoptNoWorktree(issue.id);
 		}
 	}
 
@@ -158,6 +176,21 @@
 			<ContextualActionButtons
 				derivedActions={contextualActions}
 				onExecute={handleContextualAction}
+			/>
+		</div>
+	{/if}
+
+	<!-- Ghost card adopt split-button -->
+	{#if ctx.isGhost && (onAdoptNoWorktree || onAdoptWithWorktree)}
+		<!-- svelte-ignore a11y_no_static_element_interactions -->
+		<!-- svelte-ignore a11y_click_events_have_key_events -->
+		<div class="absolute bottom-2 right-2.5" onclick={(event) => event.stopPropagation()}>
+			<SplitButton
+				options={ADOPT_SPLIT_BUTTON_OPTIONS}
+				defaultValue={ADOPT_ACTION_VALUES.WITH_WORKTREE}
+				settingsKey={ADOPT_SETTINGS_KEY}
+				size="sm"
+				onselect={handleAdoptSelect}
 			/>
 		</div>
 	{/if}

--- a/src/lib/components/blocks/issue-card/ghost_card_utils.test.ts
+++ b/src/lib/components/blocks/issue-card/ghost_card_utils.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect } from 'vitest';
 import type { AssignedIssue } from '$lib/types/generated';
 import type { Issue } from '$lib/modules/issues';
-import { assignedIssueToGhostIssue, getUnlinkedOpenAssignedIssues } from './ghost_card_utils.js';
+import {
+	assignedIssueToGhostIssue,
+	getUnlinkedOpenAssignedIssues,
+	ADOPT_ACTION_VALUES,
+	ADOPT_SPLIT_BUTTON_OPTIONS,
+	ADOPT_SETTINGS_KEY,
+} from './ghost_card_utils.js';
 
 function makeAssignedIssue(overrides: Partial<AssignedIssue> = {}): AssignedIssue {
 	return {
@@ -95,6 +101,38 @@ describe('assignedIssueToGhostIssue', () => {
 	it('handles parent_issue_number: null without affecting parent_issue_id', () => {
 		const result = assignedIssueToGhostIssue(makeAssignedIssue({ parent_issue_number: null }));
 		expect(result.parent_issue_id).toBeNull();
+	});
+});
+
+describe('ADOPT_ACTION_VALUES', () => {
+	it('defines adopt and adopt-worktree values', () => {
+		expect(ADOPT_ACTION_VALUES.NO_WORKTREE).toBe('adopt');
+		expect(ADOPT_ACTION_VALUES.WITH_WORKTREE).toBe('adopt-worktree');
+	});
+});
+
+describe('ADOPT_SPLIT_BUTTON_OPTIONS', () => {
+	it('has two options in correct order (with-worktree first as default)', () => {
+		expect(ADOPT_SPLIT_BUTTON_OPTIONS).toHaveLength(2);
+		expect(ADOPT_SPLIT_BUTTON_OPTIONS[0]).toEqual({
+			value: 'adopt-worktree',
+			label: 'Adopt with Worktree',
+		});
+		expect(ADOPT_SPLIT_BUTTON_OPTIONS[1]).toEqual({
+			value: 'adopt',
+			label: 'Adopt (no worktree)',
+		});
+	});
+
+	it('option values match ADOPT_ACTION_VALUES', () => {
+		expect(ADOPT_SPLIT_BUTTON_OPTIONS[0].value).toBe(ADOPT_ACTION_VALUES.WITH_WORKTREE);
+		expect(ADOPT_SPLIT_BUTTON_OPTIONS[1].value).toBe(ADOPT_ACTION_VALUES.NO_WORKTREE);
+	});
+});
+
+describe('ADOPT_SETTINGS_KEY', () => {
+	it('is adopt_default_action', () => {
+		expect(ADOPT_SETTINGS_KEY).toBe('adopt_default_action');
 	});
 });
 

--- a/src/lib/components/blocks/issue-card/ghost_card_utils.ts
+++ b/src/lib/components/blocks/issue-card/ghost_card_utils.ts
@@ -1,6 +1,19 @@
 import type { AssignedIssue } from '$lib/types/generated';
 import type { Issue } from '$lib/modules/issues';
+import type { SplitButtonOption } from '$lib/components/derived/split-button/split_button_types.js';
 import { categorizeAssignedIssues } from '$lib/components/blocks/issue/assigned_issues_utils.js';
+
+export const ADOPT_ACTION_VALUES = {
+	NO_WORKTREE: 'adopt',
+	WITH_WORKTREE: 'adopt-worktree',
+} as const;
+
+export const ADOPT_SPLIT_BUTTON_OPTIONS: readonly SplitButtonOption[] = [
+	{ value: ADOPT_ACTION_VALUES.WITH_WORKTREE, label: 'Adopt with Worktree' },
+	{ value: ADOPT_ACTION_VALUES.NO_WORKTREE, label: 'Adopt (no worktree)' },
+] as const;
+
+export const ADOPT_SETTINGS_KEY = 'adopt_default_action';
 
 export function assignedIssueToGhostIssue(assigned: AssignedIssue): Issue {
 	return {


### PR DESCRIPTION
## Summary

- Ghost cards now render an outlined `SplitButton` (bottom-right) with two adopt options: "Adopt with Worktree" (default) and "Adopt (no worktree)"
- Selection persists across sessions via `app_settings` key `adopt_default_action` (using existing `settingsKey` prop)
- Removed the full-card click wrapper from `GhostCardAccordion` — adopt is now explicit via the split-button
- SplitButton click stops propagation to prevent card selection handlers from firing

## Test plan

- [x] Unit tests for adopt action constants (values, option order, settings key)
- [ ] Visual: ghost cards show split-button with "Adopt with Worktree" as default text
- [ ] Visual: dropdown shows both options
- [ ] Clicking main button triggers adopt-with-worktree handler
- [ ] Selecting "Adopt (no worktree)" from dropdown triggers wizard-open handler
- [ ] Non-ghost cards do NOT show split-button
- [ ] Selection persists after page reload

Fixes #374