### PR TITLE
Refactor overview radial workspace launcher

### DIFF
--- a/src/lib/components/blocks/overview/OverviewCostUsagePanel.svelte
+++ b/src/lib/components/blocks/overview/OverviewCostUsagePanel.svelte
@@ -1,0 +1,145 @@
+<script lang="ts">
+	import { Button } from '$lib/components/shadcn/button/index.js';
+	import { formatCostDisplay } from '$lib/components/blocks/usage/cost_link_utils.js';
+	import type { UsageDashboardData } from '$lib/types/generated';
+	import {
+		overviewMetricCardClass,
+		overviewPanelClass,
+		overviewPanelHeaderClass,
+	} from './overview_style.js';
+
+	interface Props {
+		usageData: UsageDashboardData | null;
+		cacheSavingsEstimate: number;
+		maxToolCallCount: number;
+		maxTrendCost: number;
+		onOpenUsage: () => void;
+	}
+
+	let { usageData, cacheSavingsEstimate, maxToolCallCount, maxTrendCost, onOpenUsage }: Props =
+		$props();
+
+	function formatDelta(value: number | null | undefined): string {
+		if (value == null) {
+			return 'no comparison';
+		}
+		return `${value >= 0 ? '+' : ''}${value.toFixed(0)}% vs previous`;
+	}
+
+	function formatSessionDelta(value: number | null | undefined): string {
+		if (value == null) {
+			return 'no comparison';
+		}
+		return `${value >= 0 ? '+' : ''}${value} vs previous`;
+	}
+</script>
+
+<section class={overviewPanelClass} aria-label="Cost and usage">
+	<div class={overviewPanelHeaderClass}>
+		<span>Cost and usage</span>
+		<Button
+			intent="secondary"
+			size="sm"
+			class="h-7 rounded-sm border-[color-mix(in_oklch,var(--moss-400)_25%,var(--border))] bg-[color-mix(in_oklch,var(--surface-2)_70%,transparent)] px-2 text-[11px] font-medium normal-case text-foreground-muted hover:border-[color-mix(in_oklch,var(--moss-400)_45%,var(--border))] hover:text-foreground"
+			onclick={onOpenUsage}
+		>
+			Open usage
+		</Button>
+	</div>
+
+	{#if usageData}
+		<div class="mt-3.5 grid grid-cols-4 gap-2.5 max-md:grid-cols-2">
+			<div class={overviewMetricCardClass}>
+				<span class="text-[11px] font-semibold text-foreground-subtle uppercase"
+					>30d cost</span
+				>
+				<strong class="mt-1 block font-mono text-xl leading-none font-semibold">
+					{formatCostDisplay(usageData.stats.total_cost_usd)}
+				</strong>
+				<small class="mt-1 block text-[11px] text-foreground-muted">
+					{formatDelta(usageData.stats.cost_delta_percent)}
+				</small>
+			</div>
+			<div class={overviewMetricCardClass}>
+				<span class="text-[11px] font-semibold text-foreground-subtle uppercase"
+					>Sessions</span
+				>
+				<strong class="mt-1 block font-mono text-xl leading-none font-semibold">
+					{usageData.stats.session_count}
+				</strong>
+				<small class="mt-1 block text-[11px] text-foreground-muted">
+					{formatSessionDelta(usageData.stats.session_count_delta)}
+				</small>
+			</div>
+			<div class={overviewMetricCardClass}>
+				<span class="text-[11px] font-semibold text-foreground-subtle uppercase"
+					>One-shot</span
+				>
+				<strong class="mt-1 block font-mono text-xl leading-none font-semibold">
+					{usageData.stats.one_shot_rate.toFixed(0)}%
+				</strong>
+				<small class="mt-1 block text-[11px] text-foreground-muted"
+					>first-pass completion</small
+				>
+			</div>
+			<div class={overviewMetricCardClass}>
+				<span class="text-[11px] font-semibold text-foreground-subtle uppercase"
+					>Cache hit</span
+				>
+				<strong class="mt-1 block font-mono text-xl leading-none font-semibold">
+					{usageData.stats.cache_hit_ratio.toFixed(0)}%
+				</strong>
+				<small class="mt-1 block text-[11px] text-foreground-muted">
+					saving ~{formatCostDisplay(cacheSavingsEstimate)}/mo
+				</small>
+			</div>
+		</div>
+
+		<div
+			class="mt-4 grid grid-cols-[minmax(0,1fr)_minmax(240px,0.8fr)] gap-4 max-lg:grid-cols-1"
+		>
+			<div>
+				<div class="text-[11px] font-semibold text-foreground-subtle uppercase">
+					Cost trend
+				</div>
+				<div class="mt-2.5 flex h-12 items-end gap-1" aria-hidden="true">
+					{#each usageData.time_bucket_costs.slice(-14) as bucket (bucket.date)}
+						<span
+							class="w-full min-w-1.5 rounded-t-xs bg-linear-to-b from-moss-300 to-[color-mix(in_oklch,var(--moss-500)_65%,var(--surface))]"
+							title={`${bucket.date}: ${formatCostDisplay(bucket.cost_usd)}`}
+							style:height={`${Math.max(10, (bucket.cost_usd / maxTrendCost) * 44)}px`}
+						></span>
+					{/each}
+				</div>
+			</div>
+
+			<div>
+				<div class="text-[11px] font-semibold text-foreground-subtle uppercase">
+					Top tools
+				</div>
+				<div class="mt-2.5 grid gap-1.5">
+					{#each usageData.tool_usage.slice(0, 4) as tool (tool.tool_name)}
+						<div
+							class="grid grid-cols-[76px_minmax(0,1fr)_42px] items-center gap-2 text-xs text-foreground-muted"
+						>
+							<span class="truncate">{tool.tool_name}</span>
+							<div
+								class="h-1.5 overflow-hidden rounded-full bg-[color-mix(in_oklch,var(--foreground)_8%,transparent)]"
+							>
+								<span
+									class="block h-full rounded-[inherit] bg-[color-mix(in_oklch,var(--teal-400)_70%,var(--moss-300))]"
+									style:width={`${(tool.call_count / maxToolCallCount) * 100}%`}
+								></span>
+							</div>
+							<small class="text-right font-mono">{tool.call_count}</small>
+						</div>
+					{/each}
+				</div>
+			</div>
+		</div>
+	{:else}
+		<div class="grid min-h-22 place-items-center text-xs text-foreground-muted">
+			Usage metrics loading...
+		</div>
+	{/if}
+</section>

--- a/src/lib/components/blocks/overview/OverviewHeader.svelte
+++ b/src/lib/components/blocks/overview/OverviewHeader.svelte
@@ -1,0 +1,109 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import { page } from '$app/state';
+	import { resolve } from '$app/paths';
+	import * as m from '$lib/paraglide/messages.js';
+	import { useSettings } from '$lib/modules/settings';
+	import type { VersionControlContext } from '$lib/modules/version-control';
+	import GitHubStatusCard from '$lib/components/blocks/github/GitHubStatusCard.svelte';
+	import GitHubAuthWizard from '$lib/components/blocks/github-auth/GitHubAuthWizard.svelte';
+	import ThemeToggle from '$lib/components/derived/theme-toggle/ThemeToggle.svelte';
+	import GithubIcon from '$lib/components/derived/icons/GithubIcon.svelte';
+	import { Button } from '$lib/components/shadcn/button/index.js';
+	import * as Popover from '$lib/components/shadcn/popover/index.js';
+	import { Toggle } from '$lib/components/shadcn/toggle/index.js';
+	import { SimpleTooltip } from '$lib/components/shadcn/tooltip/index.js';
+	import { invoke } from '$lib/tauri.js';
+	import { overviewActionButtonClass } from './overview_style.js';
+	import ArchiveIcon from '@lucide/svelte/icons/archive';
+	import SettingsIcon from '@lucide/svelte/icons/settings';
+
+	interface Props {
+		showArchived: boolean;
+		onShowArchivedChange: (pressed: boolean) => void;
+		versionControl: VersionControlContext;
+	}
+
+	let { showArchived, onShowArchivedChange, versionControl }: Props = $props();
+	let authWizardOpen = $state(false);
+
+	const settingsCtx = useSettings();
+
+	function openSettings() {
+		settingsCtx.setReturnUrl(page.url.pathname + page.url.search);
+		void goto(resolve('/settings/general'));
+	}
+</script>
+
+<header
+	class="mb-8 grid grid-cols-[minmax(0,1fr)_auto] items-end gap-6 max-md:grid-cols-1 max-md:items-start"
+>
+	<div class="grid gap-1">
+		<h1 class="text-3xl leading-tight font-semibold text-foreground">{m.app_name()}</h1>
+		<p class="text-sm text-muted-foreground">{m.overview_subtitle()}</p>
+	</div>
+
+	<div class="flex items-center gap-2">
+		<ThemeToggle compact class={overviewActionButtonClass} />
+		<SimpleTooltip text={m.nav_settings()} side="bottom">
+			{#snippet asChild(props)}
+				<button
+					{...props}
+					type="button"
+					class={[
+						'rounded-lg p-1.5 text-muted-foreground transition-colors',
+						overviewActionButtonClass,
+					]}
+					aria-label={m.nav_settings()}
+					onclick={openSettings}
+				>
+					<SettingsIcon size={14} />
+				</button>
+			{/snippet}
+		</SimpleTooltip>
+		<Toggle
+			intent="outline"
+			size="icon"
+			pressed={showArchived}
+			onPressedChange={onShowArchivedChange}
+			aria-label="Toggle archived workspaces"
+			class={overviewActionButtonClass}
+		>
+			<ArchiveIcon data-icon="inline-start" />
+		</Toggle>
+		<Popover.Root>
+			<Popover.Trigger>
+				{#snippet child({ props })}
+					<Button
+						{...props}
+						intent="secondary"
+						size="icon"
+						aria-label="GitHub connection settings"
+						class={overviewActionButtonClass}
+					>
+						<GithubIcon data-icon="inline-start" />
+					</Button>
+				{/snippet}
+			</Popover.Trigger>
+			<Popover.Content class="w-80" align="end">
+				<GitHubStatusCard
+					borderless
+					authStatus={versionControl.authStatus}
+					ghAvailability={versionControl.ghAvailability}
+					onconnect={() => (authWizardOpen = true)}
+					ondisconnect={async () => {
+						await invoke('github_logout');
+						await versionControl.checkAvailability();
+					}}
+				/>
+			</Popover.Content>
+		</Popover.Root>
+	</div>
+</header>
+
+{#if authWizardOpen}
+	<GitHubAuthWizard
+		bind:open={authWizardOpen}
+		onconnected={() => void versionControl.checkAvailability()}
+	/>
+{/if}

--- a/src/lib/components/blocks/overview/OverviewRecentActivityPanel.svelte
+++ b/src/lib/components/blocks/overview/OverviewRecentActivityPanel.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+	import ActivityIcon from '@lucide/svelte/icons/activity';
+	import ClockIcon from '@lucide/svelte/icons/clock';
+	import { overviewPanelClass, overviewPanelHeaderClass } from './overview_style.js';
+	import type {
+		OverviewWorkspaceActivity,
+		OverviewWorkspaceTotals,
+	} from '$lib/modules/overview/overview_summary.js';
+
+	interface Props {
+		activities: OverviewWorkspaceActivity[];
+		totals: OverviewWorkspaceTotals;
+		formatRelativeTime: (isoString: string | null) => string;
+		onOpenWorkspace: (dashboardId: string) => void;
+	}
+
+	let { activities, totals, formatRelativeTime, onOpenWorkspace }: Props = $props();
+</script>
+
+<section class={overviewPanelClass} aria-label="Recent activity">
+	<div class={overviewPanelHeaderClass}>
+		<span>Recent activity</span>
+		<ActivityIcon class="size-3.5 text-foreground-subtle" />
+	</div>
+
+	<div class="mt-3.5 grid gap-2">
+		{#if activities.length > 0}
+			{#each activities as activity (activity.workspace.dashboard_id)}
+				<button
+					type="button"
+					class="grid w-full grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2.5 rounded-md border border-[color-mix(in_oklch,var(--foreground)_8%,transparent)] bg-[color-mix(in_oklch,var(--surface-2)_54%,transparent)] px-2.5 py-2 text-left text-foreground hover:border-[color-mix(in_oklch,var(--moss-400)_34%,var(--border))] hover:bg-[color-mix(in_oklch,var(--moss-400)_7%,var(--surface-2))]"
+					onclick={() => onOpenWorkspace(activity.workspace.dashboard_id)}
+				>
+					<span
+						class="size-2 rounded-full bg-moss-400 shadow-[0_0_10px_color-mix(in_oklch,var(--moss-400)_65%,transparent)]"
+					></span>
+					<span class="min-w-0">
+						<strong class="block truncate text-xs font-semibold">
+							{activity.workspace.name}
+						</strong>
+						<small class="block truncate text-[11px] text-foreground-muted">
+							{activity.workspace.active_session_count} sessions / {activity.workspace
+								.open_issue_count} issues
+						</small>
+					</span>
+					<span
+						class="flex items-center gap-1 whitespace-nowrap font-mono text-[11px] text-foreground-muted"
+					>
+						<ClockIcon class="size-3" />
+						{formatRelativeTime(activity.workspace.last_activity)}
+					</span>
+				</button>
+			{/each}
+		{:else}
+			<div class="grid min-h-22 place-items-center text-xs text-foreground-muted">
+				No recent workspace activity
+			</div>
+		{/if}
+	</div>
+
+	<div
+		class="mt-3 flex flex-wrap gap-2 border-t border-dashed border-[color-mix(in_oklch,var(--foreground)_10%,transparent)] pt-2.5 font-mono text-[11px] text-foreground-subtle"
+	>
+		<span>{totals.openIssueCount} open issues</span>
+		<span>{totals.activeSessionCount} active sessions</span>
+		<span>{totals.attentionCount} need attention</span>
+	</div>
+</section>

--- a/src/lib/components/blocks/overview/OverviewSummaryBasin.svelte
+++ b/src/lib/components/blocks/overview/OverviewSummaryBasin.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+	import OverviewCostUsagePanel from './OverviewCostUsagePanel.svelte';
+	import OverviewRecentActivityPanel from './OverviewRecentActivityPanel.svelte';
+	import type { UsageDashboardData } from '$lib/types/generated';
+	import type {
+		OverviewWorkspaceActivity,
+		OverviewWorkspaceTotals,
+	} from '$lib/modules/overview/overview_summary.js';
+
+	interface Props {
+		usageData: UsageDashboardData | null;
+		cacheSavingsEstimate: number;
+		maxToolCallCount: number;
+		maxTrendCost: number;
+		activities: OverviewWorkspaceActivity[];
+		totals: OverviewWorkspaceTotals;
+		formatRelativeTime: (isoString: string | null) => string;
+		onOpenUsage: () => void;
+		onOpenWorkspace: (dashboardId: string) => void;
+	}
+
+	let {
+		usageData,
+		cacheSavingsEstimate,
+		maxToolCallCount,
+		maxTrendCost,
+		activities,
+		totals,
+		formatRelativeTime,
+		onOpenUsage,
+		onOpenWorkspace,
+	}: Props = $props();
+</script>
+
+<div
+	class="mt-auto grid grid-cols-[minmax(0,1.35fr)_minmax(300px,0.65fr)] gap-4 pt-7 max-lg:grid-cols-1"
+>
+	<OverviewCostUsagePanel
+		{usageData}
+		{cacheSavingsEstimate}
+		{maxToolCallCount}
+		{maxTrendCost}
+		{onOpenUsage}
+	/>
+	<OverviewRecentActivityPanel {activities} {totals} {formatRelativeTime} {onOpenWorkspace} />
+</div>

--- a/src/lib/components/blocks/overview/OverviewWorkspaceGrid.svelte
+++ b/src/lib/components/blocks/overview/OverviewWorkspaceGrid.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+	import WorkspaceCard from '$lib/components/blocks/workspace-card/WorkspaceCard.svelte';
+	import AddWorkspaceCard from '$lib/components/blocks/workspace/AddWorkspaceCard.svelte';
+	import type { OverviewWorkspaceData } from '$lib/types/generated';
+
+	interface Props {
+		workspaces: OverviewWorkspaceData[];
+		onAddWorkspace: () => void;
+		onOpenWorkspace: (dashboardId: string) => void;
+		onGithubClick: (workspace: OverviewWorkspaceData) => void;
+		onFolderClick: (workspace: OverviewWorkspaceData) => void;
+		onConfigureWorkspace: (dashboardId: string) => void;
+	}
+
+	let {
+		workspaces,
+		onAddWorkspace,
+		onOpenWorkspace,
+		onGithubClick,
+		onFolderClick,
+		onConfigureWorkspace,
+	}: Props = $props();
+</script>
+
+<div
+	class="grid auto-rows-fr grid-cols-[repeat(auto-fill,340px)] items-stretch gap-4 max-md:grid-cols-[minmax(0,1fr)]"
+>
+	{#each workspaces as workspace (workspace.dashboard_id)}
+		<WorkspaceCard
+			{workspace}
+			onclick={() => onOpenWorkspace(workspace.dashboard_id)}
+			onGithubClick={() => onGithubClick(workspace)}
+			onFolderClick={() => onFolderClick(workspace)}
+			onGithubRightClick={() => onConfigureWorkspace(workspace.dashboard_id)}
+			onFolderRightClick={() => onConfigureWorkspace(workspace.dashboard_id)}
+		/>
+	{/each}
+	<AddWorkspaceCard onclick={onAddWorkspace} />
+</div>

--- a/src/lib/components/blocks/overview/overview_style.ts
+++ b/src/lib/components/blocks/overview/overview_style.ts
@@ -1,0 +1,11 @@
+export const overviewActionButtonClass =
+	'border-[color-mix(in_oklch,var(--foreground)_11%,transparent)] bg-[radial-gradient(42px_34px_at_18%_86%,color-mix(in_oklch,var(--moss-400)_12%,transparent),transparent_72%),color-mix(in_oklch,var(--surface)_86%,transparent)] shadow-[inset_0_1px_0_color-mix(in_oklch,var(--foreground)_6%,transparent)] hover:border-[color-mix(in_oklch,var(--moss-400)_44%,var(--border))] hover:text-foreground hover:shadow-[0_0_22px_color-mix(in_oklch,var(--moss-400)_15%,transparent),inset_0_1px_0_color-mix(in_oklch,var(--foreground)_7%,transparent)] data-[state=on]:border-[color-mix(in_oklch,var(--moss-400)_44%,var(--border))] data-[state=on]:shadow-[0_0_22px_color-mix(in_oklch,var(--moss-400)_15%,transparent),inset_0_1px_0_color-mix(in_oklch,var(--foreground)_7%,transparent)]';
+
+export const overviewPanelClass =
+	'min-h-[118px] rounded-lg border border-[color-mix(in_oklch,var(--moss-400)_18%,var(--border))] bg-[radial-gradient(280px_150px_at_0%_100%,color-mix(in_oklch,var(--moss-400)_11%,transparent),transparent_70%),color-mix(in_oklch,var(--surface)_72%,transparent)] p-3.5 shadow-[inset_0_1px_0_color-mix(in_oklch,var(--foreground)_5%,transparent)]';
+
+export const overviewPanelHeaderClass =
+	'flex items-center justify-between gap-3 font-mono text-[11px] font-semibold uppercase text-foreground-muted';
+
+export const overviewMetricCardClass =
+	'min-w-0 rounded-md border border-[color-mix(in_oklch,var(--foreground)_9%,transparent)] bg-[radial-gradient(120px_80px_at_0%_100%,color-mix(in_oklch,var(--moss-400)_10%,transparent),transparent_70%),color-mix(in_oklch,var(--surface-2)_58%,transparent)] p-2.5';

--- a/src/lib/components/blocks/workspace-card/WorkspaceCard.stories.svelte
+++ b/src/lib/components/blocks/workspace-card/WorkspaceCard.stories.svelte
@@ -45,7 +45,7 @@
 		await expect(canvas.getByText(/3 sessions/)).toBeInTheDocument();
 
 		// Branch info visible
-		await expect(canvas.getByText(/dev · 5 worktrees/)).toBeInTheDocument();
+		await expect(canvas.getByText(/dev \/ 5 worktrees/)).toBeInTheDocument();
 
 		// PRD row visible
 		await expect(canvas.getByText(/3 PRDs/)).toBeInTheDocument();

--- a/src/lib/components/blocks/workspace-card/WorkspaceCard.svelte
+++ b/src/lib/components/blocks/workspace-card/WorkspaceCard.svelte
@@ -1,5 +1,4 @@
 ﻿<script lang="ts">
-	import * as m from '$lib/paraglide/messages.js';
 	import * as Card from '$lib/components/shadcn/card/index.js';
 	import { Button } from '$lib/components/shadcn/button/index.js';
 	import { StatCell } from '$lib/components/base/stat-cell/index.js';
@@ -16,6 +15,7 @@
 	import SparklesIcon from '@lucide/svelte/icons/sparkles';
 	import CostLink from '$lib/components/blocks/usage/CostLink.svelte';
 	import { cn } from '$lib/utils.js';
+	import { formatWorkspaceActivityRelativeTime } from '$lib/modules/overview/overview_time.js';
 	import type { OverviewWorkspaceData } from '$lib/types/generated';
 	import {
 		AFK_LOOP_RUNNING,
@@ -67,11 +67,14 @@
 	);
 
 	const accentColor = $derived(getVariantAccentColor(variant, originalAccent));
-	const gradientTint = $derived(`color-mix(in oklch, ${accentColor} 8%, transparent)`);
 
 	const isAfkOn = $derived(workspace.afk_loop_status === AFK_LOOP_RUNNING);
 	const isEmpty = $derived(variant === 'empty');
 	const isDormant = $derived(variant === 'dormant');
+	const isArchived = $derived(workspace.status === 'archived');
+	const isMissingConfiguration = $derived(
+		workspace.github_repo == null || workspace.local_folder == null,
+	);
 
 	const issuesSuffix = $derived(`/${workspace.open_issue_count}`);
 
@@ -107,8 +110,10 @@
 		if (workspace.active_session_count > 0) {
 			return `${workspace.active_session_count} sessions`;
 		}
-		const relativeTime = formatRelativeTime(workspace.last_activity);
-		return relativeTime !== m.workspace_no_activity() ? `last ${relativeTime}` : undefined;
+		const relativeTime = formatWorkspaceActivityRelativeTime(workspace.last_activity);
+		return relativeTime !== formatWorkspaceActivityRelativeTime(null)
+			? `last ${relativeTime}`
+			: undefined;
 	});
 
 	const prdProgressPercent = $derived(
@@ -124,32 +129,6 @@
 			.map((word) => word[0]?.toUpperCase() ?? '')
 			.join(''),
 	);
-
-	function formatRelativeTime(isoString: string | null): string {
-		if (isoString == null) {
-			return m.workspace_no_activity();
-		}
-		const date = new Date(isoString);
-		const now = new Date();
-		const diffMs = now.getTime() - date.getTime();
-		const diffMinutes = Math.floor(diffMs / 60000);
-
-		if (diffMinutes < 1) {
-			return m.time_just_now();
-		}
-		if (diffMinutes < 60) {
-			return m.time_minutes_ago({ count: String(diffMinutes) });
-		}
-		const diffHours = Math.floor(diffMinutes / 60);
-		if (diffHours < 24) {
-			return m.time_hours_ago({ count: String(diffHours) });
-		}
-		const diffDays = Math.floor(diffHours / 24);
-		if (diffDays === 1) {
-			return m.workspace_yesterday();
-		}
-		return m.time_days_ago({ count: String(diffDays) });
-	}
 
 	function handleIconClick(event: MouseEvent, handler?: () => void) {
 		event.stopPropagation();
@@ -173,12 +152,19 @@
 >
 	<Card.Card
 		padding="none"
-		accentBarColor={accentColor}
-		{gradientTint}
 		class={cn(
-			'group relative isolate h-full cursor-pointer transition-all duration-4',
-			'hover:-translate-y-0.5 gk-ws-hover-glow',
+			'group relative isolate h-full min-h-[198px] cursor-pointer overflow-hidden rounded-lg bg-surface transition-all duration-4',
+			'border-[color-mix(in_oklch,var(--ws-accent)_25%,var(--border))]',
+			'shadow-[0_16px_34px_rgb(0_0_0_/_20%),inset_0_0_4px_color-mix(in_oklch,var(--ws-accent)_22%,transparent),inset_0_1px_0_color-mix(in_oklch,var(--foreground)_6%,transparent)]',
+			"before:pointer-events-none before:absolute before:inset-0 before:z-0 before:rounded-[inherit] before:content-['']",
+			'before:bg-[radial-gradient(250px_210px_at_0%_100%,color-mix(in_oklch,var(--ws-accent)_30%,transparent),transparent_68%),radial-gradient(180px_150px_at_12%_84%,color-mix(in_oklch,var(--ws-accent)_18%,transparent),transparent_72%),linear-gradient(180deg,color-mix(in_oklch,var(--surface-2)_56%,transparent),transparent_55%)]',
+			'hover:-translate-y-0.5 hover:border-[color-mix(in_oklch,var(--ws-accent)_58%,var(--border))]',
+			'hover:shadow-[0_22px_48px_rgb(0_0_0_/_26%),0_0_34px_color-mix(in_oklch,var(--ws-accent)_18%,transparent),inset_0_0_14px_color-mix(in_oklch,var(--ws-accent)_21%,transparent),inset_0_1px_0_color-mix(in_oklch,var(--foreground)_7%,transparent)]',
 			isDormant && 'opacity-[0.72] saturate-[0.7]',
+			isArchived &&
+				'opacity-[0.54] grayscale-[0.35] saturate-[0.62] before:bg-[radial-gradient(250px_210px_at_0%_100%,color-mix(in_oklch,var(--foreground-subtle)_12%,transparent),transparent_68%),linear-gradient(180deg,color-mix(in_oklch,var(--surface-2)_42%,transparent),transparent_55%)]',
+			isMissingConfiguration &&
+				'border-[color-mix(in_oklch,var(--status-warning)_24%,var(--border))]',
 		)}
 	>
 		{#if variant === 'active'}
@@ -210,7 +196,7 @@
 						>
 							<GitBranchIcon class="size-3 shrink-0" />
 							<span class="truncate">
-								{workspace.default_branch ?? 'main'} · {workspace.worktree_count} worktrees
+								{workspace.default_branch ?? 'main'} / {workspace.worktree_count} worktrees
 							</span>
 						</span>
 					</div>
@@ -245,11 +231,11 @@
 				{#if isEmpty}
 					<!-- Empty placeholder content -->
 					<div
-						class="flex h-full flex-col items-center justify-center gap-2 rounded-sm border border-dashed border-border px-4 py-6"
+						class="flex h-full flex-col items-center justify-center gap-2 rounded-sm border border-dashed border-[color-mix(in_oklch,var(--ws-accent)_28%,var(--border))] bg-[color-mix(in_oklch,var(--ws-accent)_7%,transparent)] px-4 py-6"
 					>
 						<SparklesIcon class="size-5 text-foreground-subtle" />
 						<span class="text-xs font-medium text-foreground-muted">
-							Newly created — open to track issues
+							Newly created - open to track issues
 						</span>
 					</div>
 				{:else}
@@ -288,7 +274,14 @@
 					</div>
 
 					<!-- PRD row -->
-					{#if workspace.prd_count > 0}
+					{#if isMissingConfiguration}
+						<div
+							class="mb-1.5 flex h-7.5 items-center gap-2 rounded-sm border border-[color-mix(in_oklch,var(--status-warning)_35%,transparent)] bg-[color-mix(in_oklch,var(--status-warning)_10%,transparent)] px-2.5 text-[11px] font-medium text-status-warning"
+						>
+							<TriangleAlertIcon class="size-3 shrink-0" strokeWidth={1.7} />
+							<span class="truncate">Configuration incomplete</span>
+						</div>
+					{:else if workspace.prd_count > 0}
 						<button
 							type="button"
 							class="mb-1.5 flex w-full cursor-pointer items-center gap-2 rounded-sm border border-border bg-surface-2 px-2.5 py-1.5 hover:border-border-strong"
@@ -329,6 +322,7 @@
 						active={isAfkOn}
 						label={isAfkOn ? 'AFK loop running' : 'AFK loop off'}
 						meta={afkMeta}
+						activeColor={accentColor}
 						onclick={onAfkClick}
 					/>
 				{/if}
@@ -352,19 +346,9 @@
 					class="flex items-center gap-1 font-mono text-[10.5px] text-foreground-subtle"
 				>
 					<ClockIcon class="size-3" />
-					{formatRelativeTime(workspace.last_activity)}
+					{formatWorkspaceActivityRelativeTime(workspace.last_activity)}
 				</span>
 			</div>
 		</div></Card.Card
 	>
 </button>
-
-<style>
-	:global(.gk-ws-hover-glow):hover {
-		border-color: color-mix(in srgb, var(--ws-accent) 55%, var(--border));
-		box-shadow:
-			0 4px 6px -1px rgb(0 0 0 / 10%),
-			0 2px 4px -2px rgb(0 0 0 / 10%),
-			0 0 24px color-mix(in oklch, var(--ws-accent) 18%, transparent);
-	}
-</style>

--- a/src/lib/components/blocks/workspace/AddWorkspaceCard.svelte
+++ b/src/lib/components/blocks/workspace/AddWorkspaceCard.svelte
@@ -11,10 +11,12 @@
 
 <button class="block h-full w-full text-left" {onclick}>
 	<div
-		class="flex h-full min-h-49 cursor-pointer items-center justify-center rounded-lg border-[1.5px] border-dashed border-border bg-surface transition-all duration-4 hover:-translate-y-0.5 hover:border-moss-400 hover:bg-[color-mix(in_oklch,var(--moss-400)_6%,var(--surface))] hover:text-moss-300"
+		class="relative flex h-full min-h-[198px] cursor-pointer items-center justify-center overflow-hidden rounded-lg border-[1.5px] border-dashed border-[color-mix(in_oklch,var(--moss-400)_28%,var(--border))] bg-[radial-gradient(230px_190px_at_0%_100%,color-mix(in_oklch,var(--moss-400)_14%,transparent),transparent_70%),color-mix(in_oklch,var(--surface)_72%,transparent)] text-foreground-muted transition-[transform,border-color,background,color] duration-4 hover:-translate-y-0.5 hover:border-[color-mix(in_oklch,var(--moss-400)_48%,var(--border))] hover:text-foreground"
 	>
 		<div class="flex flex-col items-center gap-2.5 text-foreground-muted">
-			<div class="flex size-9 items-center justify-center rounded-full bg-surface-2">
+			<div
+				class="flex size-11 items-center justify-center rounded-lg border border-[color-mix(in_oklch,var(--moss-400)_35%,var(--border))] bg-[radial-gradient(44px_38px_at_20%_86%,color-mix(in_oklch,var(--moss-400)_26%,transparent),transparent_70%),var(--surface-2)]"
+			>
 				<PlusIcon class="size-5" />
 			</div>
 			<span class="text-[13px] font-medium">{m.workspace_add()}</span>

--- a/src/lib/components/derived/theme-toggle/ThemeToggle.svelte
+++ b/src/lib/components/derived/theme-toggle/ThemeToggle.svelte
@@ -8,13 +8,15 @@
 	import SidebarCollapsedItem from '$lib/components/derived/sidebar-collapsed-item/SidebarCollapsedItem.svelte';
 	import { Tabs, Tab } from '$lib/components/shadcn/tabs/index.js';
 	import { SimpleTooltip } from '$lib/components/shadcn/tooltip/index.js';
+	import { cn } from '$lib/utils.js';
 
 	interface Props {
 		collapsed?: boolean;
 		compact?: boolean;
+		class?: string;
 	}
 
-	let { collapsed = false, compact = false }: Props = $props();
+	let { collapsed = false, compact = false, class: className }: Props = $props();
 
 	const settingsCtx = useSettings();
 	const themeMode = $derived(settingsCtx.getThemeMode() as ThemeMode);
@@ -45,7 +47,10 @@
 			<button
 				{...props}
 				type="button"
-				class="rounded-lg p-1.5 text-muted-foreground transition-colors hover:bg-surface-hover hover:text-foreground"
+				class={cn(
+					'rounded-lg p-1.5 text-muted-foreground transition-colors hover:bg-surface-hover hover:text-foreground',
+					className,
+				)}
 				onclick={cycleMode}
 				aria-label="{MODE_LABELS[currentMode.labelKey]()} mode"
 			>

--- a/src/lib/modules/overview/overview_summary.test.ts
+++ b/src/lib/modules/overview/overview_summary.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import type { OverviewWorkspaceData } from '$lib/types/generated';
+import {
+	calculateOverviewWorkspaceTotals,
+	deriveRecentWorkspaceActivities,
+	estimateMonthlyCacheSavings,
+	getMaximumToolCallCount,
+} from './overview_summary.js';
+
+function makeWorkspace(overrides: Partial<OverviewWorkspaceData>): OverviewWorkspaceData {
+	return {
+		dashboard_id: 'dashboard',
+		name: 'Workspace',
+		github_repo: null,
+		local_folder: null,
+		color_palette_id: null,
+		accent_color: null,
+		open_issue_count: 0,
+		active_session_count: 0,
+		last_activity: null,
+		total_cost_usd: null,
+		hitl_count: 0,
+		open_pr_count: 0,
+		prs_needing_attention: 0,
+		afk_loop_status: 'off',
+		default_branch: 'main',
+		worktree_count: 0,
+		afk_ready_count: 0,
+		prd_count: 0,
+		prd_completed_subs: 0,
+		prd_total_subs: 0,
+		status: 'active',
+		...overrides,
+	};
+}
+
+describe('deriveRecentWorkspaceActivities', () => {
+	it('returns newest valid activity first and respects limit', () => {
+		const activities = deriveRecentWorkspaceActivities(
+			[
+				makeWorkspace({ dashboard_id: 'older', last_activity: '2026-05-20T10:00:00Z' }),
+				makeWorkspace({ dashboard_id: 'none', last_activity: null }),
+				makeWorkspace({ dashboard_id: 'invalid', last_activity: 'not-a-date' }),
+				makeWorkspace({ dashboard_id: 'newer', last_activity: '2026-05-22T10:00:00Z' }),
+			],
+			1,
+		);
+
+		expect(activities).toHaveLength(1);
+		expect(activities[0].workspace.dashboard_id).toBe('newer');
+	});
+});
+
+describe('calculateOverviewWorkspaceTotals', () => {
+	it('rolls workspace health and cost totals together', () => {
+		expect(
+			calculateOverviewWorkspaceTotals([
+				makeWorkspace({
+					active_session_count: 2,
+					open_issue_count: 8,
+					hitl_count: 1,
+					prs_needing_attention: 3,
+					total_cost_usd: 2.5,
+				}),
+				makeWorkspace({
+					active_session_count: 1,
+					open_issue_count: 4,
+					hitl_count: 2,
+					prs_needing_attention: 0,
+					total_cost_usd: null,
+				}),
+			]),
+		).toEqual({
+			activeSessionCount: 3,
+			attentionCount: 6,
+			openIssueCount: 12,
+			todayCostUsd: 2.5,
+		});
+	});
+});
+
+describe('estimateMonthlyCacheSavings', () => {
+	it('uses the usage page savings heuristic', () => {
+		expect(estimateMonthlyCacheSavings(10, 50)).toBe(4.5);
+	});
+});
+
+describe('getMaximumToolCallCount', () => {
+	it('returns one for empty tool usage so bars keep a stable denominator', () => {
+		expect(getMaximumToolCallCount([])).toBe(1);
+	});
+});

--- a/src/lib/modules/overview/overview_summary.ts
+++ b/src/lib/modules/overview/overview_summary.ts
@@ -1,0 +1,60 @@
+import type { OverviewWorkspaceData, ToolUsageBreakdown } from '$lib/types/generated';
+
+export interface OverviewWorkspaceActivity {
+	workspace: OverviewWorkspaceData;
+	activityAt: Date;
+}
+
+export interface OverviewWorkspaceTotals {
+	activeSessionCount: number;
+	attentionCount: number;
+	openIssueCount: number;
+	todayCostUsd: number;
+}
+
+export function deriveRecentWorkspaceActivities(
+	workspaces: OverviewWorkspaceData[],
+	limit = 4,
+): OverviewWorkspaceActivity[] {
+	return workspaces
+		.flatMap((workspace) => {
+			if (workspace.last_activity == null) {
+				return [];
+			}
+			const activityAt = new Date(workspace.last_activity);
+			if (Number.isNaN(activityAt.getTime())) {
+				return [];
+			}
+			return [{ workspace, activityAt }];
+		})
+		.sort((left, right) => right.activityAt.getTime() - left.activityAt.getTime())
+		.slice(0, limit);
+}
+
+export function calculateOverviewWorkspaceTotals(
+	workspaces: OverviewWorkspaceData[],
+): OverviewWorkspaceTotals {
+	return workspaces.reduce<OverviewWorkspaceTotals>(
+		(totals, workspace) => ({
+			activeSessionCount: totals.activeSessionCount + workspace.active_session_count,
+			attentionCount:
+				totals.attentionCount + workspace.prs_needing_attention + workspace.hitl_count,
+			openIssueCount: totals.openIssueCount + workspace.open_issue_count,
+			todayCostUsd: totals.todayCostUsd + (workspace.total_cost_usd ?? 0),
+		}),
+		{
+			activeSessionCount: 0,
+			attentionCount: 0,
+			openIssueCount: 0,
+			todayCostUsd: 0,
+		},
+	);
+}
+
+export function estimateMonthlyCacheSavings(totalCostUsd: number, cacheHitRatio: number): number {
+	return totalCostUsd * (cacheHitRatio / 100) * 0.9;
+}
+
+export function getMaximumToolCallCount(toolUsage: ToolUsageBreakdown[]): number {
+	return Math.max(...toolUsage.map((tool) => tool.call_count), 1);
+}

--- a/src/lib/modules/overview/overview_time.ts
+++ b/src/lib/modules/overview/overview_time.ts
@@ -1,0 +1,28 @@
+import * as m from '$lib/paraglide/messages.js';
+
+export function formatWorkspaceActivityRelativeTime(isoString: string | null): string {
+	if (isoString == null) {
+		return m.workspace_no_activity();
+	}
+
+	const date = new Date(isoString);
+	const diffMinutes = Math.floor((Date.now() - date.getTime()) / 60000);
+
+	if (diffMinutes < 1) {
+		return m.time_just_now();
+	}
+	if (diffMinutes < 60) {
+		return m.time_minutes_ago({ count: String(diffMinutes) });
+	}
+
+	const diffHours = Math.floor(diffMinutes / 60);
+	if (diffHours < 24) {
+		return m.time_hours_ago({ count: String(diffHours) });
+	}
+
+	const diffDays = Math.floor(diffHours / 24);
+	if (diffDays === 1) {
+		return m.workspace_yesterday();
+	}
+	return m.time_days_ago({ count: String(diffDays) });
+}

--- a/src/lib/modules/version-control/index.ts
+++ b/src/lib/modules/version-control/index.ts
@@ -1,1 +1,2 @@
 export { setVersionControlContext, useVersionControl } from './version_control.context.svelte.js';
+export type { VersionControlContext } from './version_control.context.svelte.js';

--- a/src/lib/modules/version-control/version_control.context.svelte.ts
+++ b/src/lib/modules/version-control/version_control.context.svelte.ts
@@ -37,7 +37,7 @@ export function isCacheStale(
 
 // ─── Context ────────────────────────────────────────────────────────────────
 
-type VersionControlContext = ReturnType<typeof createVersionControlContext>;
+export type VersionControlContext = ReturnType<typeof createVersionControlContext>;
 
 const [useVersionControl, setVersionControlInternal] = createContext<VersionControlContext>();
 export { useVersionControl };

--- a/src/routes/overview/+page.svelte
+++ b/src/routes/overview/+page.svelte
@@ -1,33 +1,32 @@
-﻿<script lang="ts">
+<script lang="ts">
+	import { onMount } from 'svelte';
 	import * as m from '$lib/paraglide/messages.js';
 	import { goto } from '$app/navigation';
-	import { page } from '$app/state';
 	import { resolve } from '$app/paths';
 	import { openPath } from '$lib/opener.js';
-	import { invoke } from '$lib/tauri.js';
 	import { useBoard } from '$lib/modules/board';
-	import { useSettings } from '$lib/modules/settings';
+	import { setUsageContext } from '$lib/modules/usage/usage.context.svelte.js';
+	import { USAGE_SCOPES } from '$lib/modules/usage/usage_types.js';
 	import { useVersionControl } from '$lib/modules/version-control';
 	import { getOverviewData, openWorkspaceWindow } from '$lib/modules/window';
-	import WorkspaceCard from '$lib/components/blocks/workspace-card/WorkspaceCard.svelte';
-	import AddWorkspaceCard from '$lib/components/blocks/workspace/AddWorkspaceCard.svelte';
-	import GitHubStatusCard from '$lib/components/blocks/github/GitHubStatusCard.svelte';
-	import GitHubAuthWizard from '$lib/components/blocks/github-auth/GitHubAuthWizard.svelte';
-	import ThemeToggle from '$lib/components/derived/theme-toggle/ThemeToggle.svelte';
-	import * as Popover from '$lib/components/shadcn/popover/index.js';
-	import { Button } from '$lib/components/shadcn/button/index.js';
-	import { Toggle } from '$lib/components/shadcn/toggle/index.js';
-	import { SimpleTooltip } from '$lib/components/shadcn/tooltip/index.js';
-	import GithubIcon from '$lib/components/derived/icons/GithubIcon.svelte';
-	import SettingsIcon from '@lucide/svelte/icons/settings';
-	import ArchiveIcon from '@lucide/svelte/icons/archive';
+	import OverviewHeader from '$lib/components/blocks/overview/OverviewHeader.svelte';
+	import OverviewSummaryBasin from '$lib/components/blocks/overview/OverviewSummaryBasin.svelte';
+	import OverviewWorkspaceGrid from '$lib/components/blocks/overview/OverviewWorkspaceGrid.svelte';
+	import {
+		calculateOverviewWorkspaceTotals,
+		deriveRecentWorkspaceActivities,
+		estimateMonthlyCacheSavings,
+		getMaximumToolCallCount,
+	} from '$lib/modules/overview/overview_summary.js';
+	import { formatWorkspaceActivityRelativeTime } from '$lib/modules/overview/overview_time.js';
 	import type { OverviewWorkspaceData } from '$lib/types/generated';
 
 	const boardStore = useBoard();
-	const settingsCtx = useSettings();
 	const versionControl = useVersionControl();
+	const usageCtx = setUsageContext();
 
-	let authWizardOpen = $state(false);
+	usageCtx.scope.current = USAGE_SCOPES.global;
+	usageCtx.activePeriod.current = 'thirty-days';
 
 	let workspaces = $state.raw<OverviewWorkspaceData[]>([]);
 	let loading = $state(true);
@@ -35,7 +34,7 @@
 	let showArchived = $state(false);
 
 	$effect(() => {
-		void boardStore.dashboards; // re-run when workspace list changes
+		void boardStore.dashboards;
 		const includeArchived = showArchived;
 		void (async () => {
 			loading = true;
@@ -50,6 +49,27 @@
 		})();
 	});
 
+	onMount(() => {
+		void usageCtx.loadData();
+		return () => usageCtx.clearTimers();
+	});
+
+	const workspaceTotals = $derived(calculateOverviewWorkspaceTotals(workspaces));
+	const recentWorkspaceActivities = $derived(deriveRecentWorkspaceActivities(workspaces, 4));
+	const usageData = $derived(usageCtx.dashboardData.current);
+	const maxToolCallCount = $derived(getMaximumToolCallCount(usageData?.tool_usage ?? []));
+	const maxTrendCost = $derived(
+		Math.max(...(usageData?.time_bucket_costs.map((entry) => entry.cost_usd) ?? []), 0.01),
+	);
+	const cacheSavingsEstimate = $derived(
+		usageData
+			? estimateMonthlyCacheSavings(
+					usageData.stats.total_cost_usd,
+					usageData.stats.cache_hit_ratio,
+				)
+			: 0,
+	);
+
 	async function handleOpenWorkspace(dashboardId: string) {
 		try {
 			await openWorkspaceWindow(dashboardId);
@@ -58,110 +78,68 @@
 		}
 	}
 
-	function handleGithubClick(githubRepo: string) {
-		window.open(`https://github.com/${githubRepo}`, '_blank');
+	function handleGithubClick(workspace: OverviewWorkspaceData) {
+		if (workspace.github_repo == null) {
+			handleConfigWizard(workspace.dashboard_id);
+			return;
+		}
+		window.open(`https://github.com/${workspace.github_repo}`, '_blank');
 	}
 
-	function handleFolderClick(localFolder: string) {
-		void openPath(localFolder);
+	function handleFolderClick(workspace: OverviewWorkspaceData) {
+		if (workspace.local_folder == null) {
+			handleConfigWizard(workspace.dashboard_id);
+			return;
+		}
+		void openPath(workspace.local_folder);
 	}
 
 	function handleConfigWizard(_dashboardId: string) {
-		// TODO: open config wizard for workspace
 		console.info('Config wizard for', _dashboardId);
+	}
+
+	function openUsagePage() {
+		void goto(resolve('/usage'));
 	}
 </script>
 
-<div class="flex flex-col gap-6 p-8">
-	<div class="flex items-end justify-between">
-		<div>
-			<h1 class="text-2xl font-bold text-foreground">{m.app_name()}</h1>
-			<p class="text-sm text-muted-foreground">{m.overview_subtitle()}</p>
-		</div>
-		<div class="flex items-center gap-2">
-			<ThemeToggle compact />
-			<SimpleTooltip text={m.nav_settings()} side="bottom">
-				{#snippet asChild(props)}
-					<button
-						{...props}
-						type="button"
-						class="rounded-lg p-1.5 text-muted-foreground transition-colors hover:bg-surface-hover hover:text-foreground"
-						aria-label={m.nav_settings()}
-						onclick={() => {
-							settingsCtx.setReturnUrl(page.url.pathname + page.url.search);
-							void goto(resolve('/settings/general'));
-						}}
-					>
-						<SettingsIcon size={14} />
-					</button>
-				{/snippet}
-			</SimpleTooltip>
-			<Toggle
-				intent="outline"
-				size="icon"
-				pressed={showArchived}
-				onPressedChange={(pressed) => (showArchived = pressed)}
-				aria-label="Toggle archived workspaces"
-			>
-				<ArchiveIcon data-icon="inline-start" />
-			</Toggle>
-			<Popover.Root>
-				<Popover.Trigger>
-					{#snippet child({ props })}
-						<Button
-							{...props}
-							intent="secondary"
-							size="icon"
-							aria-label="GitHub connection settings"
-						>
-							<GithubIcon data-icon="inline-start" />
-						</Button>
-					{/snippet}
-				</Popover.Trigger>
-				<Popover.Content class="w-80" align="end">
-					<GitHubStatusCard
-						borderless
-						authStatus={versionControl.authStatus}
-						ghAvailability={versionControl.ghAvailability}
-						onconnect={() => (authWizardOpen = true)}
-						ondisconnect={async () => {
-							await invoke('github_logout');
-							await versionControl.checkAvailability();
-						}}
-					/>
-				</Popover.Content>
-			</Popover.Root>
-		</div>
+<div
+	class="flex min-h-full bg-[radial-gradient(780px_380px_at_5%_16%,color-mix(in_oklch,var(--moss-500)_13%,transparent),transparent_72%),radial-gradient(620px_320px_at_72%_-4%,color-mix(in_oklch,var(--teal-500)_8%,transparent),transparent_66%),linear-gradient(180deg,color-mix(in_oklch,var(--surface)_32%,transparent),transparent_420px),var(--background)] px-10 pt-9.5 pb-16 max-md:px-4.5 max-md:py-6"
+>
+	<div
+		class="mx-auto flex min-h-[calc(100vh-102px)] w-full max-w-[1840px] flex-col max-md:min-h-[calc(100vh-56px)]"
+	>
+		<OverviewHeader
+			{showArchived}
+			onShowArchivedChange={(pressed) => (showArchived = pressed)}
+			{versionControl}
+		/>
+
+		{#if loading}
+			<p class="text-muted-foreground">{m.overview_loading()}</p>
+		{:else if error !== null}
+			<p class="text-destructive">{m.error_prefix({ message: error })}</p>
+		{:else}
+			<OverviewWorkspaceGrid
+				{workspaces}
+				onAddWorkspace={() => (boardStore.showCreateDialog = true)}
+				onOpenWorkspace={handleOpenWorkspace}
+				onGithubClick={handleGithubClick}
+				onFolderClick={handleFolderClick}
+				onConfigureWorkspace={handleConfigWizard}
+			/>
+
+			<OverviewSummaryBasin
+				{usageData}
+				{cacheSavingsEstimate}
+				{maxToolCallCount}
+				{maxTrendCost}
+				activities={recentWorkspaceActivities}
+				totals={workspaceTotals}
+				formatRelativeTime={formatWorkspaceActivityRelativeTime}
+				onOpenUsage={openUsagePage}
+				onOpenWorkspace={handleOpenWorkspace}
+			/>
+		{/if}
 	</div>
-
-	{#if loading}
-		<p class="text-muted-foreground">{m.overview_loading()}</p>
-	{:else if error !== null}
-		<p class="text-destructive">{m.error_prefix({ message: error })}</p>
-	{:else}
-		<div class="grid auto-rows-[1fr] grid-cols-[repeat(auto-fill,340px)] gap-4">
-			{#each workspaces as workspace (workspace.dashboard_id)}
-				<WorkspaceCard
-					{workspace}
-					onclick={() => handleOpenWorkspace(workspace.dashboard_id)}
-					onGithubClick={workspace.github_repo != null
-						? () => handleGithubClick(workspace.github_repo!)
-						: () => handleConfigWizard(workspace.dashboard_id)}
-					onFolderClick={workspace.local_folder != null
-						? () => handleFolderClick(workspace.local_folder!)
-						: () => handleConfigWizard(workspace.dashboard_id)}
-					onGithubRightClick={() => handleConfigWizard(workspace.dashboard_id)}
-					onFolderRightClick={() => handleConfigWizard(workspace.dashboard_id)}
-				/>
-			{/each}
-			<AddWorkspaceCard onclick={() => (boardStore.showCreateDialog = true)} />
-		</div>
-	{/if}
 </div>
-
-{#if authWizardOpen}
-	<GitHubAuthWizard
-		bind:open={authWizardOpen}
-		onconnected={() => void versionControl.checkAvailability()}
-	/>
-{/if}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -51,6 +51,9 @@ export default defineConfig({
 			],
 		},
 	},
+	optimizeDeps: {
+		include: ['@lucide/svelte/icons/filter'],
+	},
 	test: {
 		passWithNoTests: true,
 		expect: {


### PR DESCRIPTION
## Summary
- split the overview route into focused overview block components
- remove large Svelte style blocks from the overview/workspace card surface in favor of Tailwind utilities
- keep radial workspace launcher styling, usage summary, activity summary, and workspace card states
- add Vite pre-optimization for the lucide filter icon to prevent Vitest browser reloads

## Validation
- pnpm.cmd exec vitest run --project client src/lib/modules/processes/processes_context.svelte.test.ts
- pnpm.cmd check:fast
- pnpm.cmd typecheck
- pre-push gate: fallow, typecheck, eslint, vitest