### PR TITLE
#336 feat(overview): workspace card archive/unarchive/delete menu

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -264,6 +264,16 @@
 	"btn_create": "Create",
 	"btn_delete": "Delete",
 	"btn_confirm_delete": "Confirm Delete",
+	"btn_archive": "Archive",
+	"btn_confirm_archive": "Confirm Archive",
+	"btn_unarchive": "Restore",
+	"workspace_archive_confirm_title": "Archive Workspace",
+	"workspace_archive_confirm_body": "This workspace will be hidden from the sidebar. You can restore it later.",
+	"workspace_delete_confirm_title": "Delete Workspace",
+	"workspace_delete_confirm_body": "This action is permanent. All workspace data including issues, sessions, and settings will be deleted.",
+	"workspace_delete_name_placeholder": "Type workspace name to confirm",
+	"workspace_delete_name_mismatch": "Name does not match",
+	"workspace_status_archived": "Archived",
 
 	"settings_title": "Settings",
 

--- a/src/lib/components/blocks/overview/OverviewWorkspaceGrid.svelte
+++ b/src/lib/components/blocks/overview/OverviewWorkspaceGrid.svelte
@@ -10,6 +10,9 @@
 		onGithubClick: (workspace: OverviewWorkspaceData) => void;
 		onFolderClick: (workspace: OverviewWorkspaceData) => void;
 		onConfigureWorkspace: (dashboardId: string) => void;
+		onArchive: (workspace: OverviewWorkspaceData) => void;
+		onUnarchive: (workspace: OverviewWorkspaceData) => void;
+		onDelete: (workspace: OverviewWorkspaceData) => void;
 	}
 
 	let {
@@ -19,6 +22,9 @@
 		onGithubClick,
 		onFolderClick,
 		onConfigureWorkspace,
+		onArchive,
+		onUnarchive,
+		onDelete,
 	}: Props = $props();
 </script>
 
@@ -33,6 +39,9 @@
 			onFolderClick={() => onFolderClick(workspace)}
 			onGithubRightClick={() => onConfigureWorkspace(workspace.dashboard_id)}
 			onFolderRightClick={() => onConfigureWorkspace(workspace.dashboard_id)}
+			onArchive={() => onArchive(workspace)}
+			onUnarchive={() => onUnarchive(workspace)}
+			onDelete={() => onDelete(workspace)}
 		/>
 	{/each}
 	<AddWorkspaceCard onclick={onAddWorkspace} />

--- a/src/lib/components/blocks/workspace-card/WorkspaceCard.svelte
+++ b/src/lib/components/blocks/workspace-card/WorkspaceCard.svelte
@@ -1,12 +1,19 @@
 ﻿<script lang="ts">
+	import * as m from '$lib/paraglide/messages.js';
 	import * as Card from '$lib/components/shadcn/card/index.js';
+	import * as DropdownMenu from '$lib/components/shadcn/dropdown-menu/index.js';
+	import { Badge } from '$lib/components/shadcn/badge/index.js';
 	import { Button } from '$lib/components/shadcn/button/index.js';
 	import { StatCell } from '$lib/components/base/stat-cell/index.js';
 	import { StatusRow } from '$lib/components/base/status-row/index.js';
 	import GithubIcon from '$lib/components/derived/icons/GithubIcon.svelte';
+	import ArchiveIcon from '@lucide/svelte/icons/archive';
+	import ArchiveRestoreIcon from '@lucide/svelte/icons/archive-restore';
+	import EllipsisVerticalIcon from '@lucide/svelte/icons/ellipsis-vertical';
 	import FolderIcon from '@lucide/svelte/icons/folder';
 	import ListChecksIcon from '@lucide/svelte/icons/list-checks';
 	import GitPullRequestIcon from '@lucide/svelte/icons/git-pull-request';
+	import Trash2Icon from '@lucide/svelte/icons/trash-2';
 	import TriangleAlertIcon from '@lucide/svelte/icons/triangle-alert';
 	import UserIcon from '@lucide/svelte/icons/user';
 	import GitBranchIcon from '@lucide/svelte/icons/git-branch';
@@ -37,6 +44,9 @@
 		onHitlClick?: () => void;
 		onPrdClick?: () => void;
 		onAfkClick?: () => void;
+		onArchive?: () => void;
+		onUnarchive?: () => void;
+		onDelete?: () => void;
 	}
 
 	let {
@@ -52,6 +62,9 @@
 		onHitlClick,
 		onPrdClick,
 		onAfkClick,
+		onArchive,
+		onUnarchive,
+		onDelete,
 	}: Props = $props();
 
 	const originalAccent = $derived(workspace.accent_color ?? 'oklch(0.580 0.096 134)');
@@ -174,6 +187,12 @@
 			></div>
 		{/if}
 
+		{#if isArchived}
+			<Badge tone="neutral" class="absolute top-2 right-2 z-10"
+				>{m.workspace_status_archived()}</Badge
+			>
+		{/if}
+
 		<div class="relative z-1 flex h-full flex-col px-3.5 pt-3.5 pb-3">
 			<!-- Header: thumbnail + name + subtitle + icon buttons -->
 			<div class="mb-2.5 flex items-start justify-between gap-2">
@@ -224,6 +243,48 @@
 					>
 						<FolderIcon strokeWidth={1.7} data-icon="inline-end" />
 					</Button>
+					<DropdownMenu.Root>
+						<DropdownMenu.Trigger>
+							{#snippet child({ props })}
+								<Button
+									{...props}
+									intent="ghost"
+									size="icon"
+									class="size-6.5 opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
+									aria-label="Workspace actions"
+									onclick={(event: MouseEvent) => event.stopPropagation()}
+								>
+									<EllipsisVerticalIcon
+										strokeWidth={1.7}
+										data-icon="inline-end"
+									/>
+								</Button>
+							{/snippet}
+						</DropdownMenu.Trigger>
+						<DropdownMenu.Content side="bottom" align="end">
+							<DropdownMenu.Group>
+								{#if isArchived}
+									<DropdownMenu.Item onSelect={() => onUnarchive?.()}>
+										<ArchiveRestoreIcon />
+										{m.btn_unarchive()}
+									</DropdownMenu.Item>
+									<DropdownMenu.Separator />
+									<DropdownMenu.Item
+										variant="destructive"
+										onSelect={() => onDelete?.()}
+									>
+										<Trash2Icon />
+										{m.btn_delete()}
+									</DropdownMenu.Item>
+								{:else}
+									<DropdownMenu.Item onSelect={() => onArchive?.()}>
+										<ArchiveIcon />
+										{m.btn_archive()}
+									</DropdownMenu.Item>
+								{/if}
+							</DropdownMenu.Group>
+						</DropdownMenu.Content>
+					</DropdownMenu.Root>
 				</div>
 			</div>
 

--- a/src/lib/components/blocks/workspace/DashboardEditDialog.svelte
+++ b/src/lib/components/blocks/workspace/DashboardEditDialog.svelte
@@ -20,10 +20,10 @@
 		dashboard: Dashboard | null;
 		onClose: () => void;
 		onUpdate: (request: UpdateDashboardRequest) => void;
-		onDelete: (id: string) => void;
+		onArchive: (id: string) => void;
 	}
 
-	let { dashboard, onClose, onUpdate, onDelete }: Props = $props();
+	let { dashboard, onClose, onUpdate, onArchive }: Props = $props();
 
 	const versionControl = useVersionControl();
 
@@ -34,7 +34,7 @@
 	let worktreeParentFolder = $state('');
 	let accentColor = $state(WORKSPACE_ACCENT_PALETTE[0]);
 	let authWizardOpen = $state(false);
-	let confirmDelete = $state(false);
+	let confirmArchive = $state(false);
 
 	const open = $derived(dashboard !== null);
 
@@ -47,7 +47,7 @@
 				defaultBaseBranch = dashboard!.default_base_branch ?? '';
 				worktreeParentFolder = dashboard!.worktree_parent_folder ?? '';
 				accentColor = dashboard!.accent_color ?? WORKSPACE_ACCENT_PALETTE[0];
-				confirmDelete = false;
+				confirmArchive = false;
 			});
 		}
 	});
@@ -70,15 +70,15 @@
 		onClose();
 	}
 
-	function handleDelete() {
+	function handleArchive() {
 		if (dashboard === null) {
 			return;
 		}
-		if (!confirmDelete) {
-			confirmDelete = true;
+		if (!confirmArchive) {
+			confirmArchive = true;
 			return;
 		}
-		onDelete(dashboard.id);
+		onArchive(dashboard.id);
 		onClose();
 	}
 
@@ -153,8 +153,8 @@
 				</Dialog.Body>
 
 				<Dialog.Footer class="justify-between">
-					<Button intent="danger" type="button" size="sm" onclick={handleDelete}>
-						{confirmDelete ? m.btn_confirm_delete() : m.btn_delete()}
+					<Button intent="danger" type="button" size="sm" onclick={handleArchive}>
+						{confirmArchive ? m.btn_confirm_archive() : m.btn_archive()}
 					</Button>
 					<div class="flex gap-2">
 						<Button intent="ghost" type="button" onclick={onClose}>

--- a/src/lib/components/blocks/workspace/WorkspaceDeleteDialog.svelte
+++ b/src/lib/components/blocks/workspace/WorkspaceDeleteDialog.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+	import * as m from '$lib/paraglide/messages.js';
+	import * as Dialog from '$lib/components/shadcn/dialog/index.js';
+	import { Button } from '$lib/components/shadcn/button/index.js';
+	import { Input } from '$lib/components/shadcn/input/index.js';
+
+	interface Props {
+		open: boolean;
+		workspaceName: string;
+		onconfirm: () => void;
+		onclose: () => void;
+	}
+
+	let { open, workspaceName, onconfirm, onclose }: Props = $props();
+
+	let typedName = $state('');
+
+	const nameMatches = $derived(typedName === workspaceName);
+
+	function handleOpenChange(isOpen: boolean) {
+		if (!isOpen) {
+			typedName = '';
+			onclose();
+		}
+	}
+
+	function handleConfirm() {
+		if (nameMatches) {
+			onconfirm();
+			typedName = '';
+		}
+	}
+</script>
+
+<Dialog.Root {open} onOpenChange={handleOpenChange}>
+	<Dialog.Content class="max-w-md">
+		<Dialog.Header>
+			<Dialog.Title>{m.workspace_delete_confirm_title()}</Dialog.Title>
+		</Dialog.Header>
+
+		<Dialog.Body class="flex flex-col gap-3">
+			<p class="text-sm text-muted-foreground">
+				{m.workspace_delete_confirm_body()}
+			</p>
+			<Input placeholder={m.workspace_delete_name_placeholder()} bind:value={typedName} />
+			{#if typedName.length > 0 && !nameMatches}
+				<p class="text-xs text-destructive">{m.workspace_delete_name_mismatch()}</p>
+			{/if}
+		</Dialog.Body>
+
+		<Dialog.Footer>
+			<Button intent="ghost" type="button" onclick={() => handleOpenChange(false)}>
+				{m.btn_cancel()}
+			</Button>
+			<Button intent="danger" type="button" disabled={!nameMatches} onclick={handleConfirm}>
+				{m.btn_delete()}
+			</Button>
+		</Dialog.Footer>
+	</Dialog.Content>
+</Dialog.Root>

--- a/src/lib/components/blocks/workspace/workspace_delete_dialog.svelte.test.ts
+++ b/src/lib/components/blocks/workspace/workspace_delete_dialog.svelte.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { page } from 'vitest/browser';
+import WorkspaceDeleteDialog from './WorkspaceDeleteDialog.svelte';
+
+describe('WorkspaceDeleteDialog', () => {
+	it('renders dialog with title and body when open', async () => {
+		await render(WorkspaceDeleteDialog, {
+			props: {
+				open: true,
+				workspaceName: 'My Project',
+				onconfirm: () => {},
+				onclose: () => {},
+			},
+		});
+
+		const title = page.getByText('Delete Workspace');
+		await expect.element(title).toBeVisible();
+
+		const body = page.getByText(/This action is permanent/);
+		await expect.element(body).toBeVisible();
+	});
+
+	it('delete button is disabled when input is empty', async () => {
+		await render(WorkspaceDeleteDialog, {
+			props: {
+				open: true,
+				workspaceName: 'My Project',
+				onconfirm: () => {},
+				onclose: () => {},
+			},
+		});
+
+		const deleteButton = page.getByRole('button', { name: 'Delete' });
+		await expect.element(deleteButton).toBeDisabled();
+	});
+
+	it('delete button is disabled when typed name does not match', async () => {
+		await render(WorkspaceDeleteDialog, {
+			props: {
+				open: true,
+				workspaceName: 'My Project',
+				onconfirm: () => {},
+				onclose: () => {},
+			},
+		});
+
+		const input = page.getByPlaceholder('Type workspace name to confirm');
+		await input.fill('Wrong Name');
+
+		const deleteButton = page.getByRole('button', { name: 'Delete' });
+		await expect.element(deleteButton).toBeDisabled();
+	});
+
+	it('delete button is enabled when typed name exactly matches workspaceName', async () => {
+		await render(WorkspaceDeleteDialog, {
+			props: {
+				open: true,
+				workspaceName: 'My Project',
+				onconfirm: () => {},
+				onclose: () => {},
+			},
+		});
+
+		const input = page.getByPlaceholder('Type workspace name to confirm');
+		await input.fill('My Project');
+
+		const deleteButton = page.getByRole('button', { name: 'Delete' });
+		await expect.element(deleteButton).toBeEnabled();
+	});
+
+	it('calls onconfirm when delete button is clicked with matching name', async () => {
+		const onconfirm = vi.fn();
+		await render(WorkspaceDeleteDialog, {
+			props: {
+				open: true,
+				workspaceName: 'My Project',
+				onconfirm,
+				onclose: () => {},
+			},
+		});
+
+		const input = page.getByPlaceholder('Type workspace name to confirm');
+		await input.fill('My Project');
+
+		const deleteButton = page.getByRole('button', { name: 'Delete' });
+		await expect.element(deleteButton).toBeEnabled();
+
+		await deleteButton.click();
+
+		expect(onconfirm).toHaveBeenCalledOnce();
+	});
+});

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -172,7 +172,7 @@
 		}
 	}
 
-	async function handleDeleteDashboard(id: string) {
+	async function handleArchiveDashboard(id: string) {
 		try {
 			await boardStore.archiveDashboard(id);
 		} catch (err) {
@@ -245,7 +245,7 @@
 	dashboard={editingDashboard}
 	onClose={() => (editingDashboard = null)}
 	onUpdate={handleUpdateDashboard}
-	onDelete={handleDeleteDashboard}
+	onArchive={handleArchiveDashboard}
 />
 
 <CommandPalette />

--- a/src/routes/overview/+page.svelte
+++ b/src/routes/overview/+page.svelte
@@ -12,6 +12,7 @@
 	import OverviewHeader from '$lib/components/blocks/overview/OverviewHeader.svelte';
 	import OverviewSummaryBasin from '$lib/components/blocks/overview/OverviewSummaryBasin.svelte';
 	import OverviewWorkspaceGrid from '$lib/components/blocks/overview/OverviewWorkspaceGrid.svelte';
+	import WorkspaceDeleteDialog from '$lib/components/blocks/workspace/WorkspaceDeleteDialog.svelte';
 	import {
 		calculateOverviewWorkspaceTotals,
 		deriveRecentWorkspaceActivities,
@@ -70,6 +71,41 @@
 			: 0,
 	);
 
+	let deleteTarget = $state<{ id: string; name: string } | null>(null);
+
+	async function handleArchiveWorkspace(workspace: OverviewWorkspaceData) {
+		try {
+			await boardStore.archiveDashboard(workspace.dashboard_id);
+		} catch (err) {
+			console.error('Failed to archive workspace:', err);
+		}
+	}
+
+	async function handleUnarchiveWorkspace(workspace: OverviewWorkspaceData) {
+		try {
+			await boardStore.unarchiveDashboard(workspace.dashboard_id);
+		} catch (err) {
+			console.error('Failed to unarchive workspace:', err);
+		}
+	}
+
+	function handleDeleteWorkspace(workspace: OverviewWorkspaceData) {
+		deleteTarget = { id: workspace.dashboard_id, name: workspace.name };
+	}
+
+	async function handleConfirmDeleteWorkspace() {
+		if (deleteTarget === null) {
+			return;
+		}
+		try {
+			await boardStore.deleteDashboard(deleteTarget.id, deleteTarget.name);
+		} catch (err) {
+			console.error('Failed to delete workspace:', err);
+		} finally {
+			deleteTarget = null;
+		}
+	}
+
 	async function handleOpenWorkspace(dashboardId: string) {
 		try {
 			await openWorkspaceWindow(dashboardId);
@@ -127,6 +163,16 @@
 				onGithubClick={handleGithubClick}
 				onFolderClick={handleFolderClick}
 				onConfigureWorkspace={handleConfigWizard}
+				onArchive={handleArchiveWorkspace}
+				onUnarchive={handleUnarchiveWorkspace}
+				onDelete={handleDeleteWorkspace}
+			/>
+
+			<WorkspaceDeleteDialog
+				open={deleteTarget !== null}
+				workspaceName={deleteTarget?.name ?? ''}
+				onconfirm={handleConfirmDeleteWorkspace}
+				onclose={() => (deleteTarget = null)}
 			/>
 
 			<OverviewSummaryBasin


### PR DESCRIPTION
## Description

- Adds ellipsis menu to workspace cards with context-aware actions
- Active workspace shows "Archive" option; archived shows "Restore" and "Delete"
- Type-to-confirm deletion pattern prevents accidental workspace removal
- Displays "Archived" badge on archived workspace cards
- Renames misleading "Delete" to "Archive" in DashboardEditDialog
- Adds 11 new i18n keys for all menu labels and dialogs
- Includes 5 unit tests for delete confirmation logic

## Resolves

Closes #336

## Testing

- [ ] Hover/focus workspace card to reveal ellipsis button
- [ ] Archive active workspace and verify archived badge appears
- [ ] Unarchive archived workspace from menu
- [ ] Delete archived workspace with type-to-confirm dialog
- [ ] Verify all menu items and dialogs use correct i18n strings
- [ ] Unit tests pass: `pnpm test`