### PR TITLE
#276 fix(overview): toolbar UX polish — dropdowns, buttons, toggle states

### DIFF
--- a/src/lib/components/blocks/overview/OverviewToolbar.svelte
+++ b/src/lib/components/blocks/overview/OverviewToolbar.svelte
@@ -23,7 +23,6 @@
 	import ArchiveIcon from '@lucide/svelte/icons/archive';
 	import SettingsIcon from '@lucide/svelte/icons/settings';
 	import { useOverviewToolbar } from './overview_toolbar.context.svelte.js';
-	import { overviewActionButtonClass } from './overview_style.js';
 	import {
 		OVERVIEW_SORT_MODES,
 		OVERVIEW_SORT_DIRECTIONS,
@@ -52,6 +51,17 @@
 
 	let searchFieldRef = $state<HTMLInputElement | null>(null);
 	let authWizardOpen = $state(false);
+
+	const githubDotColor = $derived.by(() => {
+		const { authStatus, ghAvailability } = versionControl;
+		if (authStatus.status === 'oauth-connected') {
+			return 'bg-status-success';
+		}
+		if (authStatus.status === 'cli-connected' || ghAvailability === 'available') {
+			return 'bg-status-warning';
+		}
+		return null;
+	});
 
 	function openSettings() {
 		settingsCtx.setReturnUrl(page.url.pathname + page.url.search);
@@ -88,29 +98,26 @@
 
 	<!-- Sort -->
 	<DropdownMenu.Root>
-		<DropdownMenu.Trigger>
-			{#snippet child({ props })}
-				<SimpleTooltip text="Sort" side="bottom">
-					{#snippet asChild(tooltipProps)}
-						<Button
-							{...props}
-							{...tooltipProps}
-							intent="ghost"
-							size="icon-sm"
-							aria-label="Sort workspaces"
-							class={[overviewActionButtonClass, 'relative']}
-						>
-							<ArrowUpDownIcon data-icon="inline-start" />
-							{#if toolbar.isNonDefaultSort}
-								<span
-									class="absolute top-0.5 right-0.5 size-1.5 rounded-full bg-primary"
-								></span>
-							{/if}
-						</Button>
-					{/snippet}
-				</SimpleTooltip>
-			{/snippet}
-		</DropdownMenu.Trigger>
+		<SimpleTooltip text="Sort" side="bottom">
+			<DropdownMenu.Trigger>
+				{#snippet child({ props })}
+					<Button
+						{...props}
+						intent="ghost"
+						size="icon"
+						aria-label="Sort workspaces"
+						class="relative"
+					>
+						<ArrowUpDownIcon data-icon="inline-start" />
+						{#if toolbar.isNonDefaultSort}
+							<span
+								class="absolute top-0.5 right-0.5 size-1.5 rounded-full bg-primary"
+							></span>
+						{/if}
+					</Button>
+				{/snippet}
+			</DropdownMenu.Trigger>
+		</SimpleTooltip>
 		<DropdownMenu.Content align="end" class="w-48">
 			<DropdownMenu.Label>Sort by</DropdownMenu.Label>
 			<DropdownMenu.RadioGroup
@@ -148,29 +155,26 @@
 
 	<!-- Filter -->
 	<DropdownMenu.Root>
-		<DropdownMenu.Trigger>
-			{#snippet child({ props })}
-				<SimpleTooltip text="Filter" side="bottom">
-					{#snippet asChild(tooltipProps)}
-						<Button
-							{...props}
-							{...tooltipProps}
-							intent="ghost"
-							size="icon-sm"
-							aria-label="Filter workspaces"
-							class={[overviewActionButtonClass, 'relative']}
-						>
-							<FilterIcon data-icon="inline-start" />
-							{#if toolbar.isNonDefaultFilter}
-								<span
-									class="absolute top-0.5 right-0.5 size-1.5 rounded-full bg-primary"
-								></span>
-							{/if}
-						</Button>
-					{/snippet}
-				</SimpleTooltip>
-			{/snippet}
-		</DropdownMenu.Trigger>
+		<SimpleTooltip text="Filter" side="bottom">
+			<DropdownMenu.Trigger>
+				{#snippet child({ props })}
+					<Button
+						{...props}
+						intent="ghost"
+						size="icon"
+						aria-label="Filter workspaces"
+						class="relative"
+					>
+						<FilterIcon data-icon="inline-start" />
+						{#if toolbar.isNonDefaultFilter}
+							<span
+								class="absolute top-0.5 right-0.5 size-1.5 rounded-full bg-primary"
+							></span>
+						{/if}
+					</Button>
+				{/snippet}
+			</DropdownMenu.Trigger>
+		</SimpleTooltip>
 		<DropdownMenu.Content align="end" class="w-48">
 			<DropdownMenu.RadioGroup
 				value={toolbar.filterMode.current}
@@ -193,50 +197,44 @@
 		</DropdownMenu.Content>
 	</DropdownMenu.Root>
 
-	<Separator orientation="vertical" class="h-4" />
+	<Separator orientation="vertical" class="!h-5" />
 
 	<!-- Archive toggle -->
 	<SimpleTooltip text="Show archived" side="bottom">
-		{#snippet asChild(props)}
-			<Toggle
-				{...props}
-				intent="outline"
-				size="icon-sm"
-				pressed={toolbar.showArchived.current}
-				onPressedChange={(pressed) => (toolbar.showArchived.current = pressed)}
-				aria-label="Toggle archived workspaces"
-				class={overviewActionButtonClass}
-			>
-				<ArchiveIcon data-icon="inline-start" />
-			</Toggle>
-		{/snippet}
+		<Toggle
+			intent="default"
+			size="icon"
+			pressed={toolbar.showArchived.current}
+			onPressedChange={(pressed) => (toolbar.showArchived.current = pressed)}
+			aria-label="Toggle archived workspaces"
+			class="data-[state=on]:border-border"
+		>
+			<ArchiveIcon data-icon="inline-start" />
+		</Toggle>
 	</SimpleTooltip>
 
 	<!-- Footer Settings -->
 	<DropdownMenu.Root>
-		<DropdownMenu.Trigger>
-			{#snippet child({ props })}
-				<SimpleTooltip text="Card footer" side="bottom">
-					{#snippet asChild(tooltipProps)}
-						<Button
-							{...props}
-							{...tooltipProps}
-							intent="ghost"
-							size="icon-sm"
-							aria-label="Configure workspace card footer"
-							class={[overviewActionButtonClass, 'relative']}
-						>
-							<SlidersHorizontalIcon data-icon="inline-start" />
-							{#if toolbar.isNonDefaultFooter}
-								<span
-									class="absolute top-0.5 right-0.5 size-1.5 rounded-full bg-primary"
-								></span>
-							{/if}
-						</Button>
-					{/snippet}
-				</SimpleTooltip>
-			{/snippet}
-		</DropdownMenu.Trigger>
+		<SimpleTooltip text="Card footer" side="bottom">
+			<DropdownMenu.Trigger>
+				{#snippet child({ props })}
+					<Button
+						{...props}
+						intent="ghost"
+						size="icon"
+						aria-label="Configure workspace card footer"
+						class="relative"
+					>
+						<SlidersHorizontalIcon data-icon="inline-start" />
+						{#if toolbar.isNonDefaultFooter}
+							<span
+								class="absolute top-0.5 right-0.5 size-1.5 rounded-full bg-primary"
+							></span>
+						{/if}
+					</Button>
+				{/snippet}
+			</DropdownMenu.Trigger>
+		</SimpleTooltip>
 		<DropdownMenu.Content align="end" class="w-56">
 			<DropdownMenu.Label>Workspace card footer</DropdownMenu.Label>
 			<DropdownMenu.RadioGroup
@@ -256,10 +254,10 @@
 		</DropdownMenu.Content>
 	</DropdownMenu.Root>
 
-	<Separator orientation="vertical" class="h-4" />
+	<Separator orientation="vertical" class="!h-5" />
 
 	<!-- Theme Toggle -->
-	<ThemeToggle compact class={overviewActionButtonClass} />
+	<ThemeToggle compact />
 
 	<!-- Settings -->
 	<SimpleTooltip text={m.nav_settings()} side="bottom">
@@ -267,10 +265,9 @@
 			<Button
 				{...props}
 				intent="ghost"
-				size="icon-sm"
+				size="icon"
 				aria-label={m.nav_settings()}
 				onclick={openSettings}
-				class={overviewActionButtonClass}
 			>
 				<SettingsIcon data-icon="inline-start" />
 			</Button>
@@ -284,15 +281,19 @@
 				<Button
 					{...props}
 					intent="ghost"
-					size="icon-sm"
+					size="icon"
 					aria-label="GitHub connection settings"
-					class={overviewActionButtonClass}
+					class="relative"
 				>
 					<GithubIcon data-icon="inline-start" />
+					{#if githubDotColor}
+						<span class="absolute top-1 right-1 size-1.5 rounded-full {githubDotColor}"
+						></span>
+					{/if}
 				</Button>
 			{/snippet}
 		</Popover.Trigger>
-		<Popover.Content class="w-80" align="end">
+		<Popover.Content class="w-80 p-3" align="end">
 			<GitHubStatusCard
 				borderless
 				authStatus={versionControl.authStatus}

--- a/src/lib/components/blocks/overview/overview_style.ts
+++ b/src/lib/components/blocks/overview/overview_style.ts
@@ -1,6 +1,3 @@
-export const overviewActionButtonClass =
-	'border-[color-mix(in_oklch,var(--foreground)_11%,transparent)] bg-[radial-gradient(42px_34px_at_18%_86%,color-mix(in_oklch,var(--moss-400)_12%,transparent),transparent_72%),color-mix(in_oklch,var(--surface)_86%,transparent)] shadow-[inset_0_1px_0_color-mix(in_oklch,var(--foreground)_6%,transparent)] hover:border-[color-mix(in_oklch,var(--moss-400)_44%,var(--border))] hover:text-foreground hover:shadow-[0_0_22px_color-mix(in_oklch,var(--moss-400)_15%,transparent),inset_0_1px_0_color-mix(in_oklch,var(--foreground)_7%,transparent)] data-[state=on]:border-[color-mix(in_oklch,var(--moss-400)_44%,var(--border))] data-[state=on]:shadow-[0_0_22px_color-mix(in_oklch,var(--moss-400)_15%,transparent),inset_0_1px_0_color-mix(in_oklch,var(--foreground)_7%,transparent)]';
-
 export const overviewPanelClass =
 	'min-h-[118px] rounded-lg border border-[color-mix(in_oklch,var(--moss-400)_18%,var(--border))] bg-[radial-gradient(280px_150px_at_0%_100%,color-mix(in_oklch,var(--moss-400)_11%,transparent),transparent_70%),color-mix(in_oklch,var(--surface)_72%,transparent)] p-3.5 shadow-[inset_0_1px_0_color-mix(in_oklch,var(--foreground)_5%,transparent)]';
 

--- a/src/lib/components/blocks/overview/overview_toolbar_types.ts
+++ b/src/lib/components/blocks/overview/overview_toolbar_types.ts
@@ -3,16 +3,16 @@ import type { OverviewWorkspaceData } from '$lib/types/generated';
 // --- Const objects & derived types ---
 
 export const OVERVIEW_SORT_MODES = {
-	name: 'name',
 	activity: 'activity',
+	name: 'name',
 	'issue-count': 'issue-count',
 	cost: 'cost',
 } as const;
 export type OverviewSortMode = (typeof OVERVIEW_SORT_MODES)[keyof typeof OVERVIEW_SORT_MODES];
 
 export const OVERVIEW_SORT_DIRECTIONS = {
-	ascending: 'ascending',
 	descending: 'descending',
+	ascending: 'ascending',
 } as const;
 export type OverviewSortDirection =
 	(typeof OVERVIEW_SORT_DIRECTIONS)[keyof typeof OVERVIEW_SORT_DIRECTIONS];

--- a/src/lib/components/derived/theme-toggle/ThemeToggle.svelte
+++ b/src/lib/components/derived/theme-toggle/ThemeToggle.svelte
@@ -5,18 +5,25 @@
 	import Sun from '@lucide/svelte/icons/sun';
 	import Moon from '@lucide/svelte/icons/moon';
 	import Monitor from '@lucide/svelte/icons/monitor';
+	import { Button } from '$lib/components/shadcn/button/index.js';
 	import SidebarCollapsedItem from '$lib/components/derived/sidebar-collapsed-item/SidebarCollapsedItem.svelte';
 	import { Tabs, Tab } from '$lib/components/shadcn/tabs/index.js';
 	import { SimpleTooltip } from '$lib/components/shadcn/tooltip/index.js';
-	import { cn } from '$lib/utils.js';
+	import type { ButtonSize } from '$lib/components/shadcn/button/button-variants.js';
 
 	interface Props {
 		collapsed?: boolean;
 		compact?: boolean;
+		size?: ButtonSize;
 		class?: string;
 	}
 
-	let { collapsed = false, compact = false, class: className }: Props = $props();
+	let {
+		collapsed = false,
+		compact = false,
+		size = 'icon' as const,
+		class: className,
+	}: Props = $props();
 
 	const settingsCtx = useSettings();
 	const themeMode = $derived(settingsCtx.getThemeMode() as ThemeMode);
@@ -42,20 +49,18 @@
 </script>
 
 {#if compact}
-	<SimpleTooltip text="{MODE_LABELS[currentMode.labelKey]()} mode" side="top">
+	<SimpleTooltip text="{MODE_LABELS[currentMode.labelKey]()} mode" side="bottom">
 		{#snippet asChild(props)}
-			<button
+			<Button
 				{...props}
-				type="button"
-				class={cn(
-					'rounded-lg p-1.5 text-muted-foreground transition-colors hover:bg-surface-hover hover:text-foreground',
-					className,
-				)}
+				intent="ghost"
+				{size}
 				onclick={cycleMode}
 				aria-label="{MODE_LABELS[currentMode.labelKey]()} mode"
+				class={className}
 			>
-				<currentMode.Icon size={14} />
-			</button>
+				<currentMode.Icon data-icon="inline-start" />
+			</Button>
 		{/snippet}
 	</SimpleTooltip>
 {:else if collapsed}


### PR DESCRIPTION
## Summary
- Fix dropdown menus not opening (bits-ui trigger prop conflict resolved by restructuring SimpleTooltip/DropdownMenu nesting)
- Upgrade toolbar buttons from `icon-sm` (26px) to `icon` (32px), switch all to ghost intent for consistency
- Add GitHub status indicator dot (green/orange/red based on auth state)
- Fix archive toggle states: OFF = ghost, ON = surface-2 with border
- Add vertical separators between button groups with `!h-5` important override
- Reorder sort/filter dropdown items so defaults (Activity, Descending) appear first
- Refactor ThemeToggle compact mode to use Button component instead of raw `<button>`
- Remove dead `overviewActionButtonClass` export
- Add `p-3` padding to GitHub popover content

Closes #276

## Test plan
- [ ] Verify Sort and Filter dropdown menus open on click
- [ ] Confirm all toolbar buttons are 32px ghost buttons
- [ ] Check GitHub button shows colored status dot based on auth state
- [ ] Archive toggle: OFF = ghost appearance, ON = bordered surface-2 appearance
- [ ] Vertical separators visible between button groups
- [ ] Sort dropdown shows Activity first, Direction shows Descending first
- [ ] ThemeToggle cycles through modes correctly
