### PR TITLE
#399 feat(window): writable context and SPA navigation

### DIFF
--- a/.mpx/CONTEXT.md
+++ b/.mpx/CONTEXT.md
@@ -6,7 +6,7 @@ Desktop AI agent orchestration platform for developers running parallel Claude C
 
 ## Domain Language
 
-**Workspace** — Top-level container: one GitHub repo + one project folder + one window.
+**Workspace** — Top-level container: one GitHub repo + one project folder.
 **Overview** — Multi-workspace launcher view showing all workspaces as cards with health indicators.
 **Issue** — Atomic work unit. One GitHub issue, one worktree, one branch, one color. Priority defaults to medium.
 **Session** — One AI agent CLI execution tied to an issue. Has transcript, cost, turns, state. Multiple per issue.
@@ -72,7 +72,7 @@ _Avoid_: "selected" for single-click inspect, "active" for batch selection.
 
 ## Relationships
 
-- A **Workspace** has many **Issues** (1:N). One window per workspace.
+- A **Workspace** has many **Issues** (1:N). Navigation between workspaces uses SPA routing within a single window.
 - An **Issue** has many **Sessions** (1:N), one **Worktree** (1:1), one **Character Pack** (1:1).
 - A **Session** runs on one **Provider** (N:1).
 - A **Provider** has many **Discovery Sources** (1:N), each yielding **Skills**, **Rules**, **MCP Servers**.
@@ -113,7 +113,7 @@ _Avoid_: "selected" for single-click inspect, "active" for batch selection.
 ## Key Constraints
 
 - SPA mode (ssr=false, static adapter with fallback). No server-side rendering.
-- Single Tauri process, multiple windows via `single_instance` plugin.
+- Single Tauri process, single-window SPA navigation. Multi-window optional via `single_instance` plugin.
 - Frontend owns all user-facing text. Rust returns error keys. Paraglide for i18n.
 - No versioned DB migrations (pre-production). `schema::create_tables()` + `seed_defaults()`.
 - GitHub issues are source of truth for work items. No internal task database.

--- a/.mpx/DECISIONS.md
+++ b/.mpx/DECISIONS.md
@@ -6,12 +6,12 @@ Settled architectural and design decisions. Each entry records what was chosen, 
 
 ## Platform & Infrastructure
 
-### Single process, multi-window via Tauri single_instance
+### Single process, single-window SPA navigation (multi-window optional)
 
-Decided: 2026-04-28
-What: One Tauri process. Each workspace gets its own WebviewWindow.
-Why: Shared SQLite, IPC between windows, simpler auth flow.
-Rejected: Electron multi-process (too heavy), separate processes per workspace (IPC complexity).
+Decided: 2026-05-26 (revised from 2026-04-28 multi-window default)
+What: One Tauri process, one window. Workspace switching via SvelteKit `goto()` within a single window. Window context is writable — `navigateToWorkspace(id)` / `navigateToOverview()` update reactive state and route. Multi-window remains available via Tauri `single_instance` plugin but is no longer the primary navigation model.
+Why: SPA navigation is simpler, faster, and avoids window management complexity. Users navigate between workspaces like browser tabs, not desktop windows. Theme transitions are smooth within one window.
+Rejected: Multi-window as default (window management overhead, no shared reactive state between windows, theme transitions impossible across windows).
 
 ### SQLite with r2d2 pool in WAL mode (4 readers + 1 writer)
 

--- a/src/app.css
+++ b/src/app.css
@@ -565,6 +565,11 @@
 		font-synthesis: none;
 		-webkit-font-smoothing: antialiased;
 		text-rendering: optimizelegibility;
+
+		@media (prefers-reduced-motion: no-preference) {
+			transition-property: background-color, color;
+			transition-duration: var(--duration-4);
+		}
 	}
 }
 

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -11,6 +11,7 @@ declare global {
 			usageGroupBy?: string | null;
 			usageCustomFrom?: string | null;
 			usageCustomTo?: string | null;
+			dashboardId?: string;
 		}
 		// interface Platform {}
 	}

--- a/src/lib/modules/toasts/mock_toast_bridge.ts
+++ b/src/lib/modules/toasts/mock_toast_bridge.ts
@@ -33,7 +33,6 @@ const COMMAND_BODIES: Record<string, string> = {
 	spawn_session: 'Spawning sessions requires the desktop app',
 	sync_all_github_state: 'GitHub sync requires the desktop app',
 	execute_action: 'Running actions requires the desktop app',
-	open_workspace_window: 'Opening workspace windows requires the desktop app',
 	update_peacock_color: 'Peacock color sync requires the desktop app',
 	pick_folder: 'Folder picker requires the desktop app',
 	open_path: 'Opening local folders requires the desktop app',

--- a/src/lib/modules/window/index.ts
+++ b/src/lib/modules/window/index.ts
@@ -1,7 +1,6 @@
 export { setWindowContext, useWindow } from './window.context.svelte.js';
 export { type WindowType, WINDOW_TYPES, parseWindowLabel, isWindowType } from './types.js';
 export {
-	openWorkspaceWindow,
 	closeWorkspaceWindow,
 	getWindowBindings,
 	saveWindowGeometry,

--- a/src/lib/modules/window/types.ts
+++ b/src/lib/modules/window/types.ts
@@ -27,3 +27,19 @@ export function parseWindowLabel(label: string): {
 export function isWindowType(value: unknown): value is WindowType {
 	return typeof value === 'string' && value in WINDOW_TYPES;
 }
+
+export function resolvePopstateNavigation(
+	pathname: string,
+	overviewPath: string,
+	pageDashboardId: string | undefined,
+	currentDashboardId: string | null,
+): { windowType: WindowType; dashboardId: string | null } {
+	if (pathname === overviewPath || pathname.startsWith(overviewPath + '/')) {
+		return { windowType: 'overview', dashboardId: null };
+	}
+	const dashboardId = pageDashboardId ?? currentDashboardId;
+	if (dashboardId !== null) {
+		return { windowType: 'workspace', dashboardId };
+	}
+	return { windowType: 'overview', dashboardId: null };
+}

--- a/src/lib/modules/window/window.context.svelte.ts
+++ b/src/lib/modules/window/window.context.svelte.ts
@@ -1,8 +1,16 @@
 import { createContext } from 'svelte';
+import { goto } from '$app/navigation';
+import { resolve } from '$app/paths';
 import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow';
 import { isTauri } from '$lib/tauri.js';
 import { StateRaw } from '$lib/reactivity/state.svelte.js';
-import { type WindowType, OVERVIEW_LABEL, parseWindowLabel } from './types.js';
+import { setUserSetting } from '$lib/modules/settings/settings_commands.js';
+import {
+	type WindowType,
+	OVERVIEW_LABEL,
+	parseWindowLabel,
+	resolvePopstateNavigation,
+} from './types.js';
 
 type WindowContext = ReturnType<typeof createWindowContext>;
 
@@ -51,6 +59,30 @@ function createWindowContext() {
 		},
 		get isWorkspace() {
 			return windowType.current === 'workspace';
+		},
+
+		navigateToWorkspace(dashboardId: string) {
+			boundDashboardId.current = dashboardId;
+			windowType.current = 'workspace';
+			void goto(resolve('/'), { state: { dashboardId } });
+			void setUserSetting('last_workspace_id', dashboardId);
+		},
+
+		navigateToOverview() {
+			boundDashboardId.current = null;
+			windowType.current = 'overview';
+			void goto(resolve('/overview'));
+		},
+
+		syncNavigationState(pathname: string, pageState: App.PageState) {
+			const resolved = resolvePopstateNavigation(
+				pathname,
+				resolve('/overview'),
+				pageState.dashboardId,
+				boundDashboardId.current,
+			);
+			boundDashboardId.current = resolved.dashboardId;
+			windowType.current = resolved.windowType;
 		},
 	};
 }

--- a/src/lib/modules/window/window.test.ts
+++ b/src/lib/modules/window/window.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseWindowLabel, isWindowType } from './types.js';
+import { parseWindowLabel, isWindowType, resolvePopstateNavigation } from './types.js';
 
 describe('parseWindowLabel', () => {
 	it('parses overview label', () => {
@@ -49,5 +49,54 @@ describe('isWindowType', () => {
 		expect(isWindowType(42)).toBe(false);
 		expect(isWindowType(null)).toBe(false);
 		expect(isWindowType(undefined)).toBe(false);
+	});
+});
+
+describe('resolvePopstateNavigation', () => {
+	const overviewPath = '/overview';
+
+	it('returns overview when pathname matches overview path', () => {
+		const result = resolvePopstateNavigation('/overview', overviewPath, undefined, 'dash-1');
+		expect(result).toEqual({ windowType: 'overview', dashboardId: null });
+	});
+
+	it('returns overview when pathname is a sub-path of overview', () => {
+		const result = resolvePopstateNavigation(
+			'/overview/details',
+			overviewPath,
+			undefined,
+			null,
+		);
+		expect(result).toEqual({ windowType: 'overview', dashboardId: null });
+	});
+
+	it('returns workspace with page state dashboardId when available', () => {
+		const result = resolvePopstateNavigation('/', overviewPath, 'dash-abc', null);
+		expect(result).toEqual({ windowType: 'workspace', dashboardId: 'dash-abc' });
+	});
+
+	it('falls back to current dashboardId when page state has none', () => {
+		const result = resolvePopstateNavigation('/', overviewPath, undefined, 'dash-current');
+		expect(result).toEqual({ windowType: 'workspace', dashboardId: 'dash-current' });
+	});
+
+	it('prefers page state dashboardId over current dashboardId', () => {
+		const result = resolvePopstateNavigation('/', overviewPath, 'dash-from-state', 'dash-old');
+		expect(result).toEqual({ windowType: 'workspace', dashboardId: 'dash-from-state' });
+	});
+
+	it('falls back to overview when no dashboardId available at workspace path', () => {
+		const result = resolvePopstateNavigation('/', overviewPath, undefined, null);
+		expect(result).toEqual({ windowType: 'overview', dashboardId: null });
+	});
+
+	it('handles base-path-prefixed overview sub-path', () => {
+		const result = resolvePopstateNavigation(
+			'/app/overview/details',
+			'/app/overview',
+			undefined,
+			'dash-1',
+		);
+		expect(result).toEqual({ windowType: 'overview', dashboardId: null });
 	});
 });

--- a/src/lib/modules/window/window_commands.ts
+++ b/src/lib/modules/window/window_commands.ts
@@ -1,10 +1,6 @@
 import { invoke } from '$lib/tauri.js';
 import type { OverviewWorkspaceData, WindowWorkspaceBinding } from '$lib/types/generated';
 
-export function openWorkspaceWindow(dashboardId: string): Promise<void> {
-	return invoke('open_workspace_window', { dashboardId });
-}
-
 export function closeWorkspaceWindow(windowLabel: string): Promise<void> {
 	return invoke('close_workspace_window', { windowLabel });
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -4,9 +4,11 @@
 	import '../app.css';
 	import { onMount, onDestroy } from 'svelte';
 	import { SvelteSet } from 'svelte/reactivity';
-	import { preloadCode, goto } from '$app/navigation';
+	import { afterNavigate, preloadCode, goto } from '$app/navigation';
 	import { page } from '$app/state';
 	import { resolve } from '$app/paths';
+	import { isTauri } from '$lib/tauri.js';
+	import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow';
 	import DashboardSidebar from '$lib/components/blocks/layout/DashboardSidebar.svelte';
 	import DashboardCreateDialog from '$lib/components/blocks/workspace/DashboardCreateDialog.svelte';
 	import DashboardEditDialog from '$lib/components/blocks/workspace/DashboardEditDialog.svelte';
@@ -24,7 +26,7 @@
 	import { setVersionControlContext } from '$lib/modules/version-control';
 	import { setActionsContext } from '$lib/modules/actions';
 	import { setProcessesContext } from '$lib/modules/processes';
-	import { setWindowContext, openWorkspaceWindow } from '$lib/modules/window';
+	import { setWindowContext } from '$lib/modules/window';
 	import { setKeyboardShortcutsContext } from '$lib/modules/keyboard-shortcuts';
 	import { setCommandPaletteContext } from '$lib/modules/command-palette';
 	import { setRawRequirementsContext } from '$lib/modules/raw-requirements';
@@ -90,9 +92,30 @@
 
 	let editingDashboard = $state<Dashboard | null>(null);
 
+	$effect(() => {
+		const dashboardId = windowCtx.boundDashboardId;
+		void boardStore.loadDashboards(dashboardId);
+		void settingsCtx.loadSettings(dashboardId);
+	});
+
+	$effect(() => {
+		if (!isTauri()) {
+			return;
+		}
+		const title = windowCtx.isOverview
+			? 'Overview — Grovekeeper'
+			: `${boardStore.activeDashboard?.name ?? 'Workspace'} — Grovekeeper`;
+		void getCurrentWebviewWindow().setTitle(title);
+	});
+
+	afterNavigate((navigation) => {
+		if (navigation.to !== null) {
+			windowCtx.syncNavigationState(navigation.to.url.pathname, page.state);
+		}
+	});
+
 	onMount(() => {
 		registerMockToastBridge((title, body) => toastsCtx.show({ tone: 'warning', title, body }));
-		boardStore.loadDashboards(windowCtx.isWorkspace ? windowCtx.boundDashboardId : null);
 		boardStore.loadPalettes();
 		void preloadCode(resolve('/'));
 		void preloadCode(resolve('/overview'));
@@ -100,7 +123,6 @@
 		void preloadCode(resolve('/settings/general'));
 		void preloadCode(resolve('/usage'));
 		void preloadCode(resolve('/quick-ideas'));
-		void settingsCtx.loadSettings();
 		void characterPacksCtx.loadPacks();
 		void shortcutsCtx.loadCustomBindings();
 		void versionControlCtx.checkAvailability();
@@ -143,7 +165,7 @@
 			const created = await boardStore.createDashboard(request);
 			await boardStore.refreshDashboards();
 			if (windowCtx.isOverview) {
-				await openWorkspaceWindow(created.id);
+				windowCtx.navigateToWorkspace(created.id);
 			} else {
 				boardStore.selectDashboard(created.id);
 			}

--- a/src/routes/overview/+page.svelte
+++ b/src/routes/overview/+page.svelte
@@ -9,7 +9,7 @@
 	import { setUsageContext } from '$lib/modules/usage/usage.context.svelte.js';
 	import { USAGE_SCOPES } from '$lib/modules/usage/usage_types.js';
 	import { useVersionControl } from '$lib/modules/version-control';
-	import { getOverviewData, openWorkspaceWindow } from '$lib/modules/window';
+	import { getOverviewData, useWindow } from '$lib/modules/window';
 	import OverviewHeader from '$lib/components/blocks/overview/OverviewHeader.svelte';
 	import OverviewToolbar from '$lib/components/blocks/overview/OverviewToolbar.svelte';
 	import OverviewSummaryBasin from '$lib/components/blocks/overview/OverviewSummaryBasin.svelte';
@@ -33,6 +33,7 @@
 	import type { Dashboard, OverviewWorkspaceData } from '$lib/types/generated';
 
 	const boardStore = useBoard();
+	const windowCtx = useWindow();
 	const versionControl = useVersionControl();
 	const usageCtx = setUsageContext();
 	const toolbar = setOverviewToolbarContext();
@@ -153,12 +154,8 @@
 		}
 	}
 
-	async function handleOpenWorkspace(dashboardId: string) {
-		try {
-			await openWorkspaceWindow(dashboardId);
-		} catch (err) {
-			console.error('Failed to open workspace window:', err);
-		}
+	function handleOpenWorkspace(dashboardId: string) {
+		windowCtx.navigateToWorkspace(dashboardId);
 	}
 
 	function handleGithubClick(workspace: OverviewWorkspaceData) {

--- a/tests/e2e/settings-navigation.spec.ts
+++ b/tests/e2e/settings-navigation.spec.ts
@@ -17,8 +17,7 @@ test.describe('Settings entry points', () => {
 		await page.goto('/overview');
 		await page.waitForLoadState('networkidle');
 
-		const content = page.locator('main, [class*="flex-col"][class*="p-8"]').first();
-		const gearButton = content.getByRole('button', { name: 'Settings', exact: true });
+		const gearButton = page.getByRole('button', { name: 'Settings', exact: true });
 		await expect(gearButton).toBeVisible();
 		await gearButton.click();
 
@@ -29,8 +28,7 @@ test.describe('Settings entry points', () => {
 		await page.goto('/overview');
 		await page.waitForLoadState('networkidle');
 
-		const content = page.locator('main, [class*="flex-col"][class*="p-8"]').first();
-		const themeButton = content.getByRole('button', { name: /mode/i });
+		const themeButton = page.getByRole('button', { name: /mode/i });
 		await expect(themeButton).toBeVisible();
 
 		// Verify it cycles on click (compact mode behavior)


### PR DESCRIPTION
## Description

Core architectural change: switch from immutable window-label-based workspace identity to writable context with SPA navigation.

- Window context now exposes `navigateToWorkspace(dashboardId)` and `navigateToOverview()` methods that update reactive state and call SvelteKit `goto()`
- `syncNavigationState()` handles all navigation types (including browser back/forward) via `afterNavigate`
- Layout reactively reloads dashboard data and settings when workspace changes via `$effect`
- Window title updates reactively via `getCurrentWebviewWindow().setTitle()`
- `last_workspace_id` persisted to user_settings on workspace navigation
- Overview page navigates within the same window instead of spawning new windows
- CSS theme transition on body with prefers-reduced-motion guard
- Removed dead `openWorkspaceWindow` function and barrel export
- Updated CONTEXT.md and DECISIONS.md to reflect single-window-primary architecture

## Resolves

Closes #399

## Testing

- 7 new unit tests for `resolvePopstateNavigation`
- All 1824 unit tests pass
- All 50 e2e tests pass