### PR TITLE
#402 feat(startup): Add startup behavior setting

### DIFF
--- a/src-tauri/src/commands/window_commands.rs
+++ b/src-tauri/src/commands/window_commands.rs
@@ -6,65 +6,6 @@ use crate::models::overview::OverviewWorkspaceData;
 use crate::models::window_binding::WindowWorkspaceBinding;
 use crate::window_manager::{self, APP_NAME, DEFAULT_WINDOW_HEIGHT, DEFAULT_WINDOW_WIDTH};
 
-pub fn restore_workspace_windows(app: &AppHandle, state: &DatabaseState) {
-    let connection = match state.read() {
-        Ok(c) => c,
-        Err(error) => {
-            log::warn!("Failed to read DB for window restore: {error}");
-            return;
-        }
-    };
-
-    let query = format!(
-        "SELECT {BINDING_SELECT_COLUMNS}, d.name \
-         FROM window_workspace_bindings wb \
-         JOIN dashboards d ON wb.dashboard_id = d.id"
-    );
-
-    let mut statement = match connection.prepare(&query) {
-        Ok(s) => s,
-        Err(error) => {
-            log::warn!("Failed to prepare window restore query: {error}");
-            return;
-        }
-    };
-
-    let bindings: Vec<(WindowWorkspaceBinding, String)> = statement
-        .query_map([], |row| {
-            let binding = binding_from_row(row)?;
-            let name: String = row.get(6)?;
-            Ok((binding, name))
-        })
-        .ok()
-        .map(|rows| rows.filter_map(|r| r.ok()).collect())
-        .unwrap_or_default();
-
-    drop(statement);
-    drop(connection);
-
-    for (binding, name) in bindings {
-        let title = format!("{name} — {APP_NAME}");
-        let width = binding
-            .window_width
-            .map_or(DEFAULT_WINDOW_WIDTH, |v| v as f64);
-        let height = binding
-            .window_height
-            .map_or(DEFAULT_WINDOW_HEIGHT, |v| v as f64);
-        if let Err(error) = window_manager::open_or_focus_window_with_position(
-            app,
-            &binding.window_label,
-            "index.html",
-            &title,
-            width,
-            height,
-            binding.window_x,
-            binding.window_y,
-        ) {
-            log::warn!("Failed to restore window {}: {error}", binding.window_label);
-        }
-    }
-}
-
 const BINDING_SELECT_COLUMNS: &str =
     "window_label, dashboard_id, window_x, window_y, window_width, window_height";
 

--- a/src-tauri/src/database/defaults.rs
+++ b/src-tauri/src/database/defaults.rs
@@ -57,7 +57,7 @@ pub fn seed_defaults(connection: &Connection) -> Result<(), rusqlite::Error> {
         })?;
 
     connection.execute_batch(
-        "INSERT OR IGNORE INTO user_settings (key, value) VALUES ('startup_behavior', 'overview');
+        "INSERT OR IGNORE INTO user_settings (key, value) VALUES ('startup_behavior', 'last-workspace');
          INSERT OR IGNORE INTO user_settings (key, value) VALUES ('chart_color_theme', 'monochrome');
          INSERT OR IGNORE INTO user_settings (key, value) VALUES ('theme_mode', 'system');
          INSERT OR IGNORE INTO user_settings (key, value) VALUES ('accent_color', 'moss');
@@ -148,6 +148,7 @@ mod tests {
         "issue_card_header_saturation",
         "issue_card_radial_intensity",
         "editor_command",
+        "overview_footer_content",
     ];
 
     #[test]
@@ -170,6 +171,22 @@ mod tests {
                 "Missing seed default for key: {expected_key}"
             );
         }
+    }
+
+    #[test]
+    fn seed_defaults_startup_behavior_is_last_workspace() {
+        let connection = setup_test_database();
+        seed_defaults(&connection).unwrap();
+
+        let value: String = connection
+            .query_row(
+                "SELECT value FROM user_settings WHERE key = 'startup_behavior'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+
+        assert_eq!(value, crate::models::setting::STARTUP_BEHAVIOR_LAST_WORKSPACE);
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -21,18 +21,17 @@ use commands::{
 };
 use std::sync::Arc;
 
-use database::connection::DatabaseState;
 use git::fetch_coordinator::FetchCoordinator;
 use git::github_client::GitHubClient;
 use metrics::pricing::PricingEngine;
-use models::setting::{STARTUP_BEHAVIOR_KEY, STARTUP_BEHAVIOR_LAST_WORKSPACE, STARTUP_BEHAVIOR_OVERVIEW};
+use models::setting::{LAST_WORKSPACE_ID_KEY, STARTUP_BEHAVIOR_KEY, STARTUP_BEHAVIOR_LAST_WORKSPACE, STARTUP_BEHAVIOR_OVERVIEW};
 use notification::playback_queue;
 use notification::service::NotificationService;
 use process::manager::ProcessManager;
 use session::discovery_polling::DiscoveryPoller;
 use session::manager::SessionManager;
 use tauri::Manager;
-use window_manager::{APP_NAME, DEFAULT_WINDOW_HEIGHT, DEFAULT_WINDOW_WIDTH};
+use window_manager::{APP_NAME, DEFAULT_WINDOW_HEIGHT, DEFAULT_WINDOW_WIDTH, OVERVIEW_URL};
 
 pub type SharedPricingEngine = Arc<tokio::sync::Mutex<PricingEngine>>;
 
@@ -73,7 +72,7 @@ pub fn run() {
                             let _ = window_manager::open_or_focus_window(
                                 app_handle,
                                 window_manager::overview_label(),
-                                "/overview",
+                                OVERVIEW_URL,
                                 APP_NAME,
                                 DEFAULT_WINDOW_WIDTH,
                                 DEFAULT_WINDOW_HEIGHT,
@@ -96,16 +95,36 @@ pub fn run() {
                 .resource_dir()
                 .expect("Failed to resolve resource directory");
 
-            // Determine startup behavior before managing state
-            let startup_behavior = {
+            // Read startup settings before managing state (database_state moves into app)
+            let (startup_behavior, validated_last_workspace_id) = {
                 let connection = database_state.read().unwrap_or_else(|e| panic!("{e}"));
-                connection
+                let behavior = connection
                     .query_row(
                         "SELECT value FROM user_settings WHERE key = ?1",
                         [STARTUP_BEHAVIOR_KEY],
                         |row| row.get::<_, String>(0),
                     )
-                    .unwrap_or_else(|_| STARTUP_BEHAVIOR_OVERVIEW.to_string())
+                    .unwrap_or_else(|_| STARTUP_BEHAVIOR_OVERVIEW.to_string());
+
+                let last_id: Option<String> = connection
+                    .query_row(
+                        "SELECT value FROM user_settings WHERE key = ?1",
+                        [LAST_WORKSPACE_ID_KEY],
+                        |row| row.get(0),
+                    )
+                    .ok();
+
+                let dashboard_exists = last_id.as_ref().is_some_and(|id| {
+                    connection
+                        .query_row(
+                            "SELECT 1 FROM dashboards WHERE id = ?1 AND status = 'active'",
+                            [id.as_str()],
+                            |_| Ok(()),
+                        )
+                        .is_ok()
+                });
+
+                (behavior, if dashboard_exists { last_id } else { None })
             };
 
             let mut pricing_engine = PricingEngine::new(&app_data_directory);
@@ -131,11 +150,23 @@ pub fn run() {
             let poller = app.state::<DiscoveryPoller>();
             poller.start(app.handle().clone(), 3000);
 
-            // Startup behavior: restore last workspace windows or just show overview
-            if startup_behavior == STARTUP_BEHAVIOR_LAST_WORKSPACE {
-                let db = app.state::<DatabaseState>();
-                window_commands::restore_workspace_windows(app.handle(), db.inner());
-            }
+            let initial_url = if startup_behavior == STARTUP_BEHAVIOR_LAST_WORKSPACE {
+                match validated_last_workspace_id {
+                    Some(id) => format!("/?dashboardId={id}"),
+                    None => OVERVIEW_URL.to_string(),
+                }
+            } else {
+                OVERVIEW_URL.to_string()
+            };
+
+            window_manager::open_or_focus_window(
+                app.handle(),
+                window_manager::overview_label(),
+                &initial_url,
+                APP_NAME,
+                DEFAULT_WINDOW_WIDTH,
+                DEFAULT_WINDOW_HEIGHT,
+            )?;
 
             Ok(())
         })

--- a/src-tauri/src/models/setting.rs
+++ b/src-tauri/src/models/setting.rs
@@ -19,3 +19,4 @@ pub struct WorkspaceSetting {
 pub const STARTUP_BEHAVIOR_KEY: &str = "startup_behavior";
 pub const STARTUP_BEHAVIOR_OVERVIEW: &str = "overview";
 pub const STARTUP_BEHAVIOR_LAST_WORKSPACE: &str = "last-workspace";
+pub const LAST_WORKSPACE_ID_KEY: &str = "last_workspace_id";

--- a/src-tauri/src/window_manager.rs
+++ b/src-tauri/src/window_manager.rs
@@ -6,6 +6,7 @@ const WORKSPACE_PREFIX: &str = "workspace-";
 pub const DEFAULT_WINDOW_WIDTH: f64 = 1600.0;
 pub const DEFAULT_WINDOW_HEIGHT: f64 = 900.0;
 pub const APP_NAME: &str = "Grovekeeper";
+pub const OVERVIEW_URL: &str = "/overview";
 
 pub fn overview_label() -> &'static str {
     OVERVIEW_LABEL

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -11,16 +11,7 @@
 	},
 	"app": {
 		"withGlobalTauri": true,
-		"windows": [
-			{
-				"label": "overview",
-				"title": "Grovekeeper",
-				"url": "/overview",
-				"width": 1600,
-				"height": 900,
-				"center": true
-			}
-		],
+		"windows": [],
 		"security": {
 			"csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://avatars.githubusercontent.com; font-src 'self'; connect-src ipc: http://ipc.localhost https://github.com https://api.github.com ws://localhost:9223"
 		}

--- a/src/lib/modules/settings/types.ts
+++ b/src/lib/modules/settings/types.ts
@@ -42,7 +42,7 @@ export const SETTING_DEFAULTS: Record<SettingKey, string> = {
 	accentColor: 'moss',
 	username: 'User',
 	userInitials: 'U',
-	startupBehavior: 'overview',
+	startupBehavior: 'last-workspace',
 	chartColorTheme: 'monochrome',
 	language: 'en',
 	editorCommand: 'code',
@@ -84,3 +84,5 @@ export const FOUC_MIRROR_KEYS: readonly SettingKey[] = ['themeMode', 'accentColo
 export const FOUC_STORAGE_PREFIX = 'grovekeeper_settings_';
 
 export type SettingScope = 'user' | 'workspace';
+
+export const LAST_WORKSPACE_ID_KEY = 'last_workspace_id';

--- a/src/lib/modules/window/types.ts
+++ b/src/lib/modules/window/types.ts
@@ -28,6 +28,21 @@ export function isWindowType(value: unknown): value is WindowType {
 	return typeof value === 'string' && value in WINDOW_TYPES;
 }
 
+export function resolveInitialDashboardId(
+	label: string,
+	searchParams: URLSearchParams,
+): { windowType: WindowType; dashboardId: string | null } {
+	const parsed = parseWindowLabel(label);
+	if (parsed.dashboardId !== null) {
+		return parsed;
+	}
+	const dashboardId = searchParams.get('dashboardId');
+	if (dashboardId !== null && dashboardId !== '') {
+		return { windowType: 'workspace', dashboardId };
+	}
+	return parsed;
+}
+
 export function resolvePopstateNavigation(
 	pathname: string,
 	overviewPath: string,

--- a/src/lib/modules/window/window.context.svelte.ts
+++ b/src/lib/modules/window/window.context.svelte.ts
@@ -5,10 +5,11 @@ import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow';
 import { isTauri } from '$lib/tauri.js';
 import { StateRaw } from '$lib/reactivity/state.svelte.js';
 import { setUserSetting } from '$lib/modules/settings/settings_commands.js';
+import { LAST_WORKSPACE_ID_KEY } from '$lib/modules/settings/types.js';
 import {
 	type WindowType,
 	OVERVIEW_LABEL,
-	parseWindowLabel,
+	resolveInitialDashboardId,
 	resolvePopstateNavigation,
 } from './types.js';
 
@@ -38,7 +39,7 @@ function resolveWindowLabel(): string {
 
 function createWindowContext() {
 	const label = resolveWindowLabel();
-	const parsed = parseWindowLabel(label);
+	const parsed = resolveInitialDashboardId(label, new URLSearchParams(window.location.search));
 
 	const windowLabel = new StateRaw(label);
 	const windowType = new StateRaw<WindowType>(parsed.windowType);
@@ -65,7 +66,7 @@ function createWindowContext() {
 			boundDashboardId.current = dashboardId;
 			windowType.current = 'workspace';
 			void goto(resolve('/'), { state: { dashboardId } });
-			void setUserSetting('last_workspace_id', dashboardId);
+			void setUserSetting(LAST_WORKSPACE_ID_KEY, dashboardId);
 		},
 
 		navigateToOverview() {

--- a/src/lib/modules/window/window.test.ts
+++ b/src/lib/modules/window/window.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { parseWindowLabel, isWindowType, resolvePopstateNavigation } from './types.js';
+import {
+	parseWindowLabel,
+	isWindowType,
+	resolvePopstateNavigation,
+	resolveInitialDashboardId,
+} from './types.js';
 
 describe('parseWindowLabel', () => {
 	it('parses overview label', () => {
@@ -98,5 +103,33 @@ describe('resolvePopstateNavigation', () => {
 			'dash-1',
 		);
 		expect(result).toEqual({ windowType: 'overview', dashboardId: null });
+	});
+});
+
+describe('resolveInitialDashboardId', () => {
+	it('returns parsed label result when label already has a dashboardId', () => {
+		const result = resolveInitialDashboardId('workspace-abc', new URLSearchParams());
+		expect(result).toEqual({ windowType: 'workspace', dashboardId: 'abc' });
+	});
+
+	it('returns workspace with dashboardId from searchParams when label has no dashboardId', () => {
+		const result = resolveInitialDashboardId(
+			'overview',
+			new URLSearchParams('dashboardId=xyz'),
+		);
+		expect(result).toEqual({ windowType: 'workspace', dashboardId: 'xyz' });
+	});
+
+	it('returns overview fallback when neither label nor searchParams have dashboardId', () => {
+		const result = resolveInitialDashboardId('overview', new URLSearchParams());
+		expect(result).toEqual({ windowType: 'overview', dashboardId: null });
+	});
+
+	it('prefers label dashboardId over searchParams dashboardId', () => {
+		const result = resolveInitialDashboardId(
+			'workspace-from-label',
+			new URLSearchParams('dashboardId=from-params'),
+		);
+		expect(result).toEqual({ windowType: 'workspace', dashboardId: 'from-label' });
 	});
 });

--- a/src/lib/tauri_mock_data.ts
+++ b/src/lib/tauri_mock_data.ts
@@ -1756,7 +1756,7 @@ export const MOCK_USER_SETTINGS: Record<string, string> = {
 	accent_color: 'moss',
 	username: 'User',
 	user_initials: 'U',
-	startup_behavior: 'overview',
+	startup_behavior: 'last-workspace',
 	chart_color_theme: 'monochrome',
 	language: 'en',
 	notification_volume: '0.7',


### PR DESCRIPTION
## Description
- Changed default startup behavior from multi-window restore to single-window last-workspace mode
- Rust reads `startup_behavior` and `last_workspace_id` from user_settings in single DB lock on startup
- Window created with correct initial URL (`/?dashboardId=X` or `/overview`) based on setting and workspace validation
- Removed `restore_workspace_windows` multi-window spawning logic
- Frontend `resolveInitialDashboardId` reads dashboardId from URL search params for SPA navigation
- Settings UI already supported both options; added constants for consistency

## Resolves
Closes #402

## Testing
- [ ] Startup with "Overview" mode displays dashboard overview
- [ ] Startup with "Last Workspace" mode restores selected workspace
- [ ] Invalid workspace ID gracefully falls back to overview
- [ ] Settings persist across app restarts