### PR TITLE
feat(workspace): design brief + ghost selector + cleanup

### DIFF
--- a/.mpx/CONTEXT.md
+++ b/.mpx/CONTEXT.md
@@ -109,10 +109,12 @@ _Avoid_: "selected" for single-click inspect, "active" for batch selection.
 | PRD Management         | planned                     | #219      | —                                                     |
 | Keyboard Shortcuts     | implemented                 | #87       | —                                                     |
 | Internationalization   | implemented (en + cs)       | #87       | —                                                     |
+| Single-Window Nav      | planned                     | #398      | —                                                     |
 
 ## Key Constraints
 
 - SPA mode (ssr=false, static adapter with fallback). No server-side rendering.
+  <<<<<<< Updated upstream
 - Single Tauri process, single-window SPA navigation. Multi-window optional via `single_instance` plugin.
 - Frontend owns all user-facing text. Rust returns error keys. Paraglide for i18n.
 - No versioned DB migrations (pre-production). `schema::create_tables()` + `seed_defaults()`.

--- a/.mpx/DECISIONS.md
+++ b/.mpx/DECISIONS.md
@@ -6,12 +6,12 @@ Settled architectural and design decisions. Each entry records what was chosen, 
 
 ## Platform & Infrastructure
 
-### Single process, single-window SPA navigation (multi-window optional)
+### Single process, single-window SPA navigation (optional multi-window)
 
-Decided: 2026-05-26 (revised from 2026-04-28 multi-window default)
-What: One Tauri process, one window. Workspace switching via SvelteKit `goto()` within a single window. Window context is writable — `navigateToWorkspace(id)` / `navigateToOverview()` update reactive state and route. Multi-window remains available via Tauri `single_instance` plugin but is no longer the primary navigation model.
-Why: SPA navigation is simpler, faster, and avoids window management complexity. Users navigate between workspaces like browser tabs, not desktop windows. Theme transitions are smooth within one window.
-Rejected: Multi-window as default (window management overhead, no shared reactive state between windows, theme transitions impossible across windows).
+Decided: 2026-04-28. **Updated 2026-05-26: switched from mandatory multi-window to single-window SPA navigation.**
+What: One Tauri process. Single window with SvelteKit `goto()` navigation between Overview and Workspaces. Multi-window kept as optional "Open in new window" escape hatch via `single_instance` plugin.
+Why: Multi-window caused theme desync between windows, cold startup per window, and unnecessary complexity. Single-window with SPA navigation is simpler and more cohesive. Multi-window preserved for side-by-side workspace viewing.
+Rejected: Electron multi-process (too heavy), separate processes per workspace (IPC complexity), removing multi-window entirely (loses side-by-side use case).
 
 ### SQLite with r2d2 pool in WAL mode (4 readers + 1 writer)
 

--- a/designs/workspace-switcher/DESIGN_BRIEF_WORKSPACE_SWITCHER.md
+++ b/designs/workspace-switcher/DESIGN_BRIEF_WORKSPACE_SWITCHER.md
@@ -1,0 +1,248 @@
+# Workspace Switcher Dropdown — Design Brief
+
+> **Status**: Refined (Variant A)
+> **Refined mockup**: `designs/workspace-switcher/refined.html`
+> **Summary**: `designs/workspace-switcher/SUMMARY.md`
+> **Refinements**: design token alignment, gk-popover pattern consistency, selection state consistency
+
+The workspace switcher replaces the static workspace name display in the sidebar with an interactive dropdown that lets users navigate between workspaces or return to the Overview page — all within a single window. This is the primary workspace navigation affordance in Grovekeeper's new single-window model (PRD #398).
+
+**Source**: PRD #398, Issue #400
+**Gold standard reference**: `designs/issue-card-v2/ISSUE_CARD_FINAL_DECISIONS.md`
+
+---
+
+## 1. Purpose
+
+In the previous multi-window architecture, each workspace lived in its own window. Users switched workspaces by clicking the overview or taskbar. With the single-window model, the user needs an in-app mechanism to switch workspaces without leaving the current window. The workspace switcher sits in the sidebar — always visible, always accessible — and provides one-click navigation to any workspace or the overview.
+
+**Key value**: Switch workspaces in one click without opening new windows, keeping the experience cohesive and theme-consistent.
+
+---
+
+## 2. Surrounding Context
+
+The mockup **MUST** show the full sidebar with all chrome elements at correct proportions.
+
+### Full Sidebar Structure (top to bottom)
+
+**Sidebar** (`DashboardSidebar.svelte`, 240px expanded / 56px collapsed):
+
+1. **Brand row** (top): BrandMark logo + "Grovekeeper" text + collapse button. Source: `DashboardSidebar.svelte` lines 78-128.
+2. **Workspace section** (this component): "WORKSPACE" eyebrow label + workspace selector. Currently static, being replaced by this dropdown. Source: lines 131-151.
+3. **Navigation section**: "NAVIGATE" eyebrow label + 3 nav items (Dashboard, Sessions, Usage). Source: lines 153-171.
+4. **Spacer**: flex-1 empty area.
+5. **User section** (bottom, border-top): UserAvatar + ThemeToggle + Settings gear. Source: lines 176-231.
+
+**Sidebar properties**:
+- Background: `bg-sidebar`
+- Right border: `border-r border-border`
+- Width transition: `transition-[width] duration-4`
+- Expanded width: `--sidebar-width: 240px`
+- Collapsed width: `--sidebar-width-collapsed: 56px`
+
+**What parent provides**: The sidebar container, the "WORKSPACE" eyebrow label, the `px-2` horizontal padding on the workspace section wrapper.
+**What this component fills**: The space after the eyebrow label, within `px-2` padding. Full available width minus padding.
+**Must NOT include**: The "WORKSPACE" eyebrow label (parent renders it), the sidebar frame/border, nav items below.
+
+**Mockup rendering instructions**:
+- Show the full sidebar at ~240px width with all sections at actual proportions
+- Sidebar in FINAL state (show accurately as implemented)
+- Show both expanded (240px) and collapsed (56px) states
+- Show the dropdown OPEN state with 4-6 workspace items
+- Main content area to the right can be a simple dark placeholder
+
+---
+
+## 3. Requirements
+
+### 3.1 Trigger (Expanded Sidebar)
+
+- Trigger area replaces the current static `bg-surface-2 px-3 py-1.5 rounded-lg` container
+- Shows: folder icon (text-primary, size 3.5) + workspace name (truncated, 12.5px font-medium) + chevron-down icon
+- Clicking anywhere on the trigger opens the dropdown
+- Edit (pencil) and Settings (gear) buttons remain alongside the trigger, NOT inside the dropdown — they are workspace-specific quick actions that should always be visible
+- Trigger should feel interactive: hover state `bg-surface-hover`, cursor pointer
+- Current styling reference: `WorkspaceSelector.svelte` line 26 — `flex items-center gap-1 rounded-lg bg-surface-2 px-3 py-1.5`
+
+### 3.2 Trigger (Collapsed Sidebar)
+
+- Shows folder icon only (matching `SidebarCollapsedItem` pattern — 34×34px rounded-lg, centered icon)
+- Clicking opens the same dropdown, positioned to the right of the sidebar (side="right")
+- Tooltip on hover: shows workspace name (consistent with other collapsed items)
+
+### 3.3 Dropdown Content
+
+- Uses `DropdownMenu.Content` from shadcn/bits-ui (portaled, `bg-popover`, `rounded-md`, `shadow-md`, `ring-1 ring-foreground/10`)
+- Positioned: `side="bottom"` in expanded mode, `side="right"` in collapsed mode
+- Width: match trigger width in expanded mode (`w-(--bits-dropdown-menu-anchor-width)`), min 200px in collapsed mode
+- Max height: constrain with `max-h-80` (320px) + `overflow-y-auto` for scroll if many workspaces
+
+### 3.4 Dropdown Items
+
+**Group 1: Overview**
+- Single item: Home icon + "Overview" label
+- Clicking navigates to `/overview` via `navigateToOverview()`
+- When the user is currently on Overview (not in a workspace), this item should be visually distinguished (e.g., `bg-accent/15` background or check mark)
+
+**Separator**
+- Standard `DropdownMenu.Separator` between Overview and workspace list
+
+**Group 2: Workspaces**
+- Group heading: "WORKSPACES" (optional — may be unnecessary given the separator and visual context)
+- Each item: folder icon + workspace name
+- Current workspace: visually distinguished — check mark icon on the right side (consistent with radio-style selection pattern) OR `bg-accent/15` highlight background
+- All other workspaces: default item styling
+- Clicking navigates to that workspace via `navigateToWorkspace(id)`
+- Item text truncates with ellipsis if workspace name is long
+
+**Future extension zone (issue #401, NOT designed now but layout must accommodate):**
+- Workspaces open in another window: will show an `ExternalLink` or `AppWindow` icon indicator on the right
+- Bottom separator + "Open in new window" item with external-link icon
+- The dropdown layout should leave room for these additions without redesign
+
+### 3.5 Keyboard Navigation
+
+- Standard bits-ui DropdownMenu keyboard support (arrow keys, Enter, Escape)
+- No custom keyboard shortcuts needed beyond what DropdownMenu provides
+
+### 3.6 Data
+
+- Workspace list fetched via existing `get_dashboards` Tauri command (already available in board context)
+- Each workspace has: `dashboard_id`, `name`
+- Current workspace identified by `windowContext.boundDashboardId`
+- Overview state identified by `windowContext.isOverview`
+
+---
+
+## 4. States
+
+| State | Visual Treatment | Trigger |
+|---|---|---|
+| **Default (closed)** | Trigger shows current workspace name + chevron-down. `bg-surface-2` background | Initial render |
+| **Hover (closed)** | Trigger background shifts to `bg-surface-hover` | Mouse enter trigger |
+| **Open** | Trigger shows pressed state (`bg-surface-hover`), dropdown visible below/beside | Click trigger |
+| **Item hover** | Item gets `bg-accent/25` background (standard DropdownMenu focus style) | Mouse/keyboard navigation |
+| **Current workspace item** | Check mark icon on right OR persistent `bg-accent/15` tint | Item matches `boundDashboardId` |
+| **Overview active** | Overview item has same "current" treatment when user is on Overview page | `windowContext.isOverview === true` |
+| **Loading** | Not needed — workspace list is already in memory from board context | — |
+| **Empty (no workspaces)** | Should never happen — user is always in a workspace. If somehow occurs, show only Overview item | No dashboards in board store |
+| **Collapsed trigger** | Folder icon only, tooltip with workspace name on hover | Sidebar collapsed |
+| **Collapsed + open** | Dropdown appears to the right of sidebar | Click collapsed trigger |
+
+---
+
+## 5. Component Reuse Map
+
+### Existing Components (MUST use)
+
+| Component | Variant/Props | Usage in This Design |
+|---|---|---|
+| `DropdownMenu.Root` | — | Dropdown wrapper |
+| `DropdownMenu.Trigger` | `{#snippet child({ props })}` pattern | Custom trigger (not default button) |
+| `DropdownMenu.Content` | `side="bottom"` or `side="right"`, `align="start"` | Dropdown panel |
+| `DropdownMenu.Group` | — | Group for Overview, group for workspaces |
+| `DropdownMenu.Item` | default variant | Each workspace item and Overview item |
+| `DropdownMenu.Separator` | — | Between Overview and workspace list |
+| `SimpleTooltip` | `side="right"` | Collapsed trigger tooltip |
+| `SidebarCollapsedItem` | — | Reference for collapsed state sizing/styling (but trigger is custom since it opens a dropdown, not a link) |
+| `Button` | `intent="ghost"` `size="icon-sm"` | Edit (pencil) and Settings (gear) buttons alongside trigger |
+
+### Icons (Lucide path imports)
+
+| Icon | Usage |
+|---|---|
+| `folder` | Workspace items + trigger icon |
+| `home` | Overview item |
+| `chevron-down` | Trigger dropdown indicator |
+| `pencil` | Edit workspace button (existing) |
+| `settings` | Workspace settings button (existing) |
+| `check` | Current workspace indicator (if using check mark approach) |
+
+### Components to Design (new)
+
+| Component | Description | Why New |
+|---|---|---|
+| `WorkspaceSwitcher.svelte` | Replaces `WorkspaceSelector.svelte`. Dropdown trigger + menu with workspace list | Existing component is static; need interactive dropdown with data fetching and navigation |
+
+No new primitives needed — this is composed entirely from existing shadcn DropdownMenu parts.
+
+---
+
+## 6. Layout Constraints
+
+- **Trigger expanded**: Full width of workspace section (240px - 2×8px padding = 224px). Height matches current: `py-1.5` = ~34px.
+- **Trigger collapsed**: 34×34px centered in 56px sidebar (matches SidebarCollapsedItem).
+- **Dropdown width**: In expanded mode, matches trigger width (~224px). In collapsed mode, minimum 200px.
+- **Dropdown max height**: 320px (`max-h-80`). With ~38px per item, this fits ~8 workspaces before scrolling — matches the 2-8 workspace expectation.
+- **Item height**: Standard DropdownMenu.Item height (~38px with `px-2 py-1.5`).
+- **Icon sizing**: 14-16px for item icons, 14px (size-3.5) for trigger folder icon (matches current).
+- **Text**: 12.5px for trigger name (matches current), 13px (`text-sm`) for dropdown items.
+- **Spacing**: `gap-2` between icon and text in items (standard DropdownMenu.Item). `gap-1` between trigger elements (matches current selector).
+- **Edit/Settings buttons**: Remain outside the dropdown, to the right of the trigger chevron. Same size and style as current (`p-1 rounded text-muted-foreground hover:bg-surface-hover hover:text-foreground`).
+
+---
+
+## 7. Design Tokens
+
+Use the Grovekeeper Forest Moss palette from `designs/tokens.css`:
+
+- **Font**: Geist (sans) for all text
+- **Trigger background**: `bg-surface-2` (default), `bg-surface-hover` (hover/open)
+- **Dropdown background**: `bg-popover` (standard DropdownMenu)
+- **Dropdown border**: `ring-1 ring-foreground/10` (standard DropdownMenu)
+- **Item hover**: `bg-accent/25` (standard DropdownMenu focus pattern — safe with all 12 accent colors)
+- **Current item highlight**: `bg-accent/15` (subtle tint) or check mark icon in `text-primary`
+- **Folder icon**: `text-primary` (moss green accent)
+- **Overview home icon**: `text-muted-foreground` (neutral, not accented)
+- **Chevron icon**: `text-muted-foreground`
+- **Text colors**: `text-foreground` for names, `text-muted-foreground` for secondary
+- **Eyebrow label**: `text-[10px] font-semibold uppercase tracking-wider text-foreground-subtle` (matches existing sidebar section labels)
+- **Transition timing**: `duration-2` (120ms) for hover states, `duration-1` (90ms) for dropdown appear
+
+---
+
+## 8. Design Constraints (Non-Negotiable)
+
+- **Must use DropdownMenu from shadcn/bits-ui** — not a custom popover or select. DropdownMenu handles keyboard navigation, focus management, escape-to-close, and portal rendering.
+- **Edit and Settings buttons must remain visible** alongside the trigger without opening the dropdown. They are high-frequency quick actions.
+- **Trigger must fit in 240px sidebar** with room for edit+settings buttons. Name truncates.
+- **Collapsed state must use 56px width** and match the visual pattern of `SidebarCollapsedItem` (34×34px, `rounded-lg`, centered icon, tooltip on hover).
+- **Standard DropdownMenu item styling** — `focus:bg-accent/25` (never `focus:bg-accent` full, never `text-accent-foreground`). Follow the post-`shadcn add` color contrast rules.
+- **Current workspace indicator must be unambiguous** — the user must immediately see which workspace they're in when the dropdown opens.
+- **Works in browser mock mode** — no Tauri-only calls in the component itself (navigation methods are mocked upstream).
+- **Accessible**: trigger has `aria-label`, items are keyboard-navigable via bits-ui default behavior.
+- **No "WORKSPACES" group heading** in the dropdown — the separator between Overview and workspaces is sufficient visual grouping. Adding a heading wastes vertical space in a compact dropdown.
+
+---
+
+## 9. Design Freedom
+
+- **Check mark vs highlight for current item**: Designer can choose between a check mark icon on the right (radio-select pattern) or a persistent `bg-accent/15` background tint, or both. The key constraint is unambiguous identification.
+- **Trigger container styling**: The trigger can evolve from the current `bg-surface-2 rounded-lg` to something slightly different if it better communicates "this is a dropdown." For example, a subtle bottom border or different border radius. But it should feel cohesive with the sidebar.
+- **Chevron animation**: Optional subtle rotation animation on the chevron when dropdown opens (e.g., rotate 180deg with `duration-2`).
+- **Transition/animation on dropdown open**: bits-ui default animations are fine. Designer can adjust timing.
+- **Overview item icon choice**: `home` icon is suggested but designer can choose another icon that better represents "overview" (e.g., `layout-grid`, `gauge`).
+- **Item density**: Standard DropdownMenu.Item spacing is default. Designer can adjust padding slightly if the dropdown feels too loose or too tight for the sidebar context.
+- **Collapsed trigger appearance**: Can use `SidebarCollapsedItem` directly or a custom button that matches its visual style — as long as it opens a dropdown instead of navigating.
+
+---
+
+## 10. Visual References
+
+- **Internal — current workspace selector**: `src/lib/components/blocks/workspace/WorkspaceSelector.svelte` — the static version being replaced. Preserve its visual weight and position.
+- **Internal — sidebar nav items**: `src/lib/components/derived/sidebar-nav-item/SidebarNavItem.svelte` — the dropdown items should feel like siblings of these nav items in visual density and icon sizing.
+- **Internal — context menu usage**: `src/lib/components/blocks/workspace-card/` — existing DropdownMenu/ContextMenu usage for reference on item styling patterns.
+- **Internal — sidebar collapsed items**: `src/lib/components/derived/sidebar-collapsed-item/SidebarCollapsedItem.svelte` — reference for 56px collapsed state pattern.
+- **External**: VS Code workspace switcher (bottom-left status bar dropdown), JetBrains project switcher (top toolbar dropdown) — both use simple dropdown lists with current-project indicator.
+
+---
+
+## 11. Not Included (Scope Exclusions)
+
+- **Search/filter field in dropdown** — future iteration if workspace count exceeds 6-8 (explicitly excluded in PRD #398 scope)
+- **"Open in new window" option** — belongs to issue #401 (multi-window coexistence), added after this component exists
+- **"Open in another window" indicators** — belongs to issue #401, visual indicator for workspaces already open elsewhere
+- **Workspace creation from dropdown** — not in scope, users create workspaces from Overview page
+- **Workspace reordering** — not in scope
+- **Accent color indicators per workspace** — could be a future enhancement (show workspace accent color as a dot or left border) but not in initial scope

--- a/designs/workspace-switcher/SUMMARY.md
+++ b/designs/workspace-switcher/SUMMARY.md
@@ -1,0 +1,33 @@
+# Workspace Switcher — Design Summary
+
+**Base**: Variant A | **Refined**: 2026-05-26
+
+## Refinements Applied
+
+Variant A was chosen and refined with: design token alignment, selection state consistency with `gk-popover` pattern. Key changes from the base variant: dropdown now uses `--surface` bg + `--border` + `--radius-lg` + `--shadow-lg` matching `gk-popover` exactly; item hover uses `--surface-2` and active/current uses `--primary-soft` matching `gk-popover-item` states; separator uses full-bleed `margin: 6px -8px` matching `gk-popover-divider`; all hardcoded border-radius and transition values replaced with `--radius-*` and `--duration-*` tokens.
+
+## Component Map
+
+### Codebase — Use As-Is
+
+| Component | Path | Usage | Key Props/Variants |
+|---|---|---|---|
+| DropdownMenu | `src/lib/components/shadcn/dropdown-menu/` | Dropdown wrapper, trigger, content, items, separator, group | `side="bottom"` / `side="right"`, `align="start"` |
+| Button | `src/lib/components/shadcn/button/` | Edit + Settings quick-action buttons | `intent="ghost"` `size="icon-sm"` |
+| SimpleTooltip | `src/lib/components/shadcn/tooltip/` | Collapsed trigger tooltip | `side="right"` |
+| SidebarCollapsedItem | `src/lib/components/derived/sidebar-collapsed-item/` | Reference for collapsed trigger sizing (34×34, `rounded-lg`) | `icon`, `label` |
+
+### Build Custom
+
+| Proposed Name | Description | Why existing components don't cover it |
+|---|---|---|
+| WorkspaceSwitcher.svelte | Replaces WorkspaceSelector. DropdownMenu trigger + content with workspace list + Overview + navigation methods | Existing WorkspaceSelector is static (no dropdown). This is a composed block component, not a reusable primitive. |
+
+## Implementation Notes
+
+- Dropdown uses DropdownMenu from shadcn/bits-ui (not a custom Popover) for keyboard nav, focus management, escape-to-close
+- Trigger uses `{#snippet child({ props })}` pattern on `DropdownMenu.Trigger` to render custom button (not default)
+- `side` prop on Content switches between `"bottom"` (expanded) and `"right"` (collapsed) based on `collapsed` prop
+- Current workspace detection via `windowContext.boundDashboardId` — compare against each workspace's `dashboard_id`
+- Active/current state uses `--primary-soft` background (same token as active nav item `SidebarNavItem.is-active`) — visual consistency between "where I am" indicators across sidebar
+- Nav item active hover uses `color-mix(in oklch, var(--primary-soft) 60%, var(--surface-2))` — same mix used in SidebarNavItem.svelte line 84

--- a/designs/workspace-switcher/refined.html
+++ b/designs/workspace-switcher/refined.html
@@ -1,0 +1,679 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Workspace Switcher — Refined</title>
+  <link rel="stylesheet" href="../tokens.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    body {
+      font-family: 'Geist', -apple-system, BlinkMacSystemFont, sans-serif;
+      background: var(--background);
+      color: var(--foreground);
+    }
+
+    /* ── Sidebar ── */
+    .sidebar {
+      width: 240px;
+      height: 100%;
+      background: var(--sidebar);
+      border-right: 1px solid var(--border);
+      display: flex;
+      flex-direction: column;
+      flex-shrink: 0;
+    }
+
+    .sidebar-collapsed { width: 56px; }
+    .sidebar-collapsed .brand-row { justify-content: center; }
+    .sidebar-collapsed .brand-text { display: none; }
+    .sidebar-collapsed .collapse-btn { display: none; }
+    .sidebar-collapsed .section-label { display: none; }
+    .sidebar-collapsed .nav-items { align-items: center; }
+    .sidebar-collapsed .user-section-inner { flex-direction: column; align-items: center; gap: 4px; }
+    .sidebar-collapsed .user-name { display: none; }
+    .sidebar-collapsed .user-actions { display: none; }
+
+    /* ── Brand Row ── */
+    .brand-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 14px 8px;
+    }
+
+    .brand-left { display: flex; align-items: center; }
+
+    .brand-icon-wrap {
+      width: 40px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+    }
+
+    .brand-mark {
+      width: 22px;
+      height: 22px;
+      border-radius: var(--radius-sm);
+      background: linear-gradient(135deg, var(--moss-500), var(--moss-700));
+    }
+
+    .brand-text {
+      font-size: 14px;
+      font-weight: 600;
+      letter-spacing: -0.01em;
+    }
+
+    .collapse-btn {
+      width: 26px;
+      height: 26px;
+      border-radius: var(--radius-md);
+      border: none;
+      background: transparent;
+      color: var(--foreground-muted);
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .collapse-btn:hover { background: var(--surface-hover); }
+
+    /* ── Section Labels — matches .gk-eyebrow ── */
+    .section-label {
+      font-size: 10px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: var(--foreground-subtle);
+      padding: 0 6px;
+      margin-bottom: 6px;
+    }
+
+    /* ── Workspace Section ── */
+    .ws-section {
+      padding: 0 8px;
+      margin-bottom: 12px;
+      position: relative;
+      z-index: 10;
+    }
+
+    .ws-trigger-row {
+      display: flex;
+      align-items: center;
+      gap: 2px;
+      position: relative;
+    }
+
+    /* ── Trigger (expanded) — matches existing WorkspaceSelector styling ── */
+    .ws-trigger {
+      flex: 1;
+      min-width: 0;
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      padding: 6px 10px;
+      border-radius: var(--radius-md);
+      background: var(--surface-2);
+      border: none;
+      color: var(--foreground);
+      cursor: pointer;
+      transition: background var(--duration-2);
+      font-family: inherit;
+      font-size: 12.5px;
+    }
+    .ws-trigger:hover { background: var(--surface-hover); }
+    .ws-trigger.is-open { background: var(--surface-hover); }
+
+    .ws-trigger-icon { color: var(--primary); flex-shrink: 0; }
+
+    .ws-trigger-name {
+      flex: 1;
+      text-align: left;
+      font-weight: 500;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .ws-trigger-chevron {
+      color: var(--foreground-muted);
+      flex-shrink: 0;
+      transition: transform var(--duration-2);
+    }
+    .ws-trigger.is-open .ws-trigger-chevron { transform: rotate(180deg); }
+
+    /* ── Action buttons (edit, settings) ── */
+    .ws-action-btn {
+      width: 26px;
+      height: 26px;
+      border-radius: var(--radius-xs);
+      border: none;
+      background: transparent;
+      color: var(--foreground-muted);
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      transition: background var(--duration-2), color var(--duration-2);
+    }
+    .ws-action-btn:hover {
+      background: var(--surface-hover);
+      color: var(--foreground);
+    }
+
+    /* ── Trigger (collapsed) — matches SidebarCollapsedItem 34×34 pattern ── */
+    .ws-collapsed-trigger {
+      width: 34px;
+      height: 34px;
+      border-radius: var(--radius-md);
+      border: none;
+      background: transparent;
+      color: var(--primary);
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      transition: background var(--duration-2);
+      margin: 0 auto;
+    }
+    .ws-collapsed-trigger:hover { background: var(--surface-hover); }
+
+    /* ── Dropdown — uses .gk-popover tokens exactly ── */
+    .ws-dropdown {
+      position: absolute;
+      min-width: 220px;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-lg);
+      box-shadow: var(--shadow-lg);
+      padding: 8px;
+      z-index: 50;
+    }
+
+    .ws-dropdown-expanded {
+      top: calc(100% + 4px);
+      left: 0;
+      right: 0;
+    }
+
+    .ws-dropdown-collapsed {
+      top: 0;
+      left: calc(100% + 4px);
+      width: 220px;
+    }
+
+    /* ── Dropdown items — uses .gk-popover-item tokens ── */
+    .ws-dropdown-item {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 6px 8px;
+      border-radius: var(--radius-sm);
+      font-size: 13px;
+      color: var(--foreground);
+      cursor: pointer;
+      transition: background 100ms;
+      position: relative;
+    }
+
+    /* Hover: matches .gk-popover-item:hover */
+    .ws-dropdown-item:hover {
+      background: var(--surface-2);
+    }
+
+    /* Current/active: matches .gk-popover-item[data-state='active'] */
+    .ws-dropdown-item.is-current {
+      background: var(--primary-soft);
+    }
+    .ws-dropdown-item.is-current:hover {
+      background: color-mix(in oklch, var(--primary-soft) 60%, var(--surface-2));
+    }
+
+    .ws-dropdown-item-icon {
+      flex-shrink: 0;
+      color: var(--foreground-muted);
+    }
+
+    .ws-dropdown-item.is-current .ws-dropdown-item-icon {
+      color: var(--primary);
+    }
+
+    .ws-dropdown-item-name {
+      flex: 1;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .ws-dropdown-item-check {
+      flex-shrink: 0;
+      color: var(--primary);
+      opacity: 0;
+    }
+    .ws-dropdown-item.is-current .ws-dropdown-item-check { opacity: 1; }
+
+    /* Separator: matches .gk-popover-divider (full-bleed) */
+    .ws-dropdown-separator {
+      height: 1px;
+      background: var(--border);
+      margin: 6px -8px;
+    }
+
+    /* ── Nav Items — matches SidebarNavItem.svelte ── */
+    .nav-items {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      padding: 0 8px;
+    }
+
+    .nav-item {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      height: 32px;
+      padding: 7px 10px 7px 13px;
+      border-radius: var(--radius-md);
+      font-size: 12.5px;
+      color: var(--sidebar-fg);
+      text-decoration: none;
+      cursor: pointer;
+      transition: background var(--duration-2), color var(--duration-2);
+    }
+    .nav-item:hover { background: var(--surface-hover); }
+    .nav-item.is-active {
+      background: var(--primary-soft);
+      color: var(--foreground);
+      font-weight: 500;
+    }
+    .nav-item.is-active:hover {
+      background: color-mix(in oklch, var(--primary-soft) 60%, var(--surface-2));
+    }
+    .nav-item-icon { flex-shrink: 0; }
+    .nav-item.is-active .nav-item-icon { color: var(--primary); }
+
+    .nav-collapsed-item {
+      width: 34px;
+      height: 34px;
+      border-radius: var(--radius-md);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      transition: background var(--duration-2);
+      color: var(--sidebar-fg);
+    }
+    .nav-collapsed-item:hover { background: var(--surface-hover); }
+    .nav-collapsed-item.is-active {
+      background: var(--primary-soft);
+      color: var(--primary);
+    }
+
+    /* ── User Section ── */
+    .user-section {
+      border-top: 1px solid var(--border);
+      padding: 8px;
+    }
+
+    .user-section-inner {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .user-left { display: flex; align-items: center; gap: 8px; }
+
+    .user-avatar {
+      width: 28px;
+      height: 28px;
+      border-radius: 50%;
+      background: var(--surface-2);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 11px;
+      font-weight: 600;
+      color: var(--foreground-muted);
+    }
+
+    .user-name { font-size: 12.5px; color: var(--foreground); }
+
+    .user-actions { display: flex; align-items: center; gap: 2px; }
+
+    .theme-toggle, .settings-btn {
+      width: 26px;
+      height: 26px;
+      border-radius: var(--radius-md);
+      border: none;
+      background: transparent;
+      color: var(--foreground-muted);
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .theme-toggle:hover, .settings-btn:hover { background: var(--surface-hover); }
+
+    /* ── Scene Layout (mockup chrome) ── */
+    .scenes {
+      display: flex;
+      gap: 48px;
+      padding: 48px;
+      min-height: 100vh;
+      background: var(--background);
+      align-items: flex-start;
+    }
+
+    .scene { display: flex; flex-direction: column; gap: 12px; }
+
+    .scene-label {
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--foreground-subtle);
+      text-align: center;
+    }
+
+    .scene-frame {
+      position: relative;
+      height: 640px;
+      display: flex;
+      border-radius: var(--radius-lg);
+      overflow: visible;
+      box-shadow: 0 0 0 1px var(--border);
+    }
+
+    .scene-main {
+      flex: 1;
+      min-width: 400px;
+      background: var(--background);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: var(--foreground-subtle);
+      font-size: 12px;
+      border-radius: 0 var(--radius-lg) var(--radius-lg) 0;
+    }
+  </style>
+</head>
+<body>
+<div class="gk-root theme-dark">
+
+  <div class="gk-eyebrow" style="text-align:center; padding:16px 0 0; color:var(--foreground-subtle);">
+    REFINED — VARIANT A + DESIGN TOKEN ALIGNMENT
+  </div>
+
+  <div class="scenes">
+
+    <!-- ════════════════════════════════════════════ -->
+    <!-- Scene 1: Expanded sidebar, dropdown OPEN    -->
+    <!-- ════════════════════════════════════════════ -->
+    <div class="scene">
+      <div class="scene-label">Expanded — Dropdown Open</div>
+      <div class="scene-frame">
+        <div class="sidebar">
+
+          <div class="brand-row">
+            <div class="brand-left">
+              <div class="brand-icon-wrap"><div class="brand-mark"></div></div>
+              <span class="brand-text">Grovekeeper</span>
+            </div>
+            <button class="collapse-btn">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="9" y1="3" x2="9" y2="21"/></svg>
+            </button>
+          </div>
+
+          <div class="ws-section">
+            <div class="section-label">Workspace</div>
+            <div class="ws-trigger-row">
+              <button class="ws-trigger is-open">
+                <svg class="ws-trigger-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/></svg>
+                <span class="ws-trigger-name">Grovekeeper</span>
+                <svg class="ws-trigger-chevron" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>
+              </button>
+              <button class="ws-action-btn" title="Edit workspace">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z"/></svg>
+              </button>
+              <button class="ws-action-btn" title="Workspace settings">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/><circle cx="12" cy="12" r="3"/></svg>
+              </button>
+
+              <div class="ws-dropdown ws-dropdown-expanded">
+                <div class="ws-dropdown-item">
+                  <svg class="ws-dropdown-item-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+                  <span class="ws-dropdown-item-name">Overview</span>
+                  <svg class="ws-dropdown-item-check" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+                </div>
+
+                <div class="ws-dropdown-separator"></div>
+
+                <div class="ws-dropdown-item is-current">
+                  <svg class="ws-dropdown-item-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/></svg>
+                  <span class="ws-dropdown-item-name">Grovekeeper</span>
+                  <svg class="ws-dropdown-item-check" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+                </div>
+                <div class="ws-dropdown-item">
+                  <svg class="ws-dropdown-item-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/></svg>
+                  <span class="ws-dropdown-item-name">low-poly-2d-trees</span>
+                  <svg class="ws-dropdown-item-check" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+                </div>
+                <div class="ws-dropdown-item">
+                  <svg class="ws-dropdown-item-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/></svg>
+                  <span class="ws-dropdown-item-name">mpx-claude-code</span>
+                  <svg class="ws-dropdown-item-check" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+                </div>
+                <div class="ws-dropdown-item">
+                  <svg class="ws-dropdown-item-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/></svg>
+                  <span class="ws-dropdown-item-name">peon-ping</span>
+                  <svg class="ws-dropdown-item-check" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+                </div>
+                <div class="ws-dropdown-item">
+                  <svg class="ws-dropdown-item-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/></svg>
+                  <span class="ws-dropdown-item-name">Personal Website Redesign</span>
+                  <svg class="ws-dropdown-item-check" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <nav class="nav-items">
+            <div class="section-label">Navigate</div>
+            <a class="nav-item is-active" href="#">
+              <svg class="nav-item-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 10v.2A3 3 0 0 1 8.9 16H5a3 3 0 0 1-3-3v-1a3 3 0 0 1 3-3h16a3 3 0 0 1 3 3v1a3 3 0 0 1-3 3h-3.9A3 3 0 0 1 14 10.2V10"/><path d="M7 21h10"/><path d="M12 21v-5"/></svg>
+              <span>Dashboard</span>
+            </a>
+            <a class="nav-item" href="#">
+              <svg class="nav-item-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
+              <span>Sessions</span>
+            </a>
+            <a class="nav-item" href="#">
+              <svg class="nav-item-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v16a2 2 0 0 0 2 2h16"/><path d="M7 16h.01"/><path d="M11 12h.01"/><path d="M15 8h.01"/><path d="M7 11h.01"/><path d="M11 7h.01"/></svg>
+              <span>Usage</span>
+            </a>
+          </nav>
+
+          <div style="flex:1"></div>
+
+          <div class="user-section">
+            <div class="user-section-inner">
+              <div class="user-left">
+                <div class="user-avatar">MP</div>
+                <span class="user-name">MartinP</span>
+              </div>
+              <div class="user-actions">
+                <button class="theme-toggle">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/></svg>
+                </button>
+                <button class="settings-btn">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/><circle cx="12" cy="12" r="3"/></svg>
+                </button>
+              </div>
+            </div>
+          </div>
+
+        </div>
+        <div class="scene-main">Main content area</div>
+      </div>
+    </div>
+
+    <!-- ════════════════════════════════════════════ -->
+    <!-- Scene 2: Expanded sidebar, dropdown CLOSED  -->
+    <!-- ════════════════════════════════════════════ -->
+    <div class="scene">
+      <div class="scene-label">Expanded — Closed</div>
+      <div class="scene-frame">
+        <div class="sidebar">
+          <div class="brand-row">
+            <div class="brand-left">
+              <div class="brand-icon-wrap"><div class="brand-mark"></div></div>
+              <span class="brand-text">Grovekeeper</span>
+            </div>
+            <button class="collapse-btn">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="9" y1="3" x2="9" y2="21"/></svg>
+            </button>
+          </div>
+
+          <div class="ws-section">
+            <div class="section-label">Workspace</div>
+            <div class="ws-trigger-row">
+              <button class="ws-trigger">
+                <svg class="ws-trigger-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/></svg>
+                <span class="ws-trigger-name">Grovekeeper</span>
+                <svg class="ws-trigger-chevron" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>
+              </button>
+              <button class="ws-action-btn" title="Edit workspace">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z"/></svg>
+              </button>
+              <button class="ws-action-btn" title="Workspace settings">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/><circle cx="12" cy="12" r="3"/></svg>
+              </button>
+            </div>
+          </div>
+
+          <nav class="nav-items">
+            <div class="section-label">Navigate</div>
+            <a class="nav-item is-active" href="#">
+              <svg class="nav-item-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 10v.2A3 3 0 0 1 8.9 16H5a3 3 0 0 1-3-3v-1a3 3 0 0 1 3-3h16a3 3 0 0 1 3 3v1a3 3 0 0 1-3 3h-3.9A3 3 0 0 1 14 10.2V10"/><path d="M7 21h10"/><path d="M12 21v-5"/></svg>
+              <span>Dashboard</span>
+            </a>
+            <a class="nav-item" href="#">
+              <svg class="nav-item-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
+              <span>Sessions</span>
+            </a>
+            <a class="nav-item" href="#">
+              <svg class="nav-item-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v16a2 2 0 0 0 2 2h16"/><path d="M7 16h.01"/><path d="M11 12h.01"/><path d="M15 8h.01"/><path d="M7 11h.01"/><path d="M11 7h.01"/></svg>
+              <span>Usage</span>
+            </a>
+          </nav>
+
+          <div style="flex:1"></div>
+
+          <div class="user-section">
+            <div class="user-section-inner">
+              <div class="user-left">
+                <div class="user-avatar">MP</div>
+                <span class="user-name">MartinP</span>
+              </div>
+              <div class="user-actions">
+                <button class="theme-toggle">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/></svg>
+                </button>
+                <button class="settings-btn">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/><circle cx="12" cy="12" r="3"/></svg>
+                </button>
+              </div>
+            </div>
+          </div>
+
+        </div>
+        <div class="scene-main">Main content area</div>
+      </div>
+    </div>
+
+    <!-- ════════════════════════════════════════════ -->
+    <!-- Scene 3: Collapsed sidebar, dropdown OPEN   -->
+    <!-- ════════════════════════════════════════════ -->
+    <div class="scene">
+      <div class="scene-label">Collapsed — Dropdown Open</div>
+      <div class="scene-frame">
+        <div class="sidebar sidebar-collapsed">
+
+          <div class="brand-row">
+            <div class="brand-mark" style="width:22px;height:22px;border-radius:var(--radius-sm);"></div>
+          </div>
+
+          <div class="ws-section" style="display:flex; align-items:center; justify-content:center; position:relative;">
+            <button class="ws-collapsed-trigger">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/></svg>
+            </button>
+
+            <div class="ws-dropdown ws-dropdown-collapsed">
+              <div class="ws-dropdown-item">
+                <svg class="ws-dropdown-item-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+                <span class="ws-dropdown-item-name">Overview</span>
+                <svg class="ws-dropdown-item-check" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+              </div>
+              <div class="ws-dropdown-separator"></div>
+              <div class="ws-dropdown-item is-current">
+                <svg class="ws-dropdown-item-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/></svg>
+                <span class="ws-dropdown-item-name">Grovekeeper</span>
+                <svg class="ws-dropdown-item-check" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+              </div>
+              <div class="ws-dropdown-item">
+                <svg class="ws-dropdown-item-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/></svg>
+                <span class="ws-dropdown-item-name">low-poly-2d-trees</span>
+                <svg class="ws-dropdown-item-check" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+              </div>
+              <div class="ws-dropdown-item">
+                <svg class="ws-dropdown-item-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/></svg>
+                <span class="ws-dropdown-item-name">mpx-claude-code</span>
+                <svg class="ws-dropdown-item-check" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+              </div>
+              <div class="ws-dropdown-item">
+                <svg class="ws-dropdown-item-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/></svg>
+                <span class="ws-dropdown-item-name">peon-ping</span>
+                <svg class="ws-dropdown-item-check" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+              </div>
+            </div>
+          </div>
+
+          <nav class="nav-items" style="align-items:center;">
+            <div class="nav-collapsed-item is-active">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 10v.2A3 3 0 0 1 8.9 16H5a3 3 0 0 1-3-3v-1a3 3 0 0 1 3-3h16a3 3 0 0 1 3 3v1a3 3 0 0 1-3 3h-3.9A3 3 0 0 1 14 10.2V10"/><path d="M7 21h10"/><path d="M12 21v-5"/></svg>
+            </div>
+            <div class="nav-collapsed-item">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
+            </div>
+            <div class="nav-collapsed-item">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v16a2 2 0 0 0 2 2h16"/><path d="M7 16h.01"/><path d="M11 12h.01"/><path d="M15 8h.01"/></svg>
+            </div>
+          </nav>
+
+          <div style="flex:1"></div>
+
+          <div class="user-section" style="display:flex; flex-direction:column; align-items:center; gap:4px;">
+            <div class="user-avatar">MP</div>
+            <button class="theme-toggle">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/></svg>
+            </button>
+            <div class="nav-collapsed-item">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/><circle cx="12" cy="12" r="3"/></svg>
+            </div>
+          </div>
+
+        </div>
+        <div class="scene-main">Main content area</div>
+      </div>
+    </div>
+
+  </div>
+
+</div>
+</body>
+</html>

--- a/designs/workspace-switcher/variants/variant-a.html
+++ b/designs/workspace-switcher/variants/variant-a.html
@@ -1,0 +1,737 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Workspace Switcher — Variant A</title>
+  <link rel="stylesheet" href="../../tokens.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    body {
+      font-family: 'Geist', -apple-system, BlinkMacSystemFont, sans-serif;
+      background: var(--background);
+      color: var(--foreground);
+    }
+
+    /* ── Layout ── */
+    .variant-label {
+      position: fixed;
+      top: 12px;
+      left: 50%;
+      transform: translateX(-50%);
+      z-index: 100;
+    }
+
+    .viewport {
+      display: flex;
+      height: 100vh;
+      width: 100%;
+    }
+
+    .main-content {
+      flex: 1;
+      background: var(--background);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: var(--foreground-subtle);
+      font-size: 13px;
+    }
+
+    /* ── Sidebar ── */
+    .sidebar {
+      width: 240px;
+      height: 100%;
+      background: var(--sidebar);
+      border-right: 1px solid var(--border);
+      display: flex;
+      flex-direction: column;
+      flex-shrink: 0;
+    }
+
+    .sidebar-collapsed {
+      width: 56px;
+    }
+
+    .sidebar-collapsed .brand-row { justify-content: center; }
+    .sidebar-collapsed .brand-text { display: none; }
+    .sidebar-collapsed .collapse-btn { display: none; }
+    .sidebar-collapsed .section-label { display: none; }
+    .sidebar-collapsed .nav-items { align-items: center; }
+    .sidebar-collapsed .user-section-inner { flex-direction: column; align-items: center; gap: 4px; }
+    .sidebar-collapsed .user-name { display: none; }
+    .sidebar-collapsed .user-actions { display: none; }
+
+    /* ── Brand Row ── */
+    .brand-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 14px 8px;
+    }
+
+    .brand-left {
+      display: flex;
+      align-items: center;
+    }
+
+    .brand-icon-wrap {
+      width: 40px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+    }
+
+    .brand-mark {
+      width: 22px;
+      height: 22px;
+      border-radius: 6px;
+      background: linear-gradient(135deg, var(--moss-500), var(--moss-700));
+    }
+
+    .brand-text {
+      font-size: 14px;
+      font-weight: 600;
+      letter-spacing: -0.01em;
+    }
+
+    .collapse-btn {
+      width: 26px;
+      height: 26px;
+      border-radius: 8px;
+      border: none;
+      background: transparent;
+      color: var(--foreground-muted);
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .collapse-btn:hover { background: var(--surface-hover); }
+
+    /* ── Section Labels ── */
+    .section-label {
+      font-size: 10px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: var(--foreground-subtle);
+      padding: 0 6px;
+      margin-bottom: 6px;
+    }
+
+    /* ── Workspace Selector (Trigger) ── */
+    .ws-section {
+      padding: 0 8px;
+      margin-bottom: 12px;
+      position: relative;
+      z-index: 10;
+    }
+
+    .ws-trigger-row {
+      display: flex;
+      align-items: center;
+      gap: 2px;
+      position: relative;
+    }
+
+    .ws-trigger {
+      flex: 1;
+      min-width: 0;
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      padding: 6px 10px;
+      border-radius: 8px;
+      background: var(--surface-2);
+      border: none;
+      color: var(--foreground);
+      cursor: pointer;
+      transition: background 120ms;
+      font-family: inherit;
+      font-size: 12.5px;
+    }
+    .ws-trigger:hover { background: var(--surface-hover); }
+    .ws-trigger.is-open { background: var(--surface-hover); }
+
+    .ws-trigger-icon {
+      color: var(--primary);
+      flex-shrink: 0;
+    }
+
+    .ws-trigger-name {
+      flex: 1;
+      text-align: left;
+      font-weight: 500;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .ws-trigger-chevron {
+      color: var(--foreground-muted);
+      flex-shrink: 0;
+      transition: transform 120ms;
+    }
+    .ws-trigger.is-open .ws-trigger-chevron {
+      transform: rotate(180deg);
+    }
+
+    .ws-action-btn {
+      width: 26px;
+      height: 26px;
+      border-radius: 4px;
+      border: none;
+      background: transparent;
+      color: var(--foreground-muted);
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      transition: background 120ms, color 120ms;
+    }
+    .ws-action-btn:hover {
+      background: var(--surface-hover);
+      color: var(--foreground);
+    }
+
+    /* ── Collapsed Trigger ── */
+    .ws-collapsed-trigger {
+      width: 34px;
+      height: 34px;
+      border-radius: 8px;
+      border: none;
+      background: transparent;
+      color: var(--primary);
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      transition: background 120ms;
+      margin: 0 auto;
+    }
+    .ws-collapsed-trigger:hover { background: var(--surface-hover); }
+
+    /* ── Dropdown ── */
+    .ws-dropdown {
+      position: absolute;
+      min-width: 200px;
+      background: var(--surface-3);
+      border-radius: 8px;
+      padding: 4px;
+      box-shadow: 0 8px 30px rgba(0,0,0,0.35), 0 2px 8px rgba(0,0,0,0.2);
+      border: 1px solid color-mix(in oklch, var(--foreground) 10%, transparent);
+      z-index: 50;
+    }
+
+    .ws-dropdown-expanded {
+      top: calc(100% + 4px);
+      left: 0;
+      right: 0;
+    }
+
+    .ws-dropdown-collapsed {
+      top: 0;
+      left: calc(100% + 4px);
+      width: 220px;
+    }
+
+    .ws-dropdown-item {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 6px 8px;
+      border-radius: 6px;
+      font-size: 13px;
+      color: var(--foreground);
+      cursor: pointer;
+      transition: background 90ms;
+      position: relative;
+    }
+    .ws-dropdown-item:hover {
+      background: color-mix(in oklch, var(--primary) 25%, transparent);
+    }
+
+    .ws-dropdown-item.is-current {
+      background: color-mix(in oklch, var(--primary) 15%, transparent);
+    }
+    .ws-dropdown-item.is-current:hover {
+      background: color-mix(in oklch, var(--primary) 25%, transparent);
+    }
+
+    .ws-dropdown-item-icon {
+      flex-shrink: 0;
+      color: var(--foreground-muted);
+    }
+
+    .ws-dropdown-item.is-current .ws-dropdown-item-icon {
+      color: var(--primary);
+    }
+
+    .ws-dropdown-item-name {
+      flex: 1;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .ws-dropdown-item-check {
+      flex-shrink: 0;
+      color: var(--primary);
+      opacity: 0;
+    }
+    .ws-dropdown-item.is-current .ws-dropdown-item-check {
+      opacity: 1;
+    }
+
+    .ws-dropdown-separator {
+      height: 1px;
+      background: var(--border);
+      margin: 4px 8px;
+    }
+
+    /* ── Nav Items ── */
+    .nav-items {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      padding: 0 8px;
+    }
+
+    .nav-item {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      height: 32px;
+      padding: 7px 10px 7px 13px;
+      border-radius: 8px;
+      font-size: 12.5px;
+      color: var(--sidebar-fg);
+      text-decoration: none;
+      cursor: pointer;
+      transition: background 120ms, color 120ms;
+    }
+    .nav-item:hover { background: var(--surface-hover); }
+    .nav-item.is-active {
+      background: var(--primary-soft);
+      color: var(--foreground);
+      font-weight: 500;
+    }
+    .nav-item-icon { flex-shrink: 0; }
+    .nav-item.is-active .nav-item-icon { color: var(--primary); }
+
+    .nav-collapsed-item {
+      width: 34px;
+      height: 34px;
+      border-radius: 8px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      transition: background 120ms;
+      color: var(--sidebar-fg);
+    }
+    .nav-collapsed-item:hover { background: var(--surface-hover); }
+    .nav-collapsed-item.is-active {
+      background: var(--primary-soft);
+      color: var(--primary);
+    }
+
+    /* ── User Section ── */
+    .user-section {
+      border-top: 1px solid var(--border);
+      padding: 8px;
+    }
+
+    .user-section-inner {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .user-left {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .user-avatar {
+      width: 28px;
+      height: 28px;
+      border-radius: 50%;
+      background: var(--surface-2);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 11px;
+      font-weight: 600;
+      color: var(--foreground-muted);
+    }
+
+    .user-name {
+      font-size: 12.5px;
+      color: var(--foreground);
+    }
+
+    .user-actions {
+      display: flex;
+      align-items: center;
+      gap: 2px;
+    }
+
+    .theme-toggle, .settings-btn {
+      width: 26px;
+      height: 26px;
+      border-radius: 8px;
+      border: none;
+      background: transparent;
+      color: var(--foreground-muted);
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .theme-toggle:hover, .settings-btn:hover { background: var(--surface-hover); }
+
+    /* ── SVG Icons ── */
+    .icon { display: inline-flex; }
+
+    /* ── Scene Layout ── */
+    .scenes {
+      display: flex;
+      gap: 48px;
+      padding: 48px;
+      min-height: 100vh;
+      background: var(--background);
+      align-items: flex-start;
+    }
+
+    .scene {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .scene-label {
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--foreground-subtle);
+      text-align: center;
+    }
+
+    .scene-frame {
+      position: relative;
+      height: 640px;
+      display: flex;
+      border-radius: 10px;
+      overflow: visible;
+      box-shadow: 0 0 0 1px var(--border);
+    }
+
+    .scene-main {
+      flex: 1;
+      min-width: 400px;
+      background: var(--background);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: var(--foreground-subtle);
+      font-size: 12px;
+      border-radius: 0 10px 10px 0;
+    }
+  </style>
+</head>
+<body>
+<div class="gk-root theme-dark">
+
+  <div class="gk-eyebrow" style="text-align:center; padding:16px 0 0; color:var(--foreground-subtle);">
+    VARIANT A — CHECK MARK + HIGHLIGHT INDICATOR
+  </div>
+
+  <div class="scenes">
+
+    <!-- ════════════════════════════════════════════ -->
+    <!-- Scene 1: Expanded sidebar, dropdown OPEN    -->
+    <!-- ════════════════════════════════════════════ -->
+    <div class="scene">
+      <div class="scene-label">Expanded — Dropdown Open</div>
+      <div class="scene-frame">
+        <div class="sidebar">
+
+          <!-- Brand Row -->
+          <div class="brand-row">
+            <div class="brand-left">
+              <div class="brand-icon-wrap"><div class="brand-mark"></div></div>
+              <span class="brand-text">Grovekeeper</span>
+            </div>
+            <button class="collapse-btn">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="9" y1="3" x2="9" y2="21"/></svg>
+            </button>
+          </div>
+
+          <!-- Workspace Section -->
+          <div class="ws-section">
+            <div class="section-label">Workspace</div>
+            <div class="ws-trigger-row" style="position:relative;">
+              <button class="ws-trigger is-open">
+                <svg class="ws-trigger-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/></svg>
+                <span class="ws-trigger-name">Grovekeeper</span>
+                <svg class="ws-trigger-chevron" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>
+              </button>
+              <button class="ws-action-btn" title="Edit workspace">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z"/></svg>
+              </button>
+              <button class="ws-action-btn" title="Workspace settings">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/><circle cx="12" cy="12" r="3"/></svg>
+              </button>
+
+              <!-- Dropdown (open) -->
+              <div class="ws-dropdown ws-dropdown-expanded">
+                <!-- Overview -->
+                <div class="ws-dropdown-item">
+                  <svg class="ws-dropdown-item-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+                  <span class="ws-dropdown-item-name">Overview</span>
+                  <svg class="ws-dropdown-item-check" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+                </div>
+
+                <div class="ws-dropdown-separator"></div>
+
+                <!-- Workspaces -->
+                <div class="ws-dropdown-item is-current">
+                  <svg class="ws-dropdown-item-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/></svg>
+                  <span class="ws-dropdown-item-name">Grovekeeper</span>
+                  <svg class="ws-dropdown-item-check" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+                </div>
+                <div class="ws-dropdown-item">
+                  <svg class="ws-dropdown-item-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/></svg>
+                  <span class="ws-dropdown-item-name">low-poly-2d-trees</span>
+                  <svg class="ws-dropdown-item-check" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+                </div>
+                <div class="ws-dropdown-item">
+                  <svg class="ws-dropdown-item-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/></svg>
+                  <span class="ws-dropdown-item-name">mpx-claude-code</span>
+                  <svg class="ws-dropdown-item-check" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+                </div>
+                <div class="ws-dropdown-item">
+                  <svg class="ws-dropdown-item-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/></svg>
+                  <span class="ws-dropdown-item-name">peon-ping</span>
+                  <svg class="ws-dropdown-item-check" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+                </div>
+                <div class="ws-dropdown-item">
+                  <svg class="ws-dropdown-item-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/></svg>
+                  <span class="ws-dropdown-item-name">Personal Website Redesign</span>
+                  <svg class="ws-dropdown-item-check" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Navigation -->
+          <nav class="nav-items">
+            <div class="section-label">Navigate</div>
+            <a class="nav-item is-active" href="#">
+              <svg class="nav-item-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 10v.2A3 3 0 0 1 8.9 16H5a3 3 0 0 1-3-3v-1a3 3 0 0 1 3-3h16a3 3 0 0 1 3 3v1a3 3 0 0 1-3 3h-3.9A3 3 0 0 1 14 10.2V10"/><path d="M7 21h10"/><path d="M12 21v-5"/></svg>
+              <span>Dashboard</span>
+            </a>
+            <a class="nav-item" href="#">
+              <svg class="nav-item-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
+              <span>Sessions</span>
+            </a>
+            <a class="nav-item" href="#">
+              <svg class="nav-item-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v16a2 2 0 0 0 2 2h16"/><path d="M7 16h.01"/><path d="M11 12h.01"/><path d="M15 8h.01"/><path d="M7 11h.01"/><path d="M11 7h.01"/></svg>
+              <span>Usage</span>
+            </a>
+          </nav>
+
+          <div style="flex:1"></div>
+
+          <!-- User Section -->
+          <div class="user-section">
+            <div class="user-section-inner">
+              <div class="user-left">
+                <div class="user-avatar">MP</div>
+                <span class="user-name">MartinP</span>
+              </div>
+              <div class="user-actions">
+                <button class="theme-toggle">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/></svg>
+                </button>
+                <button class="settings-btn">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/><circle cx="12" cy="12" r="3"/></svg>
+                </button>
+              </div>
+            </div>
+          </div>
+
+        </div>
+        <div class="scene-main">Main content area</div>
+      </div>
+    </div>
+
+
+    <!-- ════════════════════════════════════════════ -->
+    <!-- Scene 2: Expanded sidebar, dropdown CLOSED  -->
+    <!-- ════════════════════════════════════════════ -->
+    <div class="scene">
+      <div class="scene-label">Expanded — Closed</div>
+      <div class="scene-frame">
+        <div class="sidebar">
+          <div class="brand-row">
+            <div class="brand-left">
+              <div class="brand-icon-wrap"><div class="brand-mark"></div></div>
+              <span class="brand-text">Grovekeeper</span>
+            </div>
+            <button class="collapse-btn">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="9" y1="3" x2="9" y2="21"/></svg>
+            </button>
+          </div>
+
+          <div class="ws-section">
+            <div class="section-label">Workspace</div>
+            <div class="ws-trigger-row">
+              <button class="ws-trigger">
+                <svg class="ws-trigger-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/></svg>
+                <span class="ws-trigger-name">Grovekeeper</span>
+                <svg class="ws-trigger-chevron" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>
+              </button>
+              <button class="ws-action-btn" title="Edit workspace">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z"/></svg>
+              </button>
+              <button class="ws-action-btn" title="Workspace settings">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/><circle cx="12" cy="12" r="3"/></svg>
+              </button>
+            </div>
+          </div>
+
+          <nav class="nav-items">
+            <div class="section-label">Navigate</div>
+            <a class="nav-item is-active" href="#">
+              <svg class="nav-item-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 10v.2A3 3 0 0 1 8.9 16H5a3 3 0 0 1-3-3v-1a3 3 0 0 1 3-3h16a3 3 0 0 1 3 3v1a3 3 0 0 1-3 3h-3.9A3 3 0 0 1 14 10.2V10"/><path d="M7 21h10"/><path d="M12 21v-5"/></svg>
+              <span>Dashboard</span>
+            </a>
+            <a class="nav-item" href="#">
+              <svg class="nav-item-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
+              <span>Sessions</span>
+            </a>
+            <a class="nav-item" href="#">
+              <svg class="nav-item-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v16a2 2 0 0 0 2 2h16"/><path d="M7 16h.01"/><path d="M11 12h.01"/><path d="M15 8h.01"/><path d="M7 11h.01"/><path d="M11 7h.01"/></svg>
+              <span>Usage</span>
+            </a>
+          </nav>
+
+          <div style="flex:1"></div>
+
+          <div class="user-section">
+            <div class="user-section-inner">
+              <div class="user-left">
+                <div class="user-avatar">MP</div>
+                <span class="user-name">MartinP</span>
+              </div>
+              <div class="user-actions">
+                <button class="theme-toggle">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/></svg>
+                </button>
+                <button class="settings-btn">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/><circle cx="12" cy="12" r="3"/></svg>
+                </button>
+              </div>
+            </div>
+          </div>
+
+        </div>
+        <div class="scene-main">Main content area</div>
+      </div>
+    </div>
+
+
+    <!-- ════════════════════════════════════════════ -->
+    <!-- Scene 3: Collapsed sidebar, dropdown OPEN   -->
+    <!-- ════════════════════════════════════════════ -->
+    <div class="scene">
+      <div class="scene-label">Collapsed — Dropdown Open</div>
+      <div class="scene-frame">
+        <div class="sidebar sidebar-collapsed">
+
+          <div class="brand-row">
+            <div class="brand-mark" style="width:22px;height:22px;border-radius:6px;"></div>
+          </div>
+
+          <div class="ws-section" style="display:flex; align-items:center; justify-content:center; position:relative;">
+            <button class="ws-collapsed-trigger">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/></svg>
+            </button>
+
+            <!-- Dropdown (positioned right) -->
+            <div class="ws-dropdown ws-dropdown-collapsed">
+              <div class="ws-dropdown-item">
+                <svg class="ws-dropdown-item-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+                <span class="ws-dropdown-item-name">Overview</span>
+                <svg class="ws-dropdown-item-check" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+              </div>
+
+              <div class="ws-dropdown-separator"></div>
+
+              <div class="ws-dropdown-item is-current">
+                <svg class="ws-dropdown-item-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/></svg>
+                <span class="ws-dropdown-item-name">Grovekeeper</span>
+                <svg class="ws-dropdown-item-check" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+              </div>
+              <div class="ws-dropdown-item">
+                <svg class="ws-dropdown-item-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/></svg>
+                <span class="ws-dropdown-item-name">low-poly-2d-trees</span>
+                <svg class="ws-dropdown-item-check" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+              </div>
+              <div class="ws-dropdown-item">
+                <svg class="ws-dropdown-item-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/></svg>
+                <span class="ws-dropdown-item-name">mpx-claude-code</span>
+                <svg class="ws-dropdown-item-check" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+              </div>
+              <div class="ws-dropdown-item">
+                <svg class="ws-dropdown-item-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/></svg>
+                <span class="ws-dropdown-item-name">peon-ping</span>
+                <svg class="ws-dropdown-item-check" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+              </div>
+            </div>
+          </div>
+
+          <nav class="nav-items" style="align-items:center;">
+            <div class="nav-collapsed-item is-active">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 10v.2A3 3 0 0 1 8.9 16H5a3 3 0 0 1-3-3v-1a3 3 0 0 1 3-3h16a3 3 0 0 1 3 3v1a3 3 0 0 1-3 3h-3.9A3 3 0 0 1 14 10.2V10"/><path d="M7 21h10"/><path d="M12 21v-5"/></svg>
+            </div>
+            <div class="nav-collapsed-item">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
+            </div>
+            <div class="nav-collapsed-item">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v16a2 2 0 0 0 2 2h16"/><path d="M7 16h.01"/><path d="M11 12h.01"/><path d="M15 8h.01"/></svg>
+            </div>
+          </nav>
+
+          <div style="flex:1"></div>
+
+          <div class="user-section" style="display:flex; flex-direction:column; align-items:center; gap:4px;">
+            <div class="user-avatar">MP</div>
+            <button class="theme-toggle">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/></svg>
+            </button>
+            <div class="nav-collapsed-item">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/><circle cx="12" cy="12" r="3"/></svg>
+            </div>
+          </div>
+
+        </div>
+        <div class="scene-main">Main content area</div>
+      </div>
+    </div>
+
+  </div>
+
+</div>
+</body>
+</html>

--- a/src/lib/components/blocks/layout/DashboardSidebar.svelte
+++ b/src/lib/components/blocks/layout/DashboardSidebar.svelte
@@ -26,9 +26,6 @@
 		onEditWorkspace?: () => void;
 		onOpenSettings?: () => void;
 		onOpenWorkspaceSettings?: () => void;
-		onOpenInNewWindow?: () => void;
-		onFocusWindow?: (label: string) => void;
-		openWindowLabels?: string[];
 	}
 
 	let {
@@ -40,9 +37,6 @@
 		onEditWorkspace,
 		onOpenSettings,
 		onOpenWorkspaceSettings,
-		onOpenInNewWindow,
-		onFocusWindow,
-		openWindowLabels = [],
 	}: Props = $props();
 
 	const NAV_LABELS = {
@@ -150,9 +144,6 @@
 				{collapsed}
 				onEdit={onEditWorkspace}
 				onOpenSettings={onOpenWorkspaceSettings}
-				{onOpenInNewWindow}
-				{onFocusWindow}
-				{openWindowLabels}
 			/>
 		</div>
 

--- a/src/lib/components/blocks/workspace/WorkspaceSelector.svelte
+++ b/src/lib/components/blocks/workspace/WorkspaceSelector.svelte
@@ -11,40 +11,22 @@
 	import ChevronDownIcon from '@lucide/svelte/icons/chevron-down';
 	import PencilIcon from '@lucide/svelte/icons/pencil';
 	import SettingsIcon from '@lucide/svelte/icons/settings';
-	import ExternalLinkIcon from '@lucide/svelte/icons/external-link';
-	import AppWindowIcon from '@lucide/svelte/icons/app-window';
 	import { useBoard } from '$lib/modules/board/board.context.svelte.js';
 	import { useWindow } from '$lib/modules/window/window.context.svelte.js';
-	import { workspaceLabel } from '$lib/modules/window/types.js';
 
 	interface Props {
 		collapsed?: boolean;
 		onEdit?: () => void;
 		onOpenSettings?: () => void;
-		onOpenInNewWindow?: () => void;
-		onFocusWindow?: (label: string) => void;
-		openWindowLabels?: string[];
 		portalProps?: WithoutChildrenOrChild<ComponentProps<typeof DropdownMenuPortal>>;
 	}
 
-	let {
-		collapsed = false,
-		onEdit,
-		onOpenSettings,
-		onOpenInNewWindow,
-		onFocusWindow,
-		openWindowLabels = [],
-		portalProps,
-	}: Props = $props();
+	let { collapsed = false, onEdit, onOpenSettings, portalProps }: Props = $props();
 
 	const boardCtx = useBoard();
 	const windowCtx = useWindow();
 
 	const activeDashboards = $derived(boardCtx.dashboards.filter((d) => d.status === 'active'));
-
-	function isOpenInOtherWindow(dashboardId: string): boolean {
-		return openWindowLabels.includes(workspaceLabel(dashboardId));
-	}
 
 	const currentDashboardName = $derived(
 		windowCtx.isOverview
@@ -74,13 +56,13 @@
 			{/snippet}
 		</DropdownMenu.Trigger>
 	{:else}
-		<div class="flex items-center gap-1">
+		<div class="flex items-center gap-0.5">
 			<DropdownMenu.Trigger>
 				{#snippet child({ props })}
 					<button
 						{...props}
 						type="button"
-						class="flex min-w-0 flex-1 items-center gap-1.5 rounded-lg bg-surface-2 px-3 py-1.5 transition-colors duration-2 hover:bg-surface-hover"
+						class="flex min-w-0 flex-1 items-center gap-1.5 rounded-lg px-2 py-1.5 transition-colors duration-2 hover:bg-surface-hover"
 						aria-label={m.nav_switch_workspace()}
 					>
 						<FolderIcon class="size-3.5 shrink-0 text-primary" />
@@ -94,7 +76,7 @@
 			<SimpleTooltip text="Edit workspace" side="top">
 				<button
 					type="button"
-					class="rounded p-1 text-muted-foreground transition-colors hover:bg-surface-hover hover:text-foreground"
+					class="rounded-lg px-1.5 py-1.5 text-muted-foreground transition-colors hover:bg-surface-hover hover:text-foreground"
 					aria-label="Edit workspace"
 					onclick={onEdit}
 				>
@@ -104,7 +86,7 @@
 			<SimpleTooltip text="Workspace settings" side="top">
 				<button
 					type="button"
-					class="rounded p-1 text-muted-foreground transition-colors hover:bg-surface-hover hover:text-foreground"
+					class="rounded-lg px-1.5 py-1.5 text-muted-foreground transition-colors hover:bg-surface-hover hover:text-foreground"
 					aria-label="Workspace settings"
 					onclick={onOpenSettings}
 				>
@@ -136,37 +118,18 @@
 			{#each activeDashboards as dashboard (dashboard.id)}
 				{@const isCurrent =
 					!windowCtx.isOverview && dashboard.id === windowCtx.boundDashboardId}
-				{@const isInOtherWindow = isOpenInOtherWindow(dashboard.id)}
 				<DropdownMenu.Item
 					class={cn(isCurrent && 'bg-primary-soft')}
-					onSelect={() => {
-						if (isInOtherWindow && onFocusWindow) {
-							onFocusWindow(workspaceLabel(dashboard.id));
-						} else {
-							windowCtx.navigateToWorkspace(dashboard.id);
-						}
-					}}
+					onSelect={() => windowCtx.navigateToWorkspace(dashboard.id)}
 				>
 					<FolderIcon />
 					<span class="flex-1 truncate">{dashboard.name}</span>
-					{#if isInOtherWindow}
-						<AppWindowIcon class="size-3.5 text-muted-foreground" />
-					{/if}
 					{#if isCurrent}
 						<CheckIcon class="size-3.5 text-primary" />
 					{/if}
 				</DropdownMenu.Item>
 			{/each}
 		</DropdownMenu.Group>
-		{#if onOpenInNewWindow}
-			<DropdownMenu.Separator class="-mx-2 my-1.5" />
-			<DropdownMenu.Group>
-				<DropdownMenu.Item onSelect={() => onOpenInNewWindow?.()}>
-					<ExternalLinkIcon />
-					<span class="flex-1">{m.nav_open_in_new_window()}</span>
-				</DropdownMenu.Item>
-			</DropdownMenu.Group>
-		{/if}
 		{#if collapsed && !windowCtx.isOverview}
 			<DropdownMenu.Separator class="-mx-2 my-1.5" />
 			<DropdownMenu.Group>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -26,12 +26,7 @@
 	import { setVersionControlContext } from '$lib/modules/version-control';
 	import { setActionsContext } from '$lib/modules/actions';
 	import { setProcessesContext } from '$lib/modules/processes';
-	import {
-		setWindowContext,
-		openWorkspaceWindow,
-		focusWindow,
-		listOpenWindows,
-	} from '$lib/modules/window';
+	import { setWindowContext } from '$lib/modules/window';
 	import { setKeyboardShortcutsContext } from '$lib/modules/keyboard-shortcuts';
 	import { setCommandPaletteContext } from '$lib/modules/command-palette';
 	import { setRawRequirementsContext } from '$lib/modules/raw-requirements';
@@ -131,7 +126,6 @@
 		void characterPacksCtx.loadPacks();
 		void shortcutsCtx.loadCustomBindings();
 		void versionControlCtx.checkAvailability();
-		void refreshOpenWindowLabels();
 
 		shortcutsCtx.registerShortcut({
 			id: 'command-palette',
@@ -199,28 +193,6 @@
 
 	const activeSessionCount = $derived(sessionStore.activeSessions.length);
 	const isSettingsRoute = $derived(page.url.pathname.startsWith('/settings'));
-
-	let sidebarOpenWindowLabels = $state<string[]>([]);
-
-	async function handleSidebarOpenInNewWindow() {
-		const dashboardId = windowCtx.boundDashboardId;
-		if (dashboardId !== null) {
-			await openWorkspaceWindow(dashboardId);
-			void refreshOpenWindowLabels();
-		}
-	}
-
-	function handleSidebarFocusWindow(label: string) {
-		void focusWindow(label);
-	}
-
-	async function refreshOpenWindowLabels() {
-		try {
-			sidebarOpenWindowLabels = await listOpenWindows();
-		} catch {
-			sidebarOpenWindowLabels = [];
-		}
-	}
 </script>
 
 <svelte:window onkeydown={(event) => shortcutsCtx.handleKeydown(event)} />
@@ -262,9 +234,6 @@
 						void goto(`${resolve('/settings/workspace')}?scope=ws&id=${dashboardId}`);
 					}
 				}}
-				onOpenInNewWindow={handleSidebarOpenInNewWindow}
-				onFocusWindow={handleSidebarFocusWindow}
-				openWindowLabels={sidebarOpenWindowLabels}
 			/>
 
 			<main class="flex min-w-0 flex-1 flex-col overflow-auto">


### PR DESCRIPTION
## Summary

- Add workspace-switcher design brief (mockup, refined variant, component map)
- Ghost-style workspace selector trigger (remove `bg-surface-2`, transparent by default)
- Align edit/settings button heights with selector (`py-1.5`)
- Remove "Open in new window" from workspace dropdown — per design brief, it belongs on workspace card context menu only
- Clean up multi-window props from DashboardSidebar and root layout
- Update `.mpx/CONTEXT.md` and `DECISIONS.md` (merge conflict resolution)

## Test plan

- [ ] Workspace selector trigger has no background at rest, shows bg on hover
- [ ] Edit and settings buttons align vertically with the selector
- [ ] Dropdown shows Overview + workspaces with check marks, no "Open in new window"
- [ ] "Open in new window" still works from workspace card context menu on Overview
- [ ] Collapsed sidebar behavior unchanged
