### PR TITLE
#266 feat(notification): wire 4 session notification event triggers

### DIFF
--- a/src-tauri/src/commands/session_commands.rs
+++ b/src-tauri/src/commands/session_commands.rs
@@ -14,6 +14,8 @@ use crate::session::discovery_polling::DiscoveryPoller;
 use crate::session::manager::SessionManager;
 use serde_json::Value;
 
+use crate::models::notification::NotificationEventType;
+use crate::notification::service::NotificationService;
 use crate::session::provider::{ActorCommand, ApprovalDecision, ProviderKind, SpawnConfig};
 
 const SESSION_SELECT_COLUMNS: &str =
@@ -270,6 +272,17 @@ pub async fn adopt_session(
             ],
         )
         .map_err(|e| format!("Failed to create adopted session row: {e}"))?;
+    }
+
+    if let Some(service) = app_handle.try_state::<NotificationService>() {
+        service.notify(
+            NotificationEventType::TaskAcknowledge,
+            &session_id,
+            request.issue_id.as_deref(),
+            "NOTIFICATION_SESSION_ADOPTED",
+            &app_handle,
+            &database_connection,
+        );
     }
 
     manager

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -1,3 +1,6 @@
+// TODO(PRD #91): Wire notification events from git/GitHub triggers:
+//   pr.ready, pr.merged, pr.review-requested, merge.conflict,
+//   branch.behind-base, github.issue-assigned, github.trigger-received
 pub mod branch_detection;
 pub mod cli_operations;
 pub mod error;

--- a/src-tauri/src/notification/playback_queue.rs
+++ b/src-tauri/src/notification/playback_queue.rs
@@ -260,7 +260,8 @@ fn debounce_window_for(event_type: NotificationEventType) -> u64 {
         NotificationEventType::BranchBehindBase
         | NotificationEventType::MergeConflict
         | NotificationEventType::GithubIssueAssigned
-        | NotificationEventType::GithubTriggerReceived => POLLING_DEBOUNCE_WINDOW_MS,
+        | NotificationEventType::GithubTriggerReceived
+        | NotificationEventType::ResourceLimit => POLLING_DEBOUNCE_WINDOW_MS,
         _ => DEFAULT_DEBOUNCE_WINDOW_MS,
     }
 }
@@ -309,6 +310,10 @@ mod tests {
         );
         assert_eq!(
             debounce_window_for(NotificationEventType::MergeConflict),
+            POLLING_DEBOUNCE_WINDOW_MS
+        );
+        assert_eq!(
+            debounce_window_for(NotificationEventType::ResourceLimit),
             POLLING_DEBOUNCE_WINDOW_MS
         );
     }

--- a/src-tauri/src/notification/service.rs
+++ b/src-tauri/src/notification/service.rs
@@ -268,11 +268,12 @@ fn notification_toast_title(event_type: NotificationEventType) -> &'static str {
 
 /// Map a SessionState to a notification event type.
 /// Returns None for states that should not trigger notifications (e.g. Running, Paused).
+/// Note: session.start is fired directly from SessionInit, not via this mapping.
 pub fn session_state_to_event_type(state: &SessionState) -> Option<NotificationEventType> {
     match state {
         SessionState::NeedsInput => Some(NotificationEventType::SessionNeedsInput),
         SessionState::NeedsReview => Some(NotificationEventType::SessionNeedsInput),
-        SessionState::Finished => Some(NotificationEventType::SessionEnd),
+        SessionState::Finished => Some(NotificationEventType::TaskComplete),
         SessionState::Errored => Some(NotificationEventType::SessionError),
         SessionState::Running | SessionState::Paused => None,
     }
@@ -294,7 +295,7 @@ mod tests {
         );
         assert_eq!(
             session_state_to_event_type(&SessionState::Finished),
-            Some(NotificationEventType::SessionEnd)
+            Some(NotificationEventType::TaskComplete)
         );
         assert_eq!(
             session_state_to_event_type(&SessionState::Errored),

--- a/src-tauri/src/session/session_actor.rs
+++ b/src-tauri/src/session/session_actor.rs
@@ -10,6 +10,7 @@ use super::provider::{ActorCommand, ProviderAdapter, SessionEvent, SessionHandle
 use crate::metrics::achievement_tracker;
 use crate::models::achievement::AchievementKind;
 use crate::models::session::SessionState;
+use crate::models::notification::NotificationEventType;
 use crate::notification::service::{session_state_to_event_type, NotificationService};
 use crate::SharedPricingEngine;
 
@@ -190,6 +191,13 @@ fn handle_event(
             ..
         } => {
             update_cli_session_id(session_id, cli_session_id, database_connection);
+            fire_notification_direct(
+                session_id,
+                NotificationEventType::SessionStart,
+                "NOTIFICATION_SESSION_STARTED",
+                app_handle,
+                database_connection,
+            );
         }
         SessionEvent::PermissionPrompt { .. } | SessionEvent::ElicitationPrompt { .. } => {
             if let Some(ref db_state) = resolved_state {
@@ -203,6 +211,15 @@ fn handle_event(
                 );
             }
         }
+        SessionEvent::CompactBoundary { .. } => {
+            fire_notification_direct(
+                session_id,
+                NotificationEventType::ResourceLimit,
+                "NOTIFICATION_CONTEXT_LIMIT_APPROACHING",
+                app_handle,
+                database_connection,
+            );
+        }
         _ => {}
     }
 }
@@ -215,17 +232,27 @@ fn fire_notification(
     database_connection: &std::sync::Arc<StdMutex<Connection>>,
 ) {
     if let Some(event_type) = session_state_to_event_type(state) {
-        if let Some(service) = app_handle.try_state::<NotificationService>() {
-            let issue_id = resolve_session_issue_id(session_id, database_connection);
-            service.notify(
-                event_type,
-                session_id,
-                issue_id.as_deref(),
-                message,
-                app_handle,
-                database_connection,
-            );
-        }
+        fire_notification_direct(session_id, event_type, message, app_handle, database_connection);
+    }
+}
+
+fn fire_notification_direct(
+    session_id: &str,
+    event_type: NotificationEventType,
+    message: &str,
+    app_handle: &AppHandle,
+    database_connection: &std::sync::Arc<StdMutex<Connection>>,
+) {
+    if let Some(service) = app_handle.try_state::<NotificationService>() {
+        let issue_id = resolve_session_issue_id(session_id, database_connection);
+        service.notify(
+            event_type,
+            session_id,
+            issue_id.as_deref(),
+            message,
+            app_handle,
+            database_connection,
+        );
     }
 }
 
@@ -494,6 +521,7 @@ async fn handle_session_completion(
     }
 }
 
+// TODO(PRD #93): Fire NotificationEventType::AchievementUnlocked notification here
 fn emit_achievement_unlocked(kind: &AchievementKind, app_handle: &AppHandle) {
     let _ = app_handle.emit("achievement-unlocked", kind.as_str());
 }

--- a/src/lib/modules/sessions/session_events.test.ts
+++ b/src/lib/modules/sessions/session_events.test.ts
@@ -84,7 +84,7 @@ describe('computeSessionEventEffects — resolvedState', () => {
 		expect(notificationAction).toEqual({ type: 'add', notificationType: 'session.error' });
 	});
 
-	it('returns clear notification action for running state (not in notification map)', () => {
+	it('returns clear notification action for running state (backend fires session.start directly)', () => {
 		const { notificationAction } = computeEffects(
 			makeEvent({ type: 'run_state', state: 'running', error: null }),
 			'running',
@@ -93,13 +93,13 @@ describe('computeSessionEventEffects — resolvedState', () => {
 		expect(notificationAction).toEqual({ type: 'clear' });
 	});
 
-	it('returns clear notification action for finished state (not in notification map)', () => {
+	it('returns task.complete notification action for finished state', () => {
 		const { notificationAction } = computeEffects(
 			makeEvent({ type: 'run_state', state: 'finished', error: null }),
 			'finished',
 			null,
 		);
-		expect(notificationAction).toEqual({ type: 'clear' });
+		expect(notificationAction).toEqual({ type: 'add', notificationType: 'task.complete' });
 	});
 
 	it('returns null notification action when resolvedState is null', () => {

--- a/src/lib/modules/sessions/session_events.ts
+++ b/src/lib/modules/sessions/session_events.ts
@@ -9,6 +9,7 @@ import type {
 const NOTIFICATION_STATES: Record<string, NotificationEventType> = {
 	'needs-input': 'session.needs-input',
 	'needs-review': 'session.needs-input',
+	finished: 'task.complete',
 	errored: 'session.error',
 };
 


### PR DESCRIPTION
## Summary

- Wire `session.start` notification from `SessionInit` event (fires exactly once per session spawn)
- Wire `task.complete` notification when session reaches Finished state (replaces previous `session.end` mapping)
- Wire `task.acknowledge` notification from `adopt_session` command path
- Wire `resource.limit` notification from `CompactBoundary` event (context limit approaching) with 30s polling debounce
- Add frontend `NOTIFICATION_STATES` mapping for finished → task.complete
- Refactor `fire_notification`/`fire_notification_direct` into shared core
- Add TODO comments for remaining 6 unwired events (PRD #91 git/GitHub, PRD #93 achievement)

## Test plan

- [x] Rust: `session_state_to_event_type(Finished)` → TaskComplete (unit test)
- [x] Rust: `session_state_to_event_type(Running)` → None (unit test, session.start fires from SessionInit instead)
- [x] Rust: `debounce_window_for(ResourceLimit)` → POLLING_DEBOUNCE_WINDOW_MS (unit test)
- [x] Frontend: `computeSessionEventEffects('finished')` → task.complete notification action (unit test)
- [x] Frontend: `computeSessionEventEffects('running')` → clear (backend handles session.start directly)
- [x] All 669 Rust tests pass
- [x] check:fast (prettier + oxlint) clean
- [x] check:fallow (dead-code) clean

Fixes #266
